### PR TITLE
Fix unused PersonCreate import causing ESLint failure

### DIFF
--- a/frontend/src/components/people/PersonEditForm.tsx
+++ b/frontend/src/components/people/PersonEditForm.tsx
@@ -7,7 +7,7 @@ import { CreatableSelect, type SelectOption } from '@/components/common/Creatabl
 import { CascadingOrgSelect } from '@/components/common/CascadingOrgSelect';
 import { usePeople, useSearchPeople } from '@/hooks/usePeople';
 import { FUNCTIE_LABELS, DIENSTVERBAND_LABELS } from '@/types';
-import type { Person, PersonCreate, PersonFormSubmitParams } from '@/types';
+import type { Person, PersonFormSubmitParams } from '@/types';
 
 // Character names from Bordewijk's novel "Karakter" — used as agent names
 const KARAKTER_NAMEN = [


### PR DESCRIPTION
## Summary
- Remove unused `PersonCreate` type import from `PersonEditForm.tsx` that was causing ESLint `no-unused-vars` failure in CI after PR #50

## Test plan
- [ ] ESLint CI check passes
- [ ] TypeScript typecheck passes (verified locally)