### PR TITLE
Add .dockerignore files to reduce build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+backend/.venv
+backend/__pycache__
+backend/*.pyc
+backend/.pytest_cache
+backend/.ruff_cache
+backend/.coverage
+backend/coverage.xml
+backend/htmlcov
+backend/tests
+frontend/node_modules
+frontend/dist
+frontend/coverage
+frontend/.vite

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,11 @@
+.venv
+__pycache__
+*.pyc
+.pytest_cache
+.ruff_cache
+.coverage
+coverage.xml
+htmlcov
+.mypy_cache
+*.egg-info
+tests

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+coverage
+.vite
+*.tsbuildinfo


### PR DESCRIPTION
## Summary
- Add `.dockerignore` for `backend/`, `frontend/`, and root Dockerfiles
- Excludes `node_modules` (278MB), `.venv` (231MB), `__pycache__`, test artifacts, and other build junk from Docker build context
- Prevents accidental cache busting and speeds up local builds

## Test plan
- [ ] Verify `docker.yml` CI builds still succeed
- [ ] Verify local `docker compose build` still works