### PR TITLE
Add bouwmeester.rijks.app to CORS origins

### DIFF
--- a/backend/bouwmeester/core/config.py
+++ b/backend/bouwmeester/core/config.py
@@ -37,6 +37,7 @@ class Settings(BaseSettings):
     CORS_ORIGINS: list[str] = [
         "http://localhost:5173",
         "https://component-1.bouwmeester.rijks.app",
+        "https://bouwmeester.rijks.app",
     ]
 
     ANTHROPIC_API_KEY: str = ""


### PR DESCRIPTION
Also allow the base domain, not just the component-1 subdomain.