### PR TITLE
Add --build flag to all docker compose up commands

### DIFF
--- a/justfile
+++ b/justfile
@@ -12,9 +12,9 @@ default:
 dev:
     docker compose up --build
 
-# Start all services in background
+# Start all services in background (with rebuild)
 up:
-    docker compose up -d
+    docker compose up -d --build
 
 # Stop all services (keeps data)
 down:
@@ -59,12 +59,12 @@ seed:
 # Full database reset: nuke → start db → wait → migrate → seed → start services
 reset-db:
     docker compose down -v
-    docker compose up -d db
+    docker compose up -d --build db
     @echo "Wachten op database..."
     @sleep 3
     cd backend && uv run alembic upgrade head
     cd backend && uv run python scripts/seed.py
-    docker compose up -d backend frontend
+    docker compose up -d --build backend frontend
     @echo "Klaar! Alle services draaien."
 
 # Open a psql shell in the database container


### PR DESCRIPTION
## Summary
- Adds `--build` to all `docker compose up` invocations in the justfile (`up`, `reset-db`) so images are always rebuilt, matching the existing `dev` command behavior.

## Test plan
- [ ] Run `just up` and verify containers are rebuilt
- [ ] Run `just reset-db` and verify full reset works with rebuilds