### PR TITLE
Fix functie label rendering for unknown values

### DIFF
--- a/frontend/src/components/parlementair/ParlementairReviewCard.tsx
+++ b/frontend/src/components/parlementair/ParlementairReviewCard.tsx
@@ -119,7 +119,7 @@ export function ParlementairReviewCard({ item, defaultExpanded = false }: Parlem
 
   // Helper for functie display
   const functieLabel = (functie?: string) =>
-    functie ? (FUNCTIE_LABELS[functie] ?? functie.replace(/_/g, ' ')) : undefined;
+    functie ? (FUNCTIE_LABELS[functie] ?? functie.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())) : undefined;
 
   // People options sorted: relevant eigenaren first, then the rest
   const sortedPeopleOptions: SelectOption[] = (people ?? [])

--- a/frontend/src/components/people/PersonCard.tsx
+++ b/frontend/src/components/people/PersonCard.tsx
@@ -59,7 +59,7 @@ export function PersonCard({ person, onClick, draggable, onDragStart }: PersonCa
             {person.functie && (
               <div className="flex items-center gap-1.5 text-xs text-text-secondary">
                 <Briefcase className="h-3 w-3 shrink-0" />
-                <span className="truncate">{FUNCTIE_LABELS[person.functie] || person.functie}</span>
+                <span className="truncate">{FUNCTIE_LABELS[person.functie] || person.functie.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}</span>
               </div>
             )}
             {person.is_agent && person.description && (

--- a/frontend/src/components/people/PersonCardExpandable.tsx
+++ b/frontend/src/components/people/PersonCardExpandable.tsx
@@ -108,7 +108,7 @@ export function PersonCardExpandable({ person, onEditPerson, onDragStartPerson, 
             {person.functie && !person.is_agent && (
               <span className="flex items-center gap-1">
                 <Briefcase className="h-3 w-3" />
-                {FUNCTIE_LABELS[person.functie] || person.functie}
+                {FUNCTIE_LABELS[person.functie] || person.functie.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}
               </span>
             )}
             {person.description && person.is_agent && (

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -365,6 +365,7 @@ export const FUNCTIE_LABELS: Record<string, string> = {
   programmamanager: 'Programmamanager',
   jurist: 'Jurist',
   communicatieadviseur: 'Communicatieadviseur',
+  staff_engineer: 'Staff Engineer',
 };
 
 // People


### PR DESCRIPTION
## Summary
- Add `staff_engineer` to `FUNCTIE_LABELS` so it renders as "Staff Engineer"
- Apply title case fallback for any unmapped functie values (replaces underscores with spaces and capitalizes words)
- Consistent across PersonCard, PersonCardExpandable, and ParlementairReviewCard

## Test plan
- [ ] Verify person cards show "Staff Engineer" instead of "staff_engineer"
- [ ] Verify any other unknown functie values render with title case and spaces