### PR TITLE
Assorted UI fixes: modals, rich text, node status, org linking

### DIFF
--- a/frontend/src/api/notifications.ts
+++ b/frontend/src/api/notifications.ts
@@ -37,8 +37,8 @@ export async function markNotificationRead(id: string): Promise<Notification> {
   return apiPut<Notification>(`/api/notifications/${id}/read`);
 }
 
-export async function markAllNotificationsRead(_personId: string): Promise<{ marked_read: number }> {
-  return apiPut<{ marked_read: number }>('/api/notifications/read-all', undefined);
+export async function markAllNotificationsRead(personId: string): Promise<{ marked_read: number }> {
+  return apiPut<{ marked_read: number }>(`/api/notifications/read-all?person_id=${personId}`);
 }
 
 export async function sendMessage(data: {

--- a/frontend/src/components/common/NotificationBell.tsx
+++ b/frontend/src/components/common/NotificationBell.tsx
@@ -4,6 +4,7 @@ import { useNotifications, useUnreadCount, useMarkNotificationRead, useMarkAllNo
 import { useTaskDetail } from '@/contexts/TaskDetailContext';
 import { useNodeDetail } from '@/contexts/NodeDetailContext';
 import type { Notification } from '@/api/notifications';
+import { richTextToPlain } from '@/utils/richtext';
 
 interface NotificationBellProps {
   personId: string | undefined;
@@ -62,7 +63,7 @@ function NotificationItem({
         </div>
         <p className="text-sm font-medium text-text truncate">{notification.title}</p>
         {notification.message && (
-          <p className="text-xs text-text-secondary truncate mt-0.5">{notification.message}</p>
+          <p className="text-xs text-text-secondary truncate mt-0.5">{richTextToPlain(notification.message)}</p>
         )}
       </div>
       {!notification.is_read && (

--- a/frontend/src/components/common/RichTextDisplay.tsx
+++ b/frontend/src/components/common/RichTextDisplay.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import { useTaskDetail } from '@/contexts/TaskDetailContext';
 import { useNodeDetail } from '@/contexts/NodeDetailContext';
 
@@ -30,6 +31,7 @@ function isTipTapJson(value: string): TipTapNode | null {
 }
 
 export function RichTextDisplay({ content, fallback = 'Geen beschrijving beschikbaar.' }: RichTextDisplayProps) {
+  const navigate = useNavigate();
   const { openTaskDetail } = useTaskDetail();
   const { openNodeDetail } = useNodeDetail();
 
@@ -43,13 +45,14 @@ export function RichTextDisplay({ content, fallback = 'Geen beschrijving beschik
     return <p className="text-sm text-text-secondary whitespace-pre-wrap">{content}</p>;
   }
 
-  const handlers: MentionHandlers = { openTaskDetail, openNodeDetail };
+  const handlers: MentionHandlers = { openTaskDetail, openNodeDetail, navigate };
   return <div className="text-sm text-text-secondary">{renderNodes(doc.content ?? [], handlers)}</div>;
 }
 
 interface MentionHandlers {
   openTaskDetail: (id: string) => void;
   openNodeDetail: (id: string) => void;
+  navigate: (path: string) => void;
 }
 
 function renderNodes(nodes: TipTapNode[], handlers: MentionHandlers): React.ReactNode[] {
@@ -71,16 +74,22 @@ function renderNode(node: TipTapNode, key: number, handlers: MentionHandlers): R
     case 'mention': {
       const id = node.attrs?.id as string | undefined;
       const label = node.attrs?.label as string | undefined;
+      const mentionType = (node.attrs?.mentionType as string | undefined) ?? 'person';
+      const isOrg = mentionType === 'organisatie';
       return (
         <button
           key={key}
           onClick={() => {
-            // Navigate to person detail (if we had one) or just show tooltip
-            // For now, we'll keep it as a styled span
+            if (isOrg && id) {
+              handlers.navigate(`/organisatie?eenheid=${id}`);
+            }
           }}
-          className="inline bg-blue-50 text-blue-700 rounded px-1 py-0.5 font-medium text-sm hover:bg-blue-100 transition-colors cursor-default"
-          title={`Persoon: ${label}`}
-          data-person-id={id}
+          className={`inline rounded px-1 py-0.5 font-medium text-sm transition-colors ${
+            isOrg
+              ? 'bg-emerald-50 text-emerald-700 hover:bg-emerald-100 cursor-pointer'
+              : 'bg-blue-50 text-blue-700 hover:bg-blue-100 cursor-default'
+          }`}
+          title={isOrg ? `Afdeling: ${label}` : `Persoon: ${label}`}
         >
           @{label}
         </button>

--- a/frontend/src/components/nodes/NodeCard.tsx
+++ b/frontend/src/components/nodes/NodeCard.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/common/Badge';
 import type { CorpusNode } from '@/types';
 import { NODE_TYPE_COLORS } from '@/types';
 import { useVocabulary } from '@/contexts/VocabularyContext';
+import { richTextToPlain } from '@/utils/richtext';
 
 interface NodeCardProps {
   node: CorpusNode;
@@ -37,7 +38,7 @@ export function NodeCard({ node }: NodeCardProps) {
 
           {node.description && (
             <p className="text-xs text-text-secondary line-clamp-2">
-              {node.description}
+              {richTextToPlain(node.description)}
             </p>
           )}
         </div>

--- a/frontend/src/components/nodes/NodeCreateForm.tsx
+++ b/frontend/src/components/nodes/NodeCreateForm.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
 import { Modal } from '@/components/common/Modal';
 import { Input } from '@/components/common/Input';
+import { Select } from '@/components/common/Select';
 import { CreatableSelect } from '@/components/common/CreatableSelect';
 import { FormModalFooter } from '@/components/common/FormModalFooter';
 import { RichTextEditor } from '@/components/common/RichTextEditor';
 import { useCreateNode } from '@/hooks/useNodes';
 import { useNodeTypeOptions } from '@/hooks/useNodeTypeOptions';
-import { NodeType } from '@/types';
+import { NodeType, NodeStatus, NODE_STATUS_LABELS } from '@/types';
 
 interface NodeCreateFormProps {
   open: boolean;
@@ -18,7 +19,7 @@ export function NodeCreateForm({ open, onClose }: NodeCreateFormProps) {
   const [title, setTitle] = useState('');
   const [nodeType, setNodeType] = useState<string>(NodeType.DOSSIER);
   const [description, setDescription] = useState('');
-  const [status, setStatus] = useState('');
+  const [status, setStatus] = useState(NodeStatus.ACTIEF);
   const createNode = useCreateNode();
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -36,7 +37,7 @@ export function NodeCreateForm({ open, onClose }: NodeCreateFormProps) {
     setTitle('');
     setNodeType(NodeType.DOSSIER);
     setDescription('');
-    setStatus('');
+    setStatus(NodeStatus.ACTIEF);
     onClose();
   };
 
@@ -84,11 +85,11 @@ export function NodeCreateForm({ open, onClose }: NodeCreateFormProps) {
           />
         </div>
 
-        <Input
+        <Select
           label="Status"
           value={status}
           onChange={(e) => setStatus(e.target.value)}
-          placeholder="Bijv. concept, actief, afgerond..."
+          options={Object.entries(NODE_STATUS_LABELS).map(([value, label]) => ({ value, label }))}
         />
       </form>
     </Modal>

--- a/frontend/src/components/nodes/NodeEditForm.tsx
+++ b/frontend/src/components/nodes/NodeEditForm.tsx
@@ -1,11 +1,13 @@
 import { useState, useEffect } from 'react';
 import { Modal } from '@/components/common/Modal';
 import { Input } from '@/components/common/Input';
+import { Select } from '@/components/common/Select';
 import { CreatableSelect } from '@/components/common/CreatableSelect';
 import { FormModalFooter } from '@/components/common/FormModalFooter';
 import { RichTextEditor } from '@/components/common/RichTextEditor';
 import { useUpdateNode } from '@/hooks/useNodes';
 import { useNodeTypeOptions } from '@/hooks/useNodeTypeOptions';
+import { NODE_STATUS_LABELS } from '@/types';
 import type { CorpusNode } from '@/types';
 
 interface NodeEditFormProps {
@@ -91,11 +93,11 @@ export function NodeEditForm({ open, onClose, node }: NodeEditFormProps) {
           />
         </div>
 
-        <Input
+        <Select
           label="Status"
           value={status}
           onChange={(e) => setStatus(e.target.value)}
-          placeholder="Bijv. concept, actief, afgerond..."
+          options={Object.entries(NODE_STATUS_LABELS).map(([value, label]) => ({ value, label }))}
         />
       </form>
     </Modal>

--- a/frontend/src/components/people/PersonCardExpandable.tsx
+++ b/frontend/src/components/people/PersonCardExpandable.tsx
@@ -1,5 +1,4 @@
 import { useState, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { clsx } from 'clsx';
 import { Mail, Briefcase, Pencil, CheckCircle2, Circle, FileText, Loader2, Bot, MessageSquare, Terminal, Building2, X } from 'lucide-react';
 import { Card } from '@/components/common/Card';
@@ -8,6 +7,8 @@ import { SendMessageModal } from '@/components/common/SendMessageModal';
 import { usePersonSummary, usePersonOrganisaties, useUpdatePersonOrganisatie, useRemovePersonOrganisatie } from '@/hooks/usePeople';
 import { FUNCTIE_LABELS, NODE_TYPE_COLORS, STAKEHOLDER_ROL_LABELS, DIENSTVERBAND_LABELS } from '@/types';
 import { useVocabulary } from '@/contexts/VocabularyContext';
+import { useTaskDetail } from '@/contexts/TaskDetailContext';
+import { useNodeDetail } from '@/contexts/NodeDetailContext';
 import type { Person } from '@/types';
 
 const PRIORITY_DOT_COLORS: Record<string, string> = {
@@ -31,8 +32,9 @@ export function PersonCardExpandable({ person, onEditPerson, onDragStartPerson, 
   const [copied, setCopied] = useState(false);
   const [messageOpen, setMessageOpen] = useState(false);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
-  const navigate = useNavigate();
   const { nodeLabel } = useVocabulary();
+  const { openTaskDetail } = useTaskDetail();
+  const { openNodeDetail } = useNodeDetail();
   const { data: summary, isLoading: summaryLoading } = usePersonSummary(expanded ? person.id : null);
   const { data: placements } = usePersonOrganisaties(expanded ? person.id : null);
   const endPlacement = useUpdatePersonOrganisatie();
@@ -160,7 +162,14 @@ export function PersonCardExpandable({ person, onEditPerson, onDragStartPerson, 
                 {summary.open_tasks.length > 0 && (
                   <div className="mt-1.5 space-y-1">
                     {summary.open_tasks.map((task) => (
-                      <div key={task.id} className="flex items-center gap-2 text-text">
+                      <button
+                        key={task.id}
+                        className="flex items-center gap-2 text-text w-full text-left hover:text-primary-600 transition-colors rounded px-1 -mx-1 py-0.5 hover:bg-primary-50/50"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          openTaskDetail(task.id);
+                        }}
+                      >
                         <span className={clsx('h-1.5 w-1.5 rounded-full shrink-0', PRIORITY_DOT_COLORS[task.priority] || 'bg-gray-300')} />
                         <span className="truncate">{task.title}</span>
                         {task.due_date && (
@@ -168,7 +177,7 @@ export function PersonCardExpandable({ person, onEditPerson, onDragStartPerson, 
                             {new Date(task.due_date).toLocaleDateString('nl-NL', { day: 'numeric', month: 'short' })}
                           </span>
                         )}
-                      </div>
+                      </button>
                     ))}
                   </div>
                 )}
@@ -184,7 +193,7 @@ export function PersonCardExpandable({ person, onEditPerson, onDragStartPerson, 
                         className="flex items-center gap-2 text-text w-full text-left hover:text-primary-600 transition-colors rounded px-1 -mx-1 py-0.5 hover:bg-primary-50/50"
                         onClick={(e) => {
                           e.stopPropagation();
-                          navigate(`/nodes/${node.node_id}`);
+                          openNodeDetail(node.node_id);
                         }}
                       >
                         <FileText className="h-3 w-3 text-text-secondary shrink-0" />

--- a/frontend/src/components/tasks/TaskCard.tsx
+++ b/frontend/src/components/tasks/TaskCard.tsx
@@ -10,6 +10,7 @@ import {
   TASK_STATUS_LABELS,
 } from '@/types';
 import type { Task } from '@/types';
+import { richTextToPlain } from '@/utils/richtext';
 
 interface TaskCardProps {
   task: Task;
@@ -81,7 +82,7 @@ export function TaskCard({ task, onEdit, compact = false }: TaskCardProps) {
 
           {!compact && task.description && (
             <p className="text-xs text-text-secondary mt-0.5 line-clamp-1">
-              {task.description}
+              {richTextToPlain(task.description)}
             </p>
           )}
 

--- a/frontend/src/hooks/useMoties.ts
+++ b/frontend/src/hooks/useMoties.ts
@@ -57,7 +57,7 @@ export function useCompleteMotieReview() {
     mutationFn: ({ id, data }: { id: string; data: CompleteReviewData }) =>
       completeMotieReview(id, data),
     errorMessage: 'Fout bij afronden review',
-    invalidateKeys: [...MOTIE_INVALIDATE_KEYS, ['tasks'], ['nodes']],
+    invalidateKeys: [...MOTIE_INVALIDATE_KEYS, ['tasks', 'list'], ['nodes', 'list']],
   });
 }
 

--- a/frontend/src/hooks/useNodes.ts
+++ b/frontend/src/hooks/useNodes.ts
@@ -9,14 +9,14 @@ import type { CorpusNodeCreate, CorpusNodeUpdate, NodeType } from '@/types';
 
 export function useNodes(nodeType?: NodeType) {
   return useQuery({
-    queryKey: ['nodes', nodeType],
+    queryKey: ['nodes', 'list', nodeType],
     queryFn: () => getNodes(nodeType),
   });
 }
 
 export function useNode(id: string | undefined) {
   return useQuery({
-    queryKey: ['nodes', id],
+    queryKey: ['nodes', 'detail', id],
     queryFn: () => getNode(id!),
     enabled: !!id,
   });
@@ -26,7 +26,7 @@ export function useCreateNode() {
   return useMutationWithError({
     mutationFn: (data: CorpusNodeCreate) => createNode(data),
     errorMessage: 'Fout bij aanmaken node',
-    invalidateKeys: [['nodes'], ['graph']],
+    invalidateKeys: [['nodes', 'list'], ['graph']],
   });
 }
 
@@ -39,8 +39,8 @@ export function useUpdateNode() {
       console.error('Fout bij bijwerken node:', error);
     },
     onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({ queryKey: ['nodes', variables.id] });
-      queryClient.invalidateQueries({ queryKey: ['nodes'] });
+      queryClient.invalidateQueries({ queryKey: ['nodes', 'detail', variables.id] });
+      queryClient.invalidateQueries({ queryKey: ['nodes', 'list'] });
     },
   });
 }
@@ -49,13 +49,13 @@ export function useDeleteNode() {
   return useMutationWithError({
     mutationFn: (id: string) => deleteNode(id),
     errorMessage: 'Fout bij verwijderen node',
-    invalidateKeys: [['nodes']],
+    invalidateKeys: [['nodes', 'list']],
   });
 }
 
 export function useNodeNeighbors(id: string | undefined) {
   return useQuery({
-    queryKey: ['nodes', id, 'neighbors'],
+    queryKey: ['nodes', 'detail', id, 'neighbors'],
     queryFn: () => getNodeNeighbors(id!),
     enabled: !!id,
   });
@@ -63,7 +63,7 @@ export function useNodeNeighbors(id: string | undefined) {
 
 export function useNodeStakeholders(id: string | undefined) {
   return useQuery({
-    queryKey: ['nodes', id, 'stakeholders'],
+    queryKey: ['nodes', 'detail', id, 'stakeholders'],
     queryFn: () => getNodeStakeholders(id!),
     enabled: !!id,
   });
@@ -79,7 +79,7 @@ export function useAddNodeStakeholder() {
       console.error('Fout bij toevoegen stakeholder:', error);
     },
     onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({ queryKey: ['nodes', variables.nodeId, 'stakeholders'] });
+      queryClient.invalidateQueries({ queryKey: ['nodes', 'detail', variables.nodeId, 'stakeholders'] });
     },
   });
 }
@@ -94,7 +94,7 @@ export function useUpdateNodeStakeholder() {
       console.error('Fout bij bijwerken stakeholder:', error);
     },
     onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({ queryKey: ['nodes', variables.nodeId, 'stakeholders'] });
+      queryClient.invalidateQueries({ queryKey: ['nodes', 'detail', variables.nodeId, 'stakeholders'] });
     },
   });
 }
@@ -109,14 +109,14 @@ export function useRemoveNodeStakeholder() {
       console.error('Fout bij verwijderen stakeholder:', error);
     },
     onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({ queryKey: ['nodes', variables.nodeId, 'stakeholders'] });
+      queryClient.invalidateQueries({ queryKey: ['nodes', 'detail', variables.nodeId, 'stakeholders'] });
     },
   });
 }
 
 export function useNodeMotieImport(id: string | undefined, nodeType?: string) {
   return useQuery({
-    queryKey: ['nodes', id, 'motie-import'],
+    queryKey: ['nodes', 'detail', id, 'motie-import'],
     queryFn: () => getNodeMotieImport(id!),
     enabled: !!id && nodeType === 'politieke_input',
   });

--- a/frontend/src/hooks/useTasks.ts
+++ b/frontend/src/hooks/useTasks.ts
@@ -6,14 +6,14 @@ import type { TaskFilters } from '@/api/tasks';
 
 export function useTasks(filters?: TaskFilters) {
   return useQuery({
-    queryKey: ['tasks', filters],
+    queryKey: ['tasks', 'list', filters],
     queryFn: () => getTasks(filters),
   });
 }
 
 export function useTask(id: string | null) {
   return useQuery({
-    queryKey: ['tasks', id],
+    queryKey: ['tasks', 'detail', id],
     queryFn: () => getTask(id!),
     enabled: !!id,
   });
@@ -23,7 +23,7 @@ export function useCreateTask() {
   return useMutationWithError({
     mutationFn: (data: TaskCreate) => createTask(data),
     errorMessage: 'Fout bij aanmaken taak',
-    invalidateKeys: [['tasks']],
+    invalidateKeys: [['tasks', 'list']],
   });
 }
 
@@ -31,7 +31,7 @@ export function useUpdateTask() {
   return useMutationWithError({
     mutationFn: ({ id, data }: { id: string; data: TaskUpdate }) => updateTask(id, data),
     errorMessage: 'Fout bij bijwerken taak',
-    invalidateKeys: [['tasks']],
+    invalidateKeys: [['tasks', 'list']],
   });
 }
 
@@ -39,20 +39,20 @@ export function useDeleteTask() {
   return useMutationWithError({
     mutationFn: (id: string) => deleteTask(id),
     errorMessage: 'Fout bij verwijderen taak',
-    invalidateKeys: [['tasks']],
+    invalidateKeys: [['tasks', 'list']],
   });
 }
 
 export function useUnassignedTasks(organisatieEenheidId?: string) {
   return useQuery({
-    queryKey: ['tasks', 'unassigned', organisatieEenheidId],
+    queryKey: ['tasks', 'list', 'unassigned', organisatieEenheidId],
     queryFn: () => getUnassignedTasks(organisatieEenheidId),
   });
 }
 
 export function useEenheidOverview(organisatieEenheidId: string | null) {
   return useQuery({
-    queryKey: ['tasks', 'eenheid-overview', organisatieEenheidId],
+    queryKey: ['tasks', 'list', 'eenheid-overview', organisatieEenheidId],
     queryFn: () => getEenheidOverview(organisatieEenheidId!),
     enabled: !!organisatieEenheidId,
   });
@@ -60,7 +60,7 @@ export function useEenheidOverview(organisatieEenheidId: string | null) {
 
 export function useTaskSubtasks(taskId: string | null) {
   return useQuery({
-    queryKey: ['tasks', taskId, 'subtasks'],
+    queryKey: ['tasks', 'detail', taskId, 'subtasks'],
     queryFn: () => getTaskSubtasks(taskId!),
     enabled: !!taskId,
   });
@@ -68,7 +68,7 @@ export function useTaskSubtasks(taskId: string | null) {
 
 export function useTasksByPerson(personId: string | null) {
   return useQuery({
-    queryKey: ['tasks', 'by-person', personId],
+    queryKey: ['tasks', 'list', 'by-person', personId],
     queryFn: () => getTasksByPerson(personId!),
     enabled: !!personId,
   });

--- a/frontend/src/pages/OrganisatiePage.tsx
+++ b/frontend/src/pages/OrganisatiePage.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { Plus, Building2 } from 'lucide-react';
 import { Button } from '@/components/common/Button';
 import { Card } from '@/components/common/Card';
@@ -18,7 +19,8 @@ import { useCreatePerson, useUpdatePerson, useAddPersonOrganisatie } from '@/hoo
 import type { OrganisatieEenheid, OrganisatieEenheidCreate, OrganisatieEenheidUpdate, Person, PersonCreate } from '@/types';
 
 export function OrganisatiePage() {
-  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [selectedId, setSelectedId] = useState<string | null>(searchParams.get('eenheid'));
   const [showForm, setShowForm] = useState(false);
   const [editData, setEditData] = useState<OrganisatieEenheid | null>(null);
   const [defaultParentId, setDefaultParentId] = useState<string | null>(null);
@@ -26,6 +28,15 @@ export function OrganisatiePage() {
   // Person form state
   const [showPersonForm, setShowPersonForm] = useState(false);
   const [editPerson, setEditPerson] = useState<Person | null>(null);
+
+  // Sync ?eenheid= param on arrival, then clear it
+  useEffect(() => {
+    const eenheidParam = searchParams.get('eenheid');
+    if (eenheidParam) {
+      setSelectedId(eenheidParam);
+      setSearchParams({}, { replace: true });
+    }
+  }, [searchParams, setSearchParams]);
 
   const { data: tree = [], isLoading } = useOrganisatieTree();
   const createMutation = useCreateOrganisatieEenheid();

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -41,6 +41,25 @@ export const NODE_TYPE_COLORS: Record<NodeType, string> = {
   [NodeType.OVERIG]: 'gray',
 };
 
+// Node Status
+export enum NodeStatus {
+  CONCEPT = 'concept',
+  ACTIEF = 'actief',
+  GEPAUZEERD = 'gepauzeerd',
+  AFGEROND = 'afgerond',
+  GEKOZEN = 'gekozen',
+  AFGEWEZEN = 'afgewezen',
+}
+
+export const NODE_STATUS_LABELS: Record<NodeStatus, string> = {
+  [NodeStatus.CONCEPT]: 'Concept',
+  [NodeStatus.ACTIEF]: 'Actief',
+  [NodeStatus.GEPAUZEERD]: 'Gepauzeerd',
+  [NodeStatus.AFGEROND]: 'Afgerond',
+  [NodeStatus.GEKOZEN]: 'Gekozen',
+  [NodeStatus.AFGEWEZEN]: 'Afgewezen',
+};
+
 // Corpus Node
 export interface CorpusNode {
   id: string;

--- a/frontend/src/utils/richtext.ts
+++ b/frontend/src/utils/richtext.ts
@@ -1,0 +1,33 @@
+/**
+ * Extract plain text from a string that may be TipTap/ProseMirror JSON.
+ * Returns the original string if it's not JSON.
+ */
+export function richTextToPlain(value: string | null | undefined): string {
+  if (!value) return '';
+  try {
+    const doc = JSON.parse(value);
+    if (doc && doc.type === 'doc') {
+      return extractText(doc).trim();
+    }
+  } catch {
+    // Not JSON — return as-is
+  }
+  return value;
+}
+
+interface TipTapNode {
+  type: string;
+  content?: TipTapNode[];
+  text?: string;
+  attrs?: Record<string, unknown>;
+}
+
+function extractText(node: TipTapNode): string {
+  if (node.text) return node.text;
+  if (node.type === 'mention' || node.type === 'hashtagMention') {
+    const label = node.attrs?.label as string | undefined;
+    return label ? `${label}` : '';
+  }
+  if (!node.content) return '';
+  return node.content.map(extractText).join(node.type === 'paragraph' ? ' ' : '');
+}


### PR DESCRIPTION
## Summary

- **Person card**: tasks and nodes now open detail modals (TaskDetailModal / NodeDetailModal) instead of navigating away or being non-clickable
- **Mark all notifications read**: fix bug where `person_id` query param was never sent to the backend
- **Rich text rendering**: NodeCard, TaskCard, and NotificationBell now extract plain text from TipTap JSON instead of showing raw JSON
- **Node status dropdown**: replace free-text input with a fixed `Select` dropdown using a `NodeStatus` enum (concept, actief, gepauzeerd, afgerond, gekozen, afgewezen)
- **Org @mentions**: organisatie mentions in rich text descriptions now link to the organisatie page with the unit pre-selected
- **Organisatie deep linking**: page reads `?eenheid=` query param to auto-select and show the referenced unit
- **Query key restructuring**: separate list/detail namespaces (`tasks/list`, `tasks/detail`) so mutations don't accidentally refetch disabled detail queries with null IDs (fixes board drag-and-drop)

## Test plan

- [ ] Open a person card, click a task → TaskDetailModal should open
- [ ] Open a person card, click a node → NodeDetailModal should open
- [ ] Verify "Alles gelezen" button marks all notifications as read
- [ ] Check node cards and task cards show plain text descriptions (not raw JSON)
- [ ] Edit a node → status field should be a dropdown with fixed options
- [ ] Create a node → status defaults to "Actief" as a dropdown
- [ ] Click an @organisatie mention in a description → navigates to /organisatie with the unit selected
- [ ] Notification messages display plain text instead of raw JSON
- [ ] Drag a task to another column on the board → task moves immediately without refresh, no console errors