### PR TITLE
Add omni-search across all entity types

### DIFF
--- a/backend/bouwmeester/api/routes/search.py
+++ b/backend/bouwmeester/api/routes/search.py
@@ -1,12 +1,11 @@
-"""API routes for full-text search."""
+"""API routes for omni full-text search."""
 
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from bouwmeester.core.database import get_db
 from bouwmeester.repositories.search import SearchRepository
-from bouwmeester.schema.corpus_node import NodeType
-from bouwmeester.schema.search import SearchResponse, SearchResult
+from bouwmeester.schema.search import SearchResponse, SearchResult, SearchResultType
 
 router = APIRouter(prefix="/search", tags=["search"])
 
@@ -14,15 +13,15 @@ router = APIRouter(prefix="/search", tags=["search"])
 @router.get("", response_model=SearchResponse)
 async def search(
     q: str = Query(..., min_length=1),
-    node_types: list[NodeType] | None = Query(None),
+    result_types: list[SearchResultType] | None = Query(None),
     limit: int = Query(50, ge=1, le=200),
     db: AsyncSession = Depends(get_db),
 ) -> SearchResponse:
     repo = SearchRepository(db)
-    type_values = [nt.value for nt in node_types] if node_types else None
+    type_values = [rt.value for rt in result_types] if result_types else None
     results = await repo.full_text_search(
         query=q,
-        node_types=type_values,
+        result_types=type_values,
         limit=limit,
     )
     return SearchResponse(

--- a/backend/bouwmeester/migrations/versions/94e112019e64_add_omni_search_indexes.py
+++ b/backend/bouwmeester/migrations/versions/94e112019e64_add_omni_search_indexes.py
@@ -1,0 +1,124 @@
+"""add omni search indexes
+
+Revision ID: 94e112019e64
+Revises: c5b6fca202ea
+Create Date: 2026-02-09 17:32:29.636637
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "94e112019e64"
+down_revision: str | None = "c5b6fca202ea"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # corpus_node: title (A) + description (B)
+    op.execute("""
+        ALTER TABLE corpus_node
+        ADD COLUMN search_vector tsvector
+        GENERATED ALWAYS AS (
+            setweight(to_tsvector('dutch', coalesce(title, '')), 'A') ||
+            setweight(to_tsvector('dutch', coalesce(description, '')), 'B')
+        ) STORED
+    """)
+    op.execute("""
+        CREATE INDEX ix_corpus_node_search
+        ON corpus_node USING GIN (search_vector)
+    """)
+
+    # task: title (A) + description (B)
+    op.execute("""
+        ALTER TABLE task
+        ADD COLUMN search_vector tsvector
+        GENERATED ALWAYS AS (
+            setweight(to_tsvector('dutch', coalesce(title, '')), 'A') ||
+            setweight(to_tsvector('dutch', coalesce(description, '')), 'B')
+        ) STORED
+    """)
+    op.execute("""
+        CREATE INDEX ix_task_search
+        ON task USING GIN (search_vector)
+    """)
+
+    # person: naam (A) + functie (B) + email (C)
+    op.execute("""
+        ALTER TABLE person
+        ADD COLUMN search_vector tsvector
+        GENERATED ALWAYS AS (
+            setweight(to_tsvector('dutch', coalesce(naam, '')), 'A') ||
+            setweight(to_tsvector('dutch', coalesce(functie, '')), 'B') ||
+            setweight(to_tsvector('dutch', coalesce(email, '')), 'C')
+        ) STORED
+    """)
+    op.execute("""
+        CREATE INDEX ix_person_search
+        ON person USING GIN (search_vector)
+    """)
+
+    # organisatie_eenheid: naam (A) + beschrijving (B)
+    op.execute("""
+        ALTER TABLE organisatie_eenheid
+        ADD COLUMN search_vector tsvector
+        GENERATED ALWAYS AS (
+            setweight(to_tsvector('dutch', coalesce(naam, '')), 'A') ||
+            setweight(to_tsvector('dutch', coalesce(beschrijving, '')), 'B')
+        ) STORED
+    """)
+    op.execute("""
+        CREATE INDEX ix_org_eenheid_search
+        ON organisatie_eenheid USING GIN (search_vector)
+    """)
+
+    # parlementair_item: titel (A) + onderwerp (A) + llm_samenvatting (B)
+    op.execute("""
+        ALTER TABLE parlementair_item
+        ADD COLUMN search_vector tsvector
+        GENERATED ALWAYS AS (
+            setweight(to_tsvector('dutch', coalesce(titel, '')), 'A') ||
+            setweight(to_tsvector('dutch', coalesce(onderwerp, '')), 'A') ||
+            setweight(to_tsvector('dutch', coalesce(llm_samenvatting, '')), 'B')
+        ) STORED
+    """)
+    op.execute("""
+        CREATE INDEX ix_parlementair_search
+        ON parlementair_item USING GIN (search_vector)
+    """)
+
+    # tag: name (A) + description (B)
+    op.execute("""
+        ALTER TABLE tag
+        ADD COLUMN search_vector tsvector
+        GENERATED ALWAYS AS (
+            setweight(to_tsvector('dutch', coalesce(name, '')), 'A') ||
+            setweight(to_tsvector('dutch', coalesce(description, '')), 'B')
+        ) STORED
+    """)
+    op.execute("""
+        CREATE INDEX ix_tag_search
+        ON tag USING GIN (search_vector)
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_tag_search")
+    op.execute("ALTER TABLE tag DROP COLUMN IF EXISTS search_vector")
+
+    op.execute("DROP INDEX IF EXISTS ix_parlementair_search")
+    op.execute("ALTER TABLE parlementair_item DROP COLUMN IF EXISTS search_vector")
+
+    op.execute("DROP INDEX IF EXISTS ix_org_eenheid_search")
+    op.execute("ALTER TABLE organisatie_eenheid DROP COLUMN IF EXISTS search_vector")
+
+    op.execute("DROP INDEX IF EXISTS ix_person_search")
+    op.execute("ALTER TABLE person DROP COLUMN IF EXISTS search_vector")
+
+    op.execute("DROP INDEX IF EXISTS ix_task_search")
+    op.execute("ALTER TABLE task DROP COLUMN IF EXISTS search_vector")
+
+    op.execute("DROP INDEX IF EXISTS ix_corpus_node_search")
+    op.execute("ALTER TABLE corpus_node DROP COLUMN IF EXISTS search_vector")

--- a/backend/bouwmeester/repositories/search.py
+++ b/backend/bouwmeester/repositories/search.py
@@ -1,9 +1,7 @@
-"""Repository for full-text search on corpus nodes."""
+"""Repository for omni full-text search across all entity types."""
 
-from sqlalchemy import func, literal_column, select
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
-
-from bouwmeester.models.corpus_node import CorpusNode
 
 
 class SearchRepository:
@@ -13,56 +11,172 @@ class SearchRepository:
     async def full_text_search(
         self,
         query: str,
-        node_types: list[str] | None = None,
+        result_types: list[str] | None = None,
         limit: int = 50,
     ) -> list[dict]:
-        """Search corpus nodes using PostgreSQL full-text search.
+        """Search across all entity types using stored tsvector + GIN indexes.
 
-        Uses to_tsvector/to_tsquery with ts_rank on title and description.
+        Returns unified results from corpus_node, task, person,
+        organisatie_eenheid, parlementair_item, and tag tables.
         """
-        # Build the tsvector from title (weight A) and description (weight B)
-        # setweight() requires PG "char" type — use literal SQL casts
-        ts_vector = func.setweight(
-            func.to_tsvector("dutch", func.coalesce(CorpusNode.title, "")),
-            literal_column("'A'"),
-        ).op("||")(
-            func.setweight(
-                func.to_tsvector("dutch", func.coalesce(CorpusNode.description, "")),
-                literal_column("'B'"),
-            )
+        all_types = {
+            "corpus_node",
+            "task",
+            "person",
+            "organisatie_eenheid",
+            "parlementair_item",
+            "tag",
+        }
+        active_types = set(result_types) if result_types else all_types
+
+        sub_queries = []
+
+        if "corpus_node" in active_types:
+            sub_queries.append("""
+                SELECT
+                    id,
+                    'corpus_node' AS result_type,
+                    title,
+                    node_type AS subtitle,
+                    description,
+                    ts_rank(search_vector, plainto_tsquery('dutch', :query)) AS score
+                FROM corpus_node
+                WHERE search_vector @@ plainto_tsquery('dutch', :query)
+            """)
+
+        if "task" in active_types:
+            sub_queries.append("""
+                SELECT
+                    id,
+                    'task' AS result_type,
+                    title,
+                    status AS subtitle,
+                    description,
+                    ts_rank(search_vector, plainto_tsquery('dutch', :query)) AS score
+                FROM task
+                WHERE search_vector @@ plainto_tsquery('dutch', :query)
+            """)
+
+        if "person" in active_types:
+            sub_queries.append("""
+                SELECT
+                    id,
+                    'person' AS result_type,
+                    naam AS title,
+                    functie AS subtitle,
+                    email AS description,
+                    ts_rank(search_vector, plainto_tsquery('dutch', :query)) AS score
+                FROM person
+                WHERE search_vector @@ plainto_tsquery('dutch', :query)
+            """)
+
+        if "organisatie_eenheid" in active_types:
+            sub_queries.append("""
+                SELECT
+                    id,
+                    'organisatie_eenheid' AS result_type,
+                    naam AS title,
+                    type AS subtitle,
+                    beschrijving AS description,
+                    ts_rank(search_vector, plainto_tsquery('dutch', :query)) AS score
+                FROM organisatie_eenheid
+                WHERE search_vector @@ plainto_tsquery('dutch', :query)
+            """)
+
+        if "parlementair_item" in active_types:
+            sub_queries.append("""
+                SELECT
+                    id,
+                    'parlementair_item' AS result_type,
+                    titel AS title,
+                    type AS subtitle,
+                    onderwerp AS description,
+                    ts_rank(search_vector, plainto_tsquery('dutch', :query)) AS score
+                FROM parlementair_item
+                WHERE search_vector @@ plainto_tsquery('dutch', :query)
+            """)
+
+        if "tag" in active_types:
+            sub_queries.append("""
+                SELECT
+                    id,
+                    'tag' AS result_type,
+                    name AS title,
+                    NULL AS subtitle,
+                    description,
+                    ts_rank(search_vector, plainto_tsquery('dutch', :query)) AS score
+                FROM tag
+                WHERE search_vector @@ plainto_tsquery('dutch', :query)
+            """)
+
+        if not sub_queries:
+            return []
+
+        union_sql = " UNION ALL ".join(sub_queries)
+        full_sql = f"""
+            SELECT * FROM ({union_sql}) AS combined
+            ORDER BY score DESC
+            LIMIT :limit
+        """
+
+        result = await self.session.execute(
+            text(full_sql), {"query": query, "limit": limit}
         )
-
-        # Use plainto_tsquery for simpler user input handling
-        ts_query = func.plainto_tsquery("dutch", query)
-
-        rank = func.ts_rank(ts_vector, ts_query).label("rank")
-
-        stmt = (
-            select(
-                CorpusNode.id,
-                CorpusNode.node_type,
-                CorpusNode.title,
-                CorpusNode.description,
-                rank,
-            )
-            .where(ts_vector.op("@@")(ts_query))
-            .order_by(rank.desc())
-            .limit(limit)
-        )
-
-        if node_types:
-            stmt = stmt.where(CorpusNode.node_type.in_(node_types))
-
-        result = await self.session.execute(stmt)
         rows = result.all()
 
-        return [
-            {
-                "id": row.id,
-                "node_type": row.node_type,
-                "title": row.title,
-                "description": row.description,
-                "rank": float(row.rank),
-            }
-            for row in rows
-        ]
+        url_map = {
+            "corpus_node": "/nodes/{id}",
+            "task": "/tasks?task={id}",
+            "person": "/people/{id}",
+            "organisatie_eenheid": "/organisatie/{id}",
+            "parlementair_item": "/parlementair/{id}",
+            "tag": "/corpus?tag={id}",
+        }
+
+        # Build highlights via ts_headline for the final result set
+        results = []
+        for row in rows:
+            url = url_map[row.result_type].format(id=row.id)
+            results.append(
+                {
+                    "id": row.id,
+                    "result_type": row.result_type,
+                    "title": row.title,
+                    "subtitle": row.subtitle,
+                    "description": row.description,
+                    "score": float(row.score),
+                    "highlights": None,
+                    "url": url,
+                }
+            )
+
+        # Generate highlights for rows that have descriptions
+        if results:
+            ids_with_desc = [(i, r) for i, r in enumerate(results) if r["description"]]
+            if ids_with_desc:
+                await self._add_highlights(ids_with_desc, query)
+
+        return results
+
+    async def _add_highlights(
+        self, indexed_results: list[tuple[int, dict]], query: str
+    ) -> None:
+        """Add ts_headline highlights to results that have descriptions."""
+        for _idx, result in indexed_results:
+            desc = result["description"] or ""
+            if not desc:
+                continue
+            hl_result = await self.session.execute(
+                text("""
+                    SELECT ts_headline(
+                        'dutch',
+                        :desc,
+                        plainto_tsquery('dutch', :query),
+                        'StartSel=<mark>,StopSel=</mark>,MaxWords=35,MinWords=15,MaxFragments=2'
+                    ) AS headline
+                """),
+                {"desc": desc, "query": query},
+            )
+            headline = hl_result.scalar()
+            if headline and "<mark>" in headline:
+                result["highlights"] = [headline]

--- a/backend/bouwmeester/schema/__init__.py
+++ b/backend/bouwmeester/schema/__init__.py
@@ -55,7 +55,7 @@ from bouwmeester.schema.person import (
     PersonSummaryResponse,
     PersonUpdate,
 )
-from bouwmeester.schema.search import SearchResponse, SearchResult
+from bouwmeester.schema.search import SearchResponse, SearchResult, SearchResultType
 from bouwmeester.schema.tag import (
     NodeTagCreate,
     NodeTagResponse,
@@ -146,6 +146,7 @@ __all__ = [
     # search
     "SearchResponse",
     "SearchResult",
+    "SearchResultType",
     # tag
     "NodeTagCreate",
     "NodeTagResponse",

--- a/backend/bouwmeester/schema/search.py
+++ b/backend/bouwmeester/schema/search.py
@@ -1,16 +1,29 @@
-"""Pydantic schemas for search."""
+"""Pydantic schemas for omni-search."""
 
+from enum import StrEnum
 from uuid import UUID
 
 from pydantic import BaseModel
 
 
+class SearchResultType(StrEnum):
+    corpus_node = "corpus_node"
+    task = "task"
+    person = "person"
+    organisatie_eenheid = "organisatie_eenheid"
+    parlementair_item = "parlementair_item"
+    tag = "tag"
+
+
 class SearchResult(BaseModel):
     id: UUID
-    node_type: str
+    result_type: SearchResultType
     title: str
+    subtitle: str | None = None
     description: str | None = None
-    rank: float
+    score: float
+    highlights: list[str] | None = None
+    url: str
 
 
 class SearchResponse(BaseModel):

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -35,13 +35,26 @@ async def test_search_no_match(client):
     assert data["results"] == []
 
 
-async def test_search_filter_by_node_type(client, sample_node):
-    """GET /api/search?q=...&node_types=dossier filters by node type."""
+async def test_search_filter_by_result_type(client, sample_node):
+    """GET /api/search?q=...&result_types=corpus_node filters by result type."""
     resp = await client.get(
-        "/api/search", params={"q": "Test", "node_types": "dossier"}
+        "/api/search", params={"q": "Test", "result_types": "corpus_node"}
     )
     assert resp.status_code == 200
     data = resp.json()
-    # All results should be of type dossier
     for r in data["results"]:
-        assert r["node_type"] == "dossier"
+        assert r["result_type"] == "corpus_node"
+
+
+async def test_search_result_has_required_fields(client, sample_node):
+    """Search results contain all required fields."""
+    resp = await client.get("/api/search", params={"q": "dossier"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] > 0
+    result = data["results"][0]
+    assert "id" in result
+    assert "result_type" in result
+    assert "title" in result
+    assert "score" in result
+    assert "url" in result

--- a/frontend/src/api/search.ts
+++ b/frontend/src/api/search.ts
@@ -1,10 +1,13 @@
 import { apiGet } from './client';
-import type { SearchResponse, NodeType } from '@/types';
+import type { SearchResponse, SearchResultType } from '@/types';
 
-export async function search(query: string, nodeTypes?: NodeType[]): Promise<SearchResponse> {
+export async function search(
+  query: string,
+  resultTypes?: SearchResultType[],
+): Promise<SearchResponse> {
   const params: Record<string, string> = { q: query };
-  if (nodeTypes && nodeTypes.length > 0) {
-    params.node_types = nodeTypes.join(',');
+  if (resultTypes && resultTypes.length > 0) {
+    params.result_types = resultTypes.join(',');
   }
   return apiGet<SearchResponse>('/api/search', params);
 }

--- a/frontend/src/hooks/useSearch.ts
+++ b/frontend/src/hooks/useSearch.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useState, useEffect } from 'react';
 import { search } from '@/api/search';
-import type { NodeType } from '@/types';
+import type { SearchResultType } from '@/types';
 
 function useDebounce<T>(value: T, delay: number): T {
   const [debouncedValue, setDebouncedValue] = useState<T>(value);
@@ -19,12 +19,12 @@ function useDebounce<T>(value: T, delay: number): T {
   return debouncedValue;
 }
 
-export function useSearch(query: string, nodeTypes?: NodeType[]) {
+export function useSearch(query: string, resultTypes?: SearchResultType[]) {
   const debouncedQuery = useDebounce(query, 300);
 
   return useQuery({
-    queryKey: ['search', debouncedQuery, nodeTypes],
-    queryFn: () => search(debouncedQuery, nodeTypes),
+    queryKey: ['search', debouncedQuery, resultTypes],
+    queryFn: () => search(debouncedQuery, resultTypes),
     enabled: debouncedQuery.length >= 2,
   });
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -509,13 +509,41 @@ export interface InboxResponse {
 }
 
 // Search
+export type SearchResultType =
+  | 'corpus_node'
+  | 'task'
+  | 'person'
+  | 'organisatie_eenheid'
+  | 'parlementair_item'
+  | 'tag';
+
+export const SEARCH_RESULT_TYPE_LABELS: Record<SearchResultType, string> = {
+  corpus_node: 'Beleidscorpus',
+  task: 'Taak',
+  person: 'Persoon',
+  organisatie_eenheid: 'Organisatie',
+  parlementair_item: 'Parlementair',
+  tag: 'Tag',
+};
+
+export const SEARCH_RESULT_TYPE_COLORS: Record<SearchResultType, string> = {
+  corpus_node: 'blue',
+  task: 'amber',
+  person: 'green',
+  organisatie_eenheid: 'purple',
+  parlementair_item: 'rose',
+  tag: 'cyan',
+};
+
 export interface SearchResult {
   id: string;
+  result_type: SearchResultType;
   title: string;
-  node_type: NodeType;
+  subtitle?: string;
   description?: string;
   score: number;
   highlights?: string[];
+  url: string;
 }
 
 export interface SearchResponse {


### PR DESCRIPTION
## Summary

- Adds stored `search_vector` tsvector columns with GIN indexes to 6 tables (corpus_node, task, person, organisatie_eenheid, parlementair_item, tag)
- Rewrites search backend to UNION ALL across all tables in a single round-trip, with `ts_headline` highlights
- New `SearchResultType` enum replaces `NodeType` filtering — API param changes from `node_types` to `result_types`
- Frontend SearchPage now has toggleable filter chips per entity type, groups results by type with colored badges, and opens corpus node / task detail modals inline

## Test plan

- [x] Migration applies cleanly (`just reset-db` verified)
- [x] All 290 backend tests pass
- [x] Frontend builds without TS errors
- [ ] Manual: open http://localhost:5173/search, type a query, verify results from multiple entity types appear grouped
- [ ] Manual: click filter chips to narrow results to specific types
- [ ] Manual: click a corpus node result → node detail modal opens; click a task result → task detail modal opens; click a person → navigates to person page