### PR TITLE
Navigate to inbox and highlight item on notification click

### DIFF
--- a/frontend/src/components/common/NotificationBell.tsx
+++ b/frontend/src/components/common/NotificationBell.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Bell, Check, CheckCheck } from 'lucide-react';
 import { useNotifications, useUnreadCount, useMarkNotificationRead, useMarkAllNotificationsRead } from '@/hooks/useNotifications';
 import { useTaskDetail } from '@/contexts/TaskDetailContext';
@@ -85,6 +86,7 @@ function NotificationItem({
 export function NotificationBell({ personId }: NotificationBellProps) {
   const [open, setOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+  const navigate = useNavigate();
   const { openTaskDetail } = useTaskDetail();
   const { openNodeDetail } = useNodeDetail();
 
@@ -146,14 +148,14 @@ export function NotificationBell({ personId }: NotificationBellProps) {
                   notification={notification}
                   onMarkRead={(id) => markRead.mutate(id)}
                   onClick={() => {
+                    if (!notification.is_read) markRead.mutate(notification.id);
+                    setOpen(false);
                     if (notification.related_task_id) {
                       openTaskDetail(notification.related_task_id);
-                      if (!notification.is_read) markRead.mutate(notification.id);
-                      setOpen(false);
                     } else if (notification.related_node_id) {
                       openNodeDetail(notification.related_node_id);
-                      if (!notification.is_read) markRead.mutate(notification.id);
-                      setOpen(false);
+                    } else {
+                      navigate(`/?notification=${notification.id}`);
                     }
                   }}
                 />

--- a/frontend/src/components/inbox/InboxItem.test.tsx
+++ b/frontend/src/components/inbox/InboxItem.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import { InboxItemCard } from './InboxItem';
+import { renderWithProviders } from '@/test/utils';
+import type { InboxItem } from '@/types';
+
+const baseItem: InboxItem = {
+  id: 'item-1',
+  type: 'message',
+  title: 'Testbericht',
+  description: 'Een test beschrijving',
+  created_at: new Date().toISOString(),
+  read: false,
+};
+
+const scrollMock = vi.fn();
+
+beforeEach(() => {
+  scrollMock.mockClear();
+  Element.prototype.scrollIntoView = scrollMock;
+});
+
+describe('InboxItemCard', () => {
+  it('renders title and description', () => {
+    renderWithProviders(<InboxItemCard item={baseItem} />);
+    expect(screen.getByText('Testbericht')).toBeInTheDocument();
+    expect(screen.getByText('Een test beschrijving')).toBeInTheDocument();
+  });
+
+  it('applies highlight ring when highlighted', () => {
+    const { container } = renderWithProviders(
+      <InboxItemCard item={baseItem} highlighted />,
+    );
+    const card = container.querySelector('.ring-2');
+    expect(card).toBeInTheDocument();
+  });
+
+  it('does not apply highlight ring by default', () => {
+    const { container } = renderWithProviders(
+      <InboxItemCard item={baseItem} />,
+    );
+    const card = container.querySelector('.ring-2');
+    expect(card).not.toBeInTheDocument();
+  });
+
+  it('calls scrollIntoView when highlighted', () => {
+    renderWithProviders(<InboxItemCard item={baseItem} highlighted />);
+    expect(scrollMock).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' });
+  });
+
+  it('does not scroll when not highlighted', () => {
+    renderWithProviders(<InboxItemCard item={baseItem} />);
+    expect(scrollMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/inbox/InboxItem.tsx
+++ b/frontend/src/components/inbox/InboxItem.tsx
@@ -1,3 +1,4 @@
+import { useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { FileText, CheckSquare, Bell, MessageSquare } from 'lucide-react';
 import { Card } from '@/components/common/Card';
@@ -6,6 +7,7 @@ import type { InboxItem as InboxItemType } from '@/types';
 
 interface InboxItemProps {
   item: InboxItemType;
+  highlighted?: boolean;
 }
 
 const typeIcons: Record<string, React.ReactNode> = {
@@ -22,8 +24,15 @@ const typeColors: Record<string, string> = {
   message: 'green',
 };
 
-export function InboxItemCard({ item }: InboxItemProps) {
+export function InboxItemCard({ item, highlighted }: InboxItemProps) {
   const navigate = useNavigate();
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (highlighted && ref.current) {
+      ref.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, [highlighted]);
 
   const handleClick = () => {
     if (item.node_id) {
@@ -32,7 +41,8 @@ export function InboxItemCard({ item }: InboxItemProps) {
   };
 
   return (
-    <Card hoverable={!!item.node_id} onClick={handleClick}>
+    <div ref={ref}>
+    <Card hoverable={!!item.node_id} onClick={handleClick} className={highlighted ? 'ring-2 ring-primary-400' : ''}>
       <div className="flex items-start gap-3">
         <div
           className={`flex items-center justify-center h-8 w-8 rounded-lg shrink-0 ${
@@ -78,5 +88,6 @@ export function InboxItemCard({ item }: InboxItemProps) {
         </div>
       </div>
     </Card>
+    </div>
   );
 }

--- a/frontend/src/components/inbox/InboxList.tsx
+++ b/frontend/src/components/inbox/InboxList.tsx
@@ -5,9 +5,10 @@ import type { InboxItem } from '@/types';
 
 interface InboxListProps {
   items: InboxItem[];
+  highlightId?: string | null;
 }
 
-export function InboxList({ items }: InboxListProps) {
+export function InboxList({ items, highlightId }: InboxListProps) {
   if (items.length === 0) {
     return (
       <EmptyState
@@ -37,7 +38,7 @@ export function InboxList({ items }: InboxListProps) {
           </h3>
           <div className="space-y-2">
             {groupItems.map((item) => (
-              <InboxItemCard key={item.id} item={item} />
+              <InboxItemCard key={item.id} item={item} highlighted={item.id === highlightId} />
             ))}
           </div>
         </div>

--- a/frontend/src/pages/InboxPage.tsx
+++ b/frontend/src/pages/InboxPage.tsx
@@ -1,5 +1,6 @@
 import { Inbox, CheckSquare, Network, TrendingUp, Users } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
+import { useEffect } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Card } from '@/components/common/Card';
 import { Button } from '@/components/common/Button';
 import { InboxList } from '@/components/inbox/InboxList';
@@ -12,6 +13,15 @@ import type { InboxItem } from '@/types';
 
 export function InboxPage() {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const highlightId = searchParams.get('notification');
+
+  // Clear the query param after mount so refreshing doesn't re-highlight
+  useEffect(() => {
+    if (highlightId) {
+      setSearchParams({}, { replace: true });
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const { currentPerson } = useCurrentPerson();
   const { data: notifications } = useNotifications(currentPerson?.id);
@@ -123,7 +133,7 @@ export function InboxPage() {
         </div>
 
         {inboxItems.length > 0 ? (
-          <InboxList items={inboxItems} />
+          <InboxList items={inboxItems} highlightId={highlightId} />
         ) : (
           <EmptyState
             icon={<Inbox className="h-16 w-16" />}


### PR DESCRIPTION
## Summary

- Clicking a notification in the bell dropdown that has no related task or node (e.g. direct messages, agent prompts) now navigates to the inbox and highlights the specific message
- Uses the existing `?notification=<id>` query param pattern (same as moties and organisatie deep-linking)
- Highlighted item gets a primary-colored ring and smooth-scrolls into view

## Test plan

- [ ] Send a direct message via "Stuur bericht" to the current user
- [ ] Click the notification in the bell dropdown — should navigate to inbox with highlighted message
- [ ] Notifications with related tasks still open the task modal
- [ ] Notifications with related nodes still open the node modal
- [ ] `npx vitest run` — 45 tests pass (5 new InboxItemCard tests)
- [ ] `npx tsc --noEmit` passes