### PR TITLE
Deploy to ZAD with SHA-tagged images for reliable rollouts

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -70,6 +70,10 @@ jobs:
       packages: read
 
     steps:
+      - name: Compute image tag
+        id: tag
+        run: echo "sha=sha-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
       - name: Deploy backend to ZAD
         uses: RijksICTGilde/zad-actions/deploy@v2
         with:
@@ -77,7 +81,7 @@ jobs:
           project-id: bouwm-6gn
           deployment-name: main
           component: component-2
-          image: ${{ env.IMAGE_PREFIX }}/backend:main
+          image: ${{ env.IMAGE_PREFIX }}/backend:${{ steps.tag.outputs.sha }}
 
       - name: Deploy frontend to ZAD
         uses: RijksICTGilde/zad-actions/deploy@v2
@@ -86,4 +90,4 @@ jobs:
           project-id: bouwm-6gn
           deployment-name: main
           component: component-1
-          image: ${{ env.IMAGE_PREFIX }}/frontend:main
+          image: ${{ env.IMAGE_PREFIX }}/frontend:${{ steps.tag.outputs.sha }}


### PR DESCRIPTION
## Summary
Deploy with `sha-<commit>` tags instead of `:main` so that every push to main triggers an actual Kubernetes rollout.

## Problem
Using `:main` means the image reference never changes from K8s perspective → no rollout → Robbert had to manually delete the pod to force a pull.

## Fix
- Compute `sha-${GITHUB_SHA::7}` in the deploy job (matches `docker/metadata-action`'s `type=sha` format)
- Use that tag in both zad-actions deploy steps
- Images are still also tagged with `:main` for convenience, but deploy uses the unique SHA tag

## Example
Push `abc1234` to main → builds `backend:sha-abc1234` + `backend:main` → deploys `backend:sha-abc1234` to ZAD → K8s sees new image → rollout.