### PR TITLE
Fix ZAD backend: uv cache permission + database schema search_path

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -23,6 +23,8 @@ COPY --from=builder --chown=appuser:appuser /app /app
 
 USER 1001
 
+ENV UV_NO_CACHE=1
+
 EXPOSE 8080
 
 ENTRYPOINT ["sh", "/app/entrypoint.sh"]


### PR DESCRIPTION
## Summary
- **Fix CrashLoopBackOff**: Disable uv cache in runtime container (`UV_NO_CACHE=1`) — user 1001 cannot write to `/.cache/uv` on ZAD. Cache is unnecessary since packages are pre-installed in the builder stage.
- **Fix database connection**: Add `DATABASE_SCHEMA` env var support to include `search_path` in the connection URL (ZAD uses per-app schemas). URL-encode the password. Reuse `get_settings()` in Alembic env.py so migrations get the same derived URL.

## Test plan
- [x] `just reset-db` works locally
- [x] Docker build succeeds
- [x] Ruff lint + format pass
- [ ] Deploy to ZAD and verify backend starts