### PR TITLE
Add person search+link to PersonEditForm

### DIFF
--- a/backend/bouwmeester/repositories/person.py
+++ b/backend/bouwmeester/repositories/person.py
@@ -29,9 +29,10 @@ class PersonRepository(BaseRepository[Person]):
         return result.scalar_one_or_none()
 
     async def search(self, query: str, limit: int = 10) -> list[Person]:
+        escaped = query.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
         stmt = (
             select(Person)
-            .where(Person.naam.ilike(f"%{query}%"))
+            .where(Person.naam.ilike(f"%{escaped}%"))
             .order_by(Person.naam)
             .limit(limit)
         )

--- a/frontend/src/api/mentions.ts
+++ b/frontend/src/api/mentions.ts
@@ -1,5 +1,4 @@
 import { apiGet } from './client';
-import type { Person } from '@/types';
 
 export interface MentionSearchResult {
   id: string;
@@ -12,10 +11,6 @@ export interface MentionReference {
   source_type: string;
   source_id: string;
   source_title: string;
-}
-
-export function searchPeople(q: string): Promise<Person[]> {
-  return apiGet<Person[]>('/api/people/search', { q, limit: 10 });
 }
 
 export function searchMentionables(q: string): Promise<MentionSearchResult[]> {

--- a/frontend/src/api/people.ts
+++ b/frontend/src/api/people.ts
@@ -55,3 +55,7 @@ export async function removePersonOrganisatie(
 ): Promise<void> {
   return apiDelete(`/api/people/${personId}/organisaties/${placementId}`);
 }
+
+export async function searchPeople(q: string, limit = 10): Promise<Person[]> {
+  return apiGet<Person[]>('/api/people/search', { q, limit: String(limit) });
+}

--- a/frontend/src/hooks/useDebounce.ts
+++ b/frontend/src/hooks/useDebounce.ts
@@ -1,0 +1,17 @@
+import { useState, useEffect } from 'react';
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/frontend/src/hooks/usePeople.ts
+++ b/frontend/src/hooks/usePeople.ts
@@ -8,7 +8,9 @@ import {
   addPersonOrganisatie,
   updatePersonOrganisatie,
   removePersonOrganisatie,
+  searchPeople,
 } from '@/api/people';
+import { useDebounce } from '@/hooks/useDebounce';
 import { useMutationWithError } from '@/hooks/useMutationWithError';
 import type { PersonCreate } from '@/types';
 
@@ -95,5 +97,14 @@ export function useRemovePersonOrganisatie() {
     }) => removePersonOrganisatie(personId, placementId),
     errorMessage: 'Fout bij verwijderen plaatsing',
     invalidateKeys: [['people'], ['organisatie']],
+  });
+}
+
+export function useSearchPeople(query: string) {
+  const debouncedQuery = useDebounce(query, 300);
+  return useQuery({
+    queryKey: ['people', 'search', debouncedQuery],
+    queryFn: () => searchPeople(debouncedQuery),
+    enabled: debouncedQuery.length >= 2,
   });
 }

