### PR TITLE
Fix unassigned tasks not showing on Bureau Overzicht

### DIFF
--- a/frontend/src/components/common/RichTextEditor.tsx
+++ b/frontend/src/components/common/RichTextEditor.tsx
@@ -4,6 +4,7 @@ import StarterKit from '@tiptap/starter-kit';
 import Mention from '@tiptap/extension-mention';
 import Placeholder from '@tiptap/extension-placeholder';
 import { apiGet } from '@/api/client';
+import { formatFunctie } from '@/types';
 import type { Person, OrganisatieEenheid } from '@/types';
 import type { MentionSearchResult } from '@/api/mentions';
 import type { SuggestionProps, SuggestionKeyDownProps } from '@tiptap/suggestion';
@@ -215,7 +216,7 @@ async function fetchPeopleAndOrgs(query: string): Promise<SuggestionItem[]> {
     const personItems: SuggestionItem[] = people.map((p) => ({
       id: p.id,
       label: p.naam,
-      subtitle: p.functie ?? undefined,
+      subtitle: formatFunctie(p.functie),
       mentionType: 'person',
     }));
     const orgItems: SuggestionItem[] = orgs.map((o) => ({

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -7,7 +7,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { VOCABULARY_LABELS, type VocabularyId } from '@/vocabulary';
 import { NotificationBell } from '@/components/common/NotificationBell';
 import { useManagedEenheden } from '@/hooks/useOrganisatie';
-import { ORGANISATIE_TYPE_LABELS } from '@/types';
+import { ORGANISATIE_TYPE_LABELS, formatFunctie } from '@/types';
 
 const pageTitles: Record<string, string> = {
   '/': 'Inbox',
@@ -214,7 +214,7 @@ export function Header() {
                     <div className="flex-1 min-w-0">
                       <p className="text-sm text-text truncate">{person.naam}</p>
                       {person.functie && (
-                        <p className="text-xs text-text-secondary truncate">{person.functie}</p>
+                        <p className="text-xs text-text-secondary truncate">{formatFunctie(person.functie)}</p>
                       )}
                     </div>
                     {currentPerson?.id === person.id && (

--- a/frontend/src/components/nodes/NodeDetail.tsx
+++ b/frontend/src/components/nodes/NodeDetail.tsx
@@ -20,7 +20,7 @@ import { useNodeTags, useAddTagToNode, useRemoveTagFromNode, useTags } from '@/h
 import { useReferences } from '@/hooks/useMentions';
 import { useTaskDetail } from '@/contexts/TaskDetailContext';
 import { CreatableSelect } from '@/components/common/CreatableSelect';
-import { NODE_TYPE_COLORS, STAKEHOLDER_ROL_LABELS } from '@/types';
+import { NODE_TYPE_COLORS, STAKEHOLDER_ROL_LABELS, formatFunctie } from '@/types';
 import { useVocabulary } from '@/contexts/VocabularyContext';
 import { formatDate } from '@/utils/dates';
 
@@ -472,7 +472,7 @@ export function NodeDetail({ nodeId }: NodeDetailProps) {
                     options={(allPeople ?? []).map((p) => ({
                       value: p.id,
                       label: p.naam,
-                      description: p.functie || undefined,
+                      description: formatFunctie(p.functie),
                     }))}
                     placeholder="Selecteer persoon..."
                     onCreate={async (text) => {

--- a/frontend/src/components/organisatie/OrganisatieDetail.tsx
+++ b/frontend/src/components/organisatie/OrganisatieDetail.tsx
@@ -6,7 +6,7 @@ import { Badge } from '@/components/common/Badge';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
 import { PersonCardExpandable } from '@/components/people/PersonCardExpandable';
 import { useOrganisatieEenheid, useOrganisatiePersonenRecursive } from '@/hooks/useOrganisatie';
-import { ORGANISATIE_TYPE_LABELS } from '@/types';
+import { ORGANISATIE_TYPE_LABELS, formatFunctie } from '@/types';
 import type { Person, OrganisatieEenheidPersonenGroup } from '@/types';
 
 /** Org types where the manager role is labeled "Coördinator" instead of "Manager". */
@@ -286,7 +286,7 @@ export function OrganisatieDetail({
           <h2 className="text-xl font-semibold text-text">{eenheid.naam}</h2>
           {eenheid.manager && (
             <p className="text-sm text-text-secondary mt-0.5">
-              {eenheid.manager.naam}{eenheid.manager.functie ? ` — ${eenheid.manager.functie}` : ''}
+              {eenheid.manager.naam}{eenheid.manager.functie ? ` — ${formatFunctie(eenheid.manager.functie)}` : ''}
             </p>
           )}
           {eenheid.beschrijving && (() => {

--- a/frontend/src/components/organisatie/OrganisatieForm.tsx
+++ b/frontend/src/components/organisatie/OrganisatieForm.tsx
@@ -9,7 +9,7 @@ import type {
   OrganisatieEenheidCreate,
   OrganisatieEenheidUpdate,
 } from '@/types';
-import { ORGANISATIE_TYPE_OPTIONS } from '@/types';
+import { ORGANISATIE_TYPE_OPTIONS, formatFunctie } from '@/types';
 import { useOrganisatieFlat, useOrganisatiePersonen } from '@/hooks/useOrganisatie';
 
 interface OrganisatieFormProps {
@@ -61,7 +61,7 @@ export function OrganisatieForm({
     ...personen.map((p) => ({
       value: p.id,
       label: p.naam,
-      description: p.functie || undefined,
+      description: formatFunctie(p.functie),
     })),
   ];
 

--- a/frontend/src/components/parlementair/ParlementairReviewCard.tsx
+++ b/frontend/src/components/parlementair/ParlementairReviewCard.tsx
@@ -30,7 +30,7 @@ import {
   PARLEMENTAIR_TYPE_LABELS,
   PARLEMENTAIR_TYPE_COLORS,
   NODE_TYPE_COLORS,
-  FUNCTIE_LABELS,
+  formatFunctie,
 } from '@/types';
 import { NodeDetailModal } from '@/components/nodes/NodeDetailModal';
 import { useVocabulary } from '@/contexts/VocabularyContext';
@@ -118,8 +118,7 @@ export function ParlementairReviewCard({ item, defaultExpanded = false }: Parlem
   );
 
   // Helper for functie display
-  const functieLabel = (functie?: string) =>
-    functie ? (FUNCTIE_LABELS[functie] ?? functie.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())) : undefined;
+  const functieLabel = formatFunctie;
 
   // People options sorted: relevant eigenaren first, then the rest
   const sortedPeopleOptions: SelectOption[] = (people ?? [])

--- a/frontend/src/components/people/PersonCard.tsx
+++ b/frontend/src/components/people/PersonCard.tsx
@@ -1,6 +1,6 @@
 import { User, Mail, Briefcase, Bot } from 'lucide-react';
 import { Card } from '@/components/common/Card';
-import { FUNCTIE_LABELS } from '@/types';
+import { formatFunctie } from '@/types';
 import type { Person } from '@/types';
 
 interface PersonCardProps {
@@ -59,7 +59,7 @@ export function PersonCard({ person, onClick, draggable, onDragStart }: PersonCa
             {person.functie && (
               <div className="flex items-center gap-1.5 text-xs text-text-secondary">
                 <Briefcase className="h-3 w-3 shrink-0" />
-                <span className="truncate">{FUNCTIE_LABELS[person.functie] || person.functie.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}</span>
+                <span className="truncate">{formatFunctie(person.functie)}</span>
               </div>
             )}
             {person.is_agent && person.description && (

--- a/frontend/src/components/people/PersonCardExpandable.tsx
+++ b/frontend/src/components/people/PersonCardExpandable.tsx
@@ -5,7 +5,7 @@ import { Card } from '@/components/common/Card';
 import { Badge } from '@/components/common/Badge';
 import { SendMessageModal } from '@/components/common/SendMessageModal';
 import { usePersonSummary, usePersonOrganisaties, useUpdatePersonOrganisatie, useRemovePersonOrganisatie } from '@/hooks/usePeople';
-import { FUNCTIE_LABELS, NODE_TYPE_COLORS, STAKEHOLDER_ROL_LABELS, DIENSTVERBAND_LABELS } from '@/types';
+import { formatFunctie, NODE_TYPE_COLORS, STAKEHOLDER_ROL_LABELS, DIENSTVERBAND_LABELS } from '@/types';
 import { useVocabulary } from '@/contexts/VocabularyContext';
 import { formatDateShort, todayISO } from '@/utils/dates';
 import { useTaskDetail } from '@/contexts/TaskDetailContext';
@@ -115,7 +115,7 @@ export function PersonCardExpandable({ person, onEditPerson, onDragStartPerson, 
             {person.functie && !person.is_agent && (
               <span className="flex items-center gap-1">
                 <Briefcase className="h-3 w-3" />
-                {FUNCTIE_LABELS[person.functie] || person.functie.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}
+                {formatFunctie(person.functie)}
               </span>
             )}
             {person.description && person.is_agent && (

--- a/frontend/src/components/tasks/TaskView.tsx
+++ b/frontend/src/components/tasks/TaskView.tsx
@@ -16,6 +16,7 @@ import {
   TASK_STATUS_LABELS,
   TASK_PRIORITY_LABELS,
   ORGANISATIE_TYPE_LABELS,
+  formatFunctie,
 } from '@/types';
 import type { Task } from '@/types';
 import type { SelectOption } from '@/components/common/CreatableSelect';
@@ -77,7 +78,7 @@ export function TaskView({ tasks, defaultNodeId }: TaskViewProps) {
     ...(people ?? []).map((p) => ({
       value: p.id,
       label: p.naam,
-      description: p.functie ?? undefined,
+      description: formatFunctie(p.functie),
     })),
   ], [people, currentPerson]);
 

--- a/frontend/src/hooks/useTaskFormOptions.ts
+++ b/frontend/src/hooks/useTaskFormOptions.ts
@@ -3,7 +3,7 @@ import { useNodes, useCreateNode } from '@/hooks/useNodes';
 import { usePeople } from '@/hooks/usePeople';
 import { useOrganisatieFlat } from '@/hooks/useOrganisatie';
 import { useVocabulary } from '@/contexts/VocabularyContext';
-import { ORGANISATIE_TYPE_LABELS, NodeType } from '@/types';
+import { ORGANISATIE_TYPE_LABELS, NodeType, formatFunctie } from '@/types';
 import type { SelectOption } from '@/components/common/CreatableSelect';
 
 export function useTaskFormOptions() {
@@ -29,7 +29,7 @@ export function useTaskFormOptions() {
     () => (allPeople ?? []).map((p) => ({
       value: p.id,
       label: p.naam,
-      description: p.functie ?? undefined,
+      description: formatFunctie(p.functie),
     })),
     [allPeople],
   );

--- a/frontend/src/pages/EenheidOverzichtPage.tsx
+++ b/frontend/src/pages/EenheidOverzichtPage.tsx
@@ -42,9 +42,6 @@ export function EenheidOverzichtPage() {
     selectedEenheidId || null,
   );
 
-  const highLevelTypes = new Set(['ministerie', 'directoraat_generaal', 'directie']);
-  const showNoUnit = overview ? highLevelTypes.has(overview.eenheid_type) : false;
-
   const handleSelectSubeenheid = (eenheidId: string) => {
     setSelectedEenheidId(eenheidId);
     setExpandedPersonId(null);
@@ -96,7 +93,6 @@ export function EenheidOverzichtPage() {
             noUnitCount={overview.unassigned_no_unit_count}
             noPersonTasks={overview.unassigned_no_person}
             noPersonCount={overview.unassigned_no_person_count}
-            showNoUnit={showNoUnit}
             eenheidType={overview.eenheid_type}
             selectedEenheidId={selectedEenheidId}
           />

--- a/frontend/src/pages/InboxPage.tsx
+++ b/frontend/src/pages/InboxPage.tsx
@@ -28,7 +28,7 @@ const NOTIFICATION_TYPE_MAP: Record<string, string> = {
   agent_prompt: 'message',
 };
 
-const PERSON_LEVEL_TYPES = new Set(['afdeling', 'team', 'cluster']);
+const PERSON_LEVEL_TYPES = new Set(['afdeling', 'dienst', 'bureau', 'cluster', 'team']);
 
 export function InboxPage() {
   const navigate = useNavigate();

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -221,13 +221,13 @@ export interface TaskCreate {
 
 export interface TaskUpdate {
   title?: string;
-  description?: string;
+  description?: string | null;
   status?: TaskStatus;
   priority?: TaskPriority;
-  due_date?: string;
-  assignee_id?: string;
-  organisatie_eenheid_id?: string;
-  parent_id?: string;
+  due_date?: string | null;
+  assignee_id?: string | null;
+  organisatie_eenheid_id?: string | null;
+  parent_id?: string | null;
 }
 
 export interface EenheidPersonTaskStats {
@@ -367,6 +367,11 @@ export const FUNCTIE_LABELS: Record<string, string> = {
   communicatieadviseur: 'Communicatieadviseur',
   staff_engineer: 'Staff Engineer',
 };
+
+export function formatFunctie(functie?: string | null): string | undefined {
+  if (!functie) return undefined;
+  return FUNCTIE_LABELS[functie] ?? functie.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+}
 
 // People
 export interface Person {


### PR DESCRIPTION
## Summary

- **Fix invisible unassigned tasks**: `bureau` and `dienst` org types fell through the cracks — not classified as high-level or person-level, so both "geen eenheid" and "geen persoon" sections were hidden on Bureau Overzicht
- **Always show unitless tasks**: removed the `showNoUnit` gate so any manager sees tasks without a unit assigned
- **Fix clearing assignments**: selecting "Geen" now sends `null` (included in JSON) instead of `undefined` (stripped), so the backend actually clears the field
- **Filter person dropdown by unit**: person dropdown now shows only people from the selected unit and its descendants, not all people
- **Consistent functie labels**: added shared `formatFunctie()` utility replacing 11 occurrences of raw `functie` display or duplicated inline formatting logic

## Test plan

- [ ] Log in as a manager of a bureau-type unit (e.g. Kees Keulemans)
- [ ] Verify dashboard shows "X onverdeelde taken" card
- [ ] Click through to Bureau Overzicht — "Onverdeeld" section should appear with matching count
- [ ] In "Geen persoon" section, verify person dropdown only shows people from the unit
- [ ] Select "Geen" for a task's unit — verify it moves to "Geen eenheid" section
- [ ] Verify functie labels display without underscores everywhere (person cards, dropdowns, header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)