### PR TITLE
Fix frontend backend URL detection for bouwmeester.rijks.app

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -6,8 +6,11 @@ function getBaseUrl(): string {
   // Check build-time env
   if (import.meta.env.VITE_API_BASE_URL) return import.meta.env.VITE_API_BASE_URL;
 
-  // Auto-detect: if frontend runs on component-1-*, backend is on component-2-*
+  // Auto-detect: if frontend runs on component-1, backend is on component-2
   const host = window.location.hostname;
+  if (host.startsWith('component-1.')) {
+    return `${window.location.protocol}//component-2.${host.slice('component-1.'.length)}`;
+  }
   if (host.startsWith('component-1-')) {
     return `${window.location.protocol}//component-2-${host.slice('component-1-'.length)}`;
   }


### PR DESCRIPTION
## Summary
Frontend couldn't find the backend API. The auto-detect in `client.ts` checked for `component-1-` (dash) but the actual hostname is `component-1.bouwmeester.rijks.app` (dot).

Now supports both patterns:
- `component-1.xxx` → `component-2.xxx` (new, bouwmeester.rijks.app)
- `component-1-xxx` → `component-2-xxx` (old, rig.prd1 pattern)