### PR TITLE
Fix CORS preflight errors on production

### DIFF
--- a/backend/bouwmeester/middleware/auth_required.py
+++ b/backend/bouwmeester/middleware/auth_required.py
@@ -103,6 +103,12 @@ class AuthRequiredMiddleware:
             await self.app(scope, receive, send)
             return
 
+        # Let CORS preflight (OPTIONS) requests through so CORSMiddleware
+        # can respond with the appropriate headers.
+        if scope.get("method") == "OPTIONS":
+            await self.app(scope, receive, send)
+            return
+
         # Only enforce on /api/ routes (not static files, etc.)
         path: str = scope.get("path", "")
 


### PR DESCRIPTION
## Summary

- AuthRequiredMiddleware was returning 401 on OPTIONS (preflight) requests before CORSMiddleware could add CORS headers
- Browsers then reported CORS errors since the preflight response lacked Access-Control-Allow-Origin
- The fix lets OPTIONS requests pass through auth unconditionally — preflight requests never carry credentials

## Test plan

- [x] All 296 backend tests pass
- [ ] Verify https://bouwmeester.rijks.app/organisatie loads without CORS errors after deploy
- [ ] Verify preflight OPTIONS requests return 200 with proper CORS headers