### PR TITLE
Fix rootless container: use venv PATH instead of uv run

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -23,7 +23,8 @@ COPY --from=builder --chown=appuser:appuser /app /app
 
 USER 1001
 
-ENV UV_NO_CACHE=1 UV_FROZEN=1
+# Activate venv via PATH — entrypoint uses python/alembic/uvicorn directly
+ENV PATH="/app/.venv/bin:$PATH"
 
 EXPOSE 8080
 

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,13 +1,17 @@
 #!/bin/sh
 set -e
 
+# Activate the venv directly — avoids uv run which tries to
+# re-install the project and fails on read-only .pth files.
+export PATH="/app/.venv/bin:$PATH"
+
 echo "Running database migrations..."
-uv run alembic upgrade head
+alembic upgrade head
 
 if [ "${SEED_ON_STARTUP:-false}" = "true" ]; then
     echo "Seeding database..."
-    uv run python scripts/seed.py
+    python scripts/seed.py
 fi
 
 echo "Starting uvicorn..."
-exec uv run uvicorn bouwmeester.core.app:create_app --factory --host 0.0.0.0 --port 8080
+exec uvicorn bouwmeester.core.app:create_app --factory --host 0.0.0.0 --port 8080


### PR DESCRIPTION
## Summary
Replace `uv run` with direct venv PATH activation in the entrypoint and Dockerfile. This is the standard pattern for rootless Python containers.

## Problem
`uv run` tries to sync/re-install the project at startup, which fails because user 1001 cannot modify `.pth` files in the pre-built venv:
```
error: failed to remove file /app/.venv/lib/python3.13/site-packages/_bouwmeester.pth: Permission denied (os error 13)
```

## Fix
- `ENV PATH="/app/.venv/bin:$PATH"` in Dockerfile (standard venv activation)
- Entrypoint calls `alembic`/`python`/`uvicorn` directly instead of `uv run`
- Removed `UV_NO_CACHE=1 UV_FROZEN=1` (no longer needed)
- uv binary kept in image for local dev (docker-compose mounts source + uses `uv run`)

## Tested
- [x] `just reset-db` works locally
- [x] Docker image builds and runs with migrations + uvicorn
- [ ] Deploy to ZAD