--- a/frontend/src/hooks/usePersonFormSubmit.ts
+++ b/frontend/src/hooks/usePersonFormSubmit.ts
@@ -1,0 +1,71 @@
+import { useCreatePerson, useUpdatePerson, useAddPersonOrganisatie } from '@/hooks/usePeople';
+import { todayISO } from '@/utils/dates';
+import type { PersonFormSubmitParams } from '@/types';
+
+/**
+ * Shared handler for PersonEditForm submissions.
+ * Handles all three modes: edit, link-existing, and create(+link).
+ */
+export function usePersonFormSubmit(onDone: () => void) {
+  const createPersonMutation = useCreatePerson();
+  const updatePersonMutation = useUpdatePerson();
+  const addPlacementMutation = useAddPersonOrganisatie();
+
+  const isPending =
+    createPersonMutation.isPending ||
+    updatePersonMutation.isPending ||
+    addPlacementMutation.isPending;
+
+  const handleSubmit = (params: PersonFormSubmitParams) => {
+    switch (params.kind) {
+      case 'edit':
+        updatePersonMutation.mutate(
+          { id: params.personId, data: params.data },
+          { onSuccess: onDone },
+        );
+        break;
+
+      case 'link':
+        if (params.orgEenheidId) {
+          addPlacementMutation.mutate(
+            {
+              personId: params.existingPersonId,
+              data: {
+                organisatie_eenheid_id: params.orgEenheidId,
+                dienstverband: params.dienstverband || 'in_dienst',
+                start_datum: todayISO(),
+              },
+            },
+            { onSettled: onDone },
+          );
+        } else {
+          onDone();
+        }
+        break;
+
+      case 'create':
+        createPersonMutation.mutate(params.data, {
+          onSuccess: (person) => {
+            if (params.orgEenheidId) {
+              addPlacementMutation.mutate(
+                {
+                  personId: person.id,
+                  data: {
+                    organisatie_eenheid_id: params.orgEenheidId,
+                    dienstverband: params.dienstverband || 'in_dienst',
+                    start_datum: todayISO(),
+                  },
+                },
+                { onSettled: onDone },
+              );
+            } else {
+              onDone();
+            }
+          },
+        });
+        break;
+    }
+  };
+
+  return { handleSubmit, isPending };
+}

--- a/frontend/src/hooks/useSearch.ts
+++ b/frontend/src/hooks/useSearch.ts
@@ -1,23 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
-import { useState, useEffect } from 'react';
 import { search } from '@/api/search';
+import { useDebounce } from '@/hooks/useDebounce';
 import type { SearchResultType } from '@/types';
