### PR TITLE
Fix TypeScript errors in audit log

### DIFF
--- a/frontend/src/api/activity.ts
+++ b/frontend/src/api/activity.ts
@@ -2,6 +2,7 @@ import { apiGet } from './client';
 import type { ActivityFeedResponse } from '@/types';
 
 export interface ActivityFeedParams {
+  [key: string]: string | number | boolean | undefined;
   skip?: number;
   limit?: number;
   event_type?: string;

--- a/frontend/src/pages/AuditLogPage.tsx
+++ b/frontend/src/pages/AuditLogPage.tsx
@@ -51,11 +51,11 @@ function humanizeValue(key: string, value: unknown): string {
   }
 
   if (key === 'priority') {
-    return TASK_PRIORITY_LABELS?.[str] || str;
+    return (TASK_PRIORITY_LABELS as Record<string, string>)[str] || str;
   }
 
   if (key === 'old_status' || key === 'new_status') {
-    return TASK_STATUS_LABELS?.[str] || str;
+    return (TASK_STATUS_LABELS as Record<string, string>)[str] || str;
   }
 
   return str;
@@ -170,7 +170,7 @@ function DetailCell({
   onOpenTask: (id: string) => void;
 }) {
   const d = item.details || {};
-  const subject = d.title || d.naam || d.name;
+  const subject = (d.title || d.naam || d.name) as string | undefined;
   const chips = buildChips(item);
 
   // Determine what clicking the subject should do


### PR DESCRIPTION
## Summary
- Fix 3 TypeScript strict mode errors introduced in the audit log PR (#49)
- Add index signature to `ActivityFeedParams` for `apiGet` compatibility
- Cast enum-keyed label maps to `Record<string, string>` in `humanizeValue`
- Type `subject` as `string | undefined` to satisfy `ReactNode` constraint

## Test plan
- [ ] `npx tsc -b` passes
- [ ] `npx vite build` succeeds
- [ ] Docker production build succeeds