### PR TITLE
Motie status 'out_of_scope' i.p.v. 'rejected'

### DIFF
--- a/backend/bouwmeester/models/motie_import.py
+++ b/backend/bouwmeester/models/motie_import.py
@@ -38,7 +38,7 @@ class MotieImport(Base):
         nullable=False,
         default="pending",
         server_default="pending",
-        comment="pending|imported|reviewed|rejected",
+        comment="pending|imported|reviewed|rejected|out_of_scope",
     )
     corpus_node_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),

--- a/backend/bouwmeester/services/motie_import_service.py
+++ b/backend/bouwmeester/services/motie_import_service.py
@@ -139,7 +139,7 @@ class MotieImportService:
         matched_nodes = await self._find_matching_nodes(matched_tag_names)
 
         if not matched_nodes:
-            # No matches - create import record as rejected
+            # No matches - create import record as out_of_scope
             await self.import_repo.create(
                 zaak_id=motie.zaak_id,
                 zaak_nummer=motie.zaak_nummer,
@@ -147,14 +147,16 @@ class MotieImportService:
                 onderwerp=motie.onderwerp,
                 bron=motie.bron,
                 datum=motie.datum.date() if motie.datum else None,
-                status="rejected",
+                status="out_of_scope",
                 indieners=motie.indieners,
                 document_tekst=motie.document_tekst,
                 document_url=motie.document_url,
                 llm_samenvatting=samenvatting,
                 matched_tags=matched_tag_names,
             )
-            logger.info(f"Motie {motie.zaak_nummer} rejected: no matching corpus nodes")
+            logger.info(
+                f"Motie {motie.zaak_nummer} out_of_scope: no matching corpus nodes"
+            )
             return False
 
         # Step 4: Create any newly suggested tags (only for imported moties)

--- a/frontend/src/pages/MotiesPage.tsx
+++ b/frontend/src/pages/MotiesPage.tsx
@@ -15,6 +15,7 @@ const statusFilters: { value: MotieImportStatus | 'all'; label: string }[] = [
   { value: 'imported', label: 'Te beoordelen' },
   { value: 'reviewed', label: 'Beoordeeld' },
   { value: 'rejected', label: 'Afgewezen' },
+  { value: 'out_of_scope', label: 'Buiten scope' },
   { value: 'pending', label: 'In wachtrij' },
 ];
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -380,7 +380,7 @@ export interface NodeTagResponse {
 }
 
 // Motie Import
-export type MotieImportStatus = 'pending' | 'imported' | 'reviewed' | 'rejected';
+export type MotieImportStatus = 'pending' | 'imported' | 'reviewed' | 'rejected' | 'out_of_scope';
 export type SuggestedEdgeStatus = 'pending' | 'approved' | 'rejected';
 
 export interface MotieImport {
@@ -423,6 +423,7 @@ export const MOTIE_IMPORT_STATUS_LABELS: Record<MotieImportStatus, string> = {
   imported: 'Geïmporteerd',
   reviewed: 'Beoordeeld',
   rejected: 'Afgewezen',
+  out_of_scope: 'Buiten scope',
 };
 
 export const MOTIE_IMPORT_STATUS_COLORS: Record<MotieImportStatus, string> = {
@@ -430,4 +431,5 @@ export const MOTIE_IMPORT_STATUS_COLORS: Record<MotieImportStatus, string> = {
   imported: 'blue',
   reviewed: 'green',
   rejected: 'gray',
+  out_of_scope: 'gray',
 };


### PR DESCRIPTION
Moties zonder corpus-match krijgen nu status `out_of_scope` ("Buiten scope") in plaats van `rejected` ("Afgewezen").