### PR TITLE
Fix uv runtime permission error: add UV_FROZEN=1

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -23,7 +23,7 @@ COPY --from=builder --chown=appuser:appuser /app /app
 
 USER 1001
 
-ENV UV_NO_CACHE=1
+ENV UV_NO_CACHE=1 UV_FROZEN=1
 
 EXPOSE 8080
 


### PR DESCRIPTION
## Summary
- `uv run` tries to sync/update packages at runtime, causing a permission error when it can't modify `.pth` files in the venv
- `UV_FROZEN=1` prevents this — all packages are already installed in the builder stage

## Error
```
error: failed to remove file /app/.venv/lib/python3.13/site-packages/_bouwmeester.pth: Permission denied (os error 13)
```

## Test plan
- [x] Docker build succeeds
- [ ] Deploy to ZAD and verify backend starts