### PR TITLE
Fix ZAD database: add schema search_path and URL-encode password

### DIFF
--- a/backend/bouwmeester/migrations/env.py
+++ b/backend/bouwmeester/migrations/env.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 from logging.config import fileConfig
 
 from alembic import context
@@ -9,6 +8,7 @@ from sqlalchemy.ext.asyncio import async_engine_from_config
 
 # Ensure all models are imported so their tables are registered on Base.metadata.
 import bouwmeester.models  # noqa: F401
+from bouwmeester.core.config import get_settings
 from bouwmeester.core.database import Base
 
 config = context.config
@@ -16,9 +16,10 @@ config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-# Use DATABASE_URL env var if available (e.g. in Docker)
-if os.environ.get("DATABASE_URL"):
-    config.set_main_option("sqlalchemy.url", os.environ["DATABASE_URL"])
+# Use Settings to derive DATABASE_URL (handles both direct URL and ZAD env vars)
+_settings = get_settings()
+if _settings.DATABASE_URL:
+    config.set_main_option("sqlalchemy.url", _settings.DATABASE_URL)
 
 target_metadata = Base.metadata
 


### PR DESCRIPTION
## Summary
- Add `DATABASE_SCHEMA` env var support to construct the PostgreSQL `search_path` option in the connection URL (ZAD uses per-app schemas, not separate databases)
- URL-encode the database password to handle special characters
- Reuse `get_settings()` in Alembic's `env.py` so migrations get the same derived `DATABASE_URL` as the app (previously only checked the raw `DATABASE_URL` env var, which ZAD doesn't set)

## Context
Backend was CrashLoopBackOff on ZAD because:
1. ZAD provides individual DB env vars (`DATABASE_SERVER_HOST`, `DATABASE_PASSWORD`, etc.) — not a single `DATABASE_URL`
2. The ZAD PostgreSQL instance uses schemas (`DATABASE_SCHEMA=bouwm_6gn_main`) instead of separate databases
3. Without `search_path`, Alembic migrations tried the `public` schema and failed on permissions

## Test plan
- [x] `ruff check` + `ruff format` pass
- [x] Local Alembic migrations still work
- [x] Docker build succeeds
- [ ] Deploy to ZAD and verify backend starts without CrashLoopBackOff