-
-function useDebounce<T>(value: T, delay: number): T {
-  const [debouncedValue, setDebouncedValue] = useState<T>(value);
-
-  useEffect(() => {
-    const handler = setTimeout(() => {
-      setDebouncedValue(value);
-    }, delay);
-
-    return () => {
-      clearTimeout(handler);
-    };
-  }, [value, delay]);
-
-  return debouncedValue;
-}
 
 export function useSearch(query: string, resultTypes?: SearchResultType[]) {
   const debouncedQuery = useDebounce(query, 300);

--- a/frontend/src/pages/PeoplePage.tsx
+++ b/frontend/src/pages/PeoplePage.tsx
@@ -3,18 +3,16 @@ import { Plus } from 'lucide-react';
 import { Button } from '@/components/common/Button';
 import { PersonList } from '@/components/people/PersonList';
 import { PersonEditForm } from '@/components/people/PersonEditForm';
-import { usePeople, useCreatePerson, useUpdatePerson, useAddPersonOrganisatie } from '@/hooks/usePeople';
-import { todayISO } from '@/utils/dates';
-import type { Person, PersonCreate } from '@/types';
+import { usePeople } from '@/hooks/usePeople';
+import { usePersonFormSubmit } from '@/hooks/usePersonFormSubmit';
+import type { Person } from '@/types';
 
 export function PeoplePage() {
   const [showForm, setShowForm] = useState(false);
   const [editPerson, setEditPerson] = useState<Person | null>(null);
 
   const { data: people = [], isLoading } = usePeople();
-  const createPersonMutation = useCreatePerson();
-  const updatePersonMutation = useUpdatePerson();
-  const addPlacementMutation = useAddPersonOrganisatie();
+  const { handleSubmit: handleFormSubmit, isPending } = usePersonFormSubmit(() => setShowForm(false));
 
   const handleAddPerson = () => {
     setEditPerson(null);
@@ -24,35 +22,6 @@ export function PeoplePage() {
   const handleEditPerson = (person: Person) => {
     setEditPerson(person);
     setShowForm(true);
-  };
-
-  const handleFormSubmit = (data: PersonCreate, orgEenheidId?: string, dienstverband?: string) => {
-    if (editPerson) {
-      updatePersonMutation.mutate(
-        { id: editPerson.id, data },
-        { onSuccess: () => setShowForm(false) },
-      );
-    } else {
-      createPersonMutation.mutate(data, {
-        onSuccess: (person) => {
-          if (orgEenheidId) {
-            addPlacementMutation.mutate(
-              {
-                personId: person.id,
-                data: {
-                  organisatie_eenheid_id: orgEenheidId,
-                  dienstverband: dienstverband || 'in_dienst',
-                  start_datum: todayISO(),
-                },
-              },
-              { onSettled: () => setShowForm(false) },
-            );
-          } else {
-            setShowForm(false);
-          }
-        },
-      });
-    }
   };
 
   return (
@@ -84,7 +53,7 @@ export function PeoplePage() {
         open={showForm}
         onClose={() => setShowForm(false)}
         onSubmit={handleFormSubmit}
-        isLoading={createPersonMutation.isPending || updatePersonMutation.isPending || addPlacementMutation.isPending}
+        isLoading={isPending}
         editData={editPerson}
       />
     </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -390,6 +390,32 @@ export interface PersonCreate {
   api_key?: string;
 }
 
+// PersonEditForm submit discriminated union
+/** Create a new person (optionally link to org) */
+interface PersonFormCreate {
+  kind: 'create';
+  data: PersonCreate;
+  orgEenheidId?: string;
+  dienstverband?: string;
+}
+
+/** Link an existing person to an org */
+interface PersonFormLink {
+  kind: 'link';
+  existingPersonId: string;
+  orgEenheidId?: string;
+  dienstverband?: string;
+}
+
+/** Edit an existing person's fields */
+interface PersonFormEdit {
+  kind: 'edit';
+  personId: string;
+  data: PersonCreate;
+}
+
+export type PersonFormSubmitParams = PersonFormCreate | PersonFormLink | PersonFormEdit;
+
 // Person ↔ OrganisatieEenheid placements
 export interface PersonOrganisatie {
   id: string;


### PR DESCRIPTION
## Summary

- The "Persoon toevoegen" modal now supports **searching for and linking existing persons** to an org unit, instead of always creating new ones
- The naam field in create mode uses a `CreatableSelect` backed by `GET /api/people/search`, with agents filtered out
- Selecting an existing person shows read-only email/functie and a "Koppelen" button; typing a new name falls through to the existing create flow
- An X button allows deselecting a chosen person to return to search/create mode

**Also included:**
- Extract shared `usePersonFormSubmit` hook — deduplicates ~40 lines of submit logic from both `PeoplePage` and `OrganisatiePage`
- Discriminated union type (`PersonFormSubmitParams`) with `kind: 'create' | 'link' | 'edit'` for type-safe submit handling
- New `CreatableSelect` props: `onClear`, `emptyMessage`, `filterLocally`, `displayValue`, `onQueryChange`
- Extract shared `useDebounce` hook (was duplicated in `useSearch.ts`)
- Move canonical `searchPeople` from `mentions.ts` to `people.ts`
- Escape SQL wildcards (`%`, `_`) in `PersonRepository.search`

## Test plan

- [ ] Go to Organisatie page → select an eenheid → click "Persoon toevoegen"
- [ ] Type 2+ chars → existing persons appear in dropdown (no agents)
- [ ] Select existing person → email/functie become read-only, button says "Koppelen"
- [ ] Click X to deselect → returns to search/create mode
- [ ] Submit with existing person → linked to org (no new person created)
- [ ] Type unknown name → "Nieuwe persoon aanmaken" option appears → creates new person
- [ ] Type 1 char → shows "Typ minimaal 2 tekens om te zoeken..."
- [ ] Verify edit mode still works (click existing person in org detail)
- [ ] Verify agent creation flow unchanged (click "Agent toevoegen")
- [ ] Verify PeoplePage "Persoon toevoegen" works with search+link
- [ ] Try linking a person already placed in the same eenheid → expect 409 toast