### PR TITLE
fix: lint errors in merge migration

### DIFF
--- a/backend/bouwmeester/migrations/versions/03bc23d0b7e2_merge_motie_import_task_and_person_.py
+++ b/backend/bouwmeester/migrations/versions/03bc23d0b7e2_merge_motie_import_task_and_person_.py
@@ -5,17 +5,14 @@ Revises: 66dd28885049, 74f8addb8848
 Create Date: 2026-02-08 19:51:04.541141
 
 """
-from typing import Sequence, Union
 
-from alembic import op
-import sqlalchemy as sa
-
+from collections.abc import Sequence
 
 # revision identifiers, used by Alembic.
-revision: str = '03bc23d0b7e2'
-down_revision: Union[str, None] = ('66dd28885049', '74f8addb8848')
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+revision: str = "03bc23d0b7e2"
+down_revision: str | None = ("66dd28885049", "74f8addb8848")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:


### PR DESCRIPTION
## Summary
- Fix ruff lint errors in auto-generated merge migration `03bc23d0b7e2`
- Convert `Union[X, Y]` to `X | Y` syntax
- Fix import sorting

## Test plan
- [x] `just lint` passes