### PR TITLE
Make frontend fully responsive for mobile and tablet

### DIFF
--- a/frontend/src/components/common/Button.tsx
+++ b/frontend/src/components/common/Button.tsx
@@ -17,7 +17,7 @@ const variantClasses: Record<ButtonVariant, string> = {
 };
 
 const sizeClasses: Record<ButtonSize, string> = {
-  sm: 'px-2.5 py-1.5 text-xs rounded-lg',
+  sm: 'px-2.5 py-1.5 text-xs rounded-lg min-h-[44px] md:min-h-0',
   md: 'px-3.5 py-2 text-sm rounded-xl',
   lg: 'px-4 py-2.5 text-sm rounded-xl',
 };

--- a/frontend/src/components/common/Modal.tsx
+++ b/frontend/src/components/common/Modal.tsx
@@ -51,7 +51,7 @@ export function Modal({ open, onClose, title, children, footer, size = 'md', clo
 
       {/* Dialog */}
       <div
-        className={`relative w-full ${sizeClasses[size]} mx-4 bg-surface rounded-2xl shadow-xl border border-border animate-in fade-in zoom-in-95`}
+        className={`relative w-full ${sizeClasses[size]} mx-2 sm:mx-4 bg-surface rounded-2xl shadow-xl border border-border animate-in fade-in zoom-in-95`}
       >
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-border">
@@ -67,7 +67,7 @@ export function Modal({ open, onClose, title, children, footer, size = 'md', clo
         </div>
 
         {/* Body – extra bottom padding so dropdown menus have room to open */}
-        <div className="px-6 py-4 max-h-[60vh] overflow-y-auto pb-40">{children}</div>
+        <div className="px-6 py-4 max-h-[70vh] sm:max-h-[60vh] overflow-y-auto pb-40">{children}</div>
 
         {/* Footer */}
         {footer && (

--- a/frontend/src/components/common/NotificationBell.tsx
+++ b/frontend/src/components/common/NotificationBell.tsx
@@ -91,7 +91,7 @@ export function NotificationBell({ personId }: NotificationBellProps) {
     <div className="relative" ref={menuRef}>
       <button
         onClick={() => setOpen(!open)}
-        className="relative flex items-center justify-center h-8 w-8 rounded-full text-text-secondary hover:bg-gray-100 hover:text-text transition-colors"
+        className="relative flex items-center justify-center h-10 w-10 md:h-8 md:w-8 rounded-full text-text-secondary hover:bg-gray-100 hover:text-text transition-colors"
       >
         <Bell className="h-5 w-5" />
         {unreadCount > 0 && (

--- a/frontend/src/components/eenheid/PersonTasksRow.tsx
+++ b/frontend/src/components/eenheid/PersonTasksRow.tsx
@@ -25,7 +25,7 @@ export function PersonTasksRow({ person, isExpanded, onToggle }: PersonTasksRowP
         className="border-b border-border last:border-0 hover:bg-gray-50 transition-colors cursor-pointer"
         onClick={onToggle}
       >
-        <td className="px-5 py-3 font-medium text-text">
+        <td className="px-3 md:px-5 py-3 font-medium text-text">
           <div className="flex items-center gap-2">
             <ChevronRight
               className={`h-4 w-4 text-text-secondary transition-transform ${
@@ -35,17 +35,17 @@ export function PersonTasksRow({ person, isExpanded, onToggle }: PersonTasksRowP
             {person.person_naam}
           </div>
         </td>
-        <td className="px-5 py-3 text-right text-text-secondary">
+        <td className="px-3 md:px-5 py-3 text-right text-text-secondary">
           {person.open_count}
         </td>
-        <td className="px-5 py-3 text-right text-text-secondary">
+        <td className="px-3 md:px-5 py-3 text-right text-text-secondary">
           {person.in_progress_count}
         </td>
-        <td className="px-5 py-3 text-right text-text-secondary">
+        <td className="px-3 md:px-5 py-3 text-right text-text-secondary">
           {person.done_count}
         </td>
         <td
-          className={`px-5 py-3 text-right font-medium ${
+          className={`px-3 md:px-5 py-3 text-right font-medium ${
             person.overdue_count > 0
               ? 'text-red-600'
               : 'text-text-secondary'
@@ -56,7 +56,7 @@ export function PersonTasksRow({ person, isExpanded, onToggle }: PersonTasksRowP
       </tr>
       {isExpanded && (
         <tr>
-          <td colSpan={5} className="px-5 py-3 bg-gray-50/50">
+          <td colSpan={5} className="px-3 md:px-5 py-3 bg-gray-50/50">
             {isLoading && <LoadingSpinner className="py-4" />}
             {tasks && tasks.length === 0 && (
               <p className="text-sm text-text-secondary py-2">Geen taken gevonden.</p>

--- a/frontend/src/components/eenheid/UnassignedTasksSection.tsx
+++ b/frontend/src/components/eenheid/UnassignedTasksSection.tsx
@@ -87,7 +87,7 @@ function TaskRow({ task, showPersonAssign, selectedEenheidId, personOptions }: {
   };
 
   return (
-    <div className="flex items-center gap-3 py-2.5 px-4 border-b border-border last:border-0 hover:bg-gray-50/50">
+    <div className="flex flex-col md:flex-row md:items-center gap-2 md:gap-3 py-2.5 px-4 border-b border-border last:border-0 hover:bg-gray-50/50">
       <div className="flex-1 min-w-0">
         <button
           onClick={() => openTaskDetail(task.id)}
@@ -115,7 +115,7 @@ function TaskRow({ task, showPersonAssign, selectedEenheidId, personOptions }: {
         </div>
       </div>
       <div className="flex items-center gap-2 shrink-0">
-        <div className="w-56">
+        <div className="w-full md:w-56">
           <CreatableSelect
             value={task.organisatie_eenheid_id ?? ''}
             onChange={handleUnitChange}
@@ -124,7 +124,7 @@ function TaskRow({ task, showPersonAssign, selectedEenheidId, personOptions }: {
           />
         </div>
         {showPersonAssign && (
-          <div className="w-56">
+          <div className="w-full md:w-56">
             <CreatableSelect
               value={task.assignee_id ?? ''}
               onChange={handlePersonChange}

--- a/frontend/src/components/graph/CorpusGraph.tsx
+++ b/frontend/src/components/graph/CorpusGraph.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useCallback, useEffect } from 'react';
 import { Plus } from 'lucide-react';
 import { useNavigate, useLocation } from 'react-router-dom';
+import { useIsMobile } from '@/hooks/useMediaQuery';
 import ReactFlow, {
   Background,
   Controls,
@@ -150,6 +151,7 @@ const nodeTypes = {
 export function CorpusGraph() {
   const navigate = useNavigate();
   const location = useLocation();
+  const isMobile = useIsMobile();
   const { nodeLabel, edgeLabel: vocabEdgeLabel } = useVocabulary();
   const { data, isLoading, error } = useGraphView();
 
@@ -413,8 +415,8 @@ export function CorpusGraph() {
   return (
     <div className="space-y-4">
       {/* Filters */}
-      <div className="flex items-center gap-3 flex-wrap">
-        <div className="w-52">
+      <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3">
+        <div className="w-full sm:w-52">
           <MultiSelect
             value={enabledNodeTypes as Set<string>}
             onChange={handleNodeTypesChange}
@@ -423,7 +425,7 @@ export function CorpusGraph() {
           />
         </div>
         {edgeTypeFilterOptions.length > 0 && (
-          <div className="w-52">
+          <div className="w-full sm:w-52">
             <MultiSelect
               value={enabledEdgeTypes}
               onChange={setEnabledEdgeTypes}
@@ -439,7 +441,7 @@ export function CorpusGraph() {
       </div>
 
       {/* Graph canvas */}
-      <div className="bg-white rounded-xl border border-border shadow-sm overflow-hidden" style={{ height: 'calc(100vh - 260px)', minHeight: '500px' }}>
+      <div className="bg-white rounded-xl border border-border shadow-sm overflow-hidden" style={{ height: 'calc(100vh - 260px)', minHeight: isMobile ? '300px' : '500px' }}>
         <ReactFlow
           nodes={nodes}
           edges={edges}
@@ -465,15 +467,17 @@ export function CorpusGraph() {
               boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
             }}
           />
-          <MiniMap
-            nodeColor={minimapNodeColor}
-            maskColor="rgba(248, 249, 250, 0.7)"
-            style={{
-              borderRadius: '10px',
-              border: '1px solid #e2e8f0',
-              boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
-            }}
-          />
+          {!isMobile && (
+            <MiniMap
+              nodeColor={minimapNodeColor}
+              maskColor="rgba(248, 249, 250, 0.7)"
+              style={{
+                borderRadius: '10px',
+                border: '1px solid #e2e8f0',
+                boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
+              }}
+            />
+          )}
         </ReactFlow>
       </div>
 

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -1,14 +1,45 @@
+import { useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
 import { Sidebar } from './Sidebar';
 import { Header } from './Header';
+import { useUIStore } from '@/store/ui';
+import { useIsMobile } from '@/hooks/useMediaQuery';
 
 export function AppLayout() {
+  const isMobile = useIsMobile();
+  const { mobileSidebarOpen, setMobileSidebarOpen } = useUIStore();
+
+  // Close mobile sidebar on Escape
+  useEffect(() => {
+    if (!mobileSidebarOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setMobileSidebarOpen(false);
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [mobileSidebarOpen, setMobileSidebarOpen]);
+
   return (
     <div className="flex min-h-screen bg-background">
-      <Sidebar />
+      {/* Desktop sidebar */}
+      {!isMobile && <Sidebar />}
+
+      {/* Mobile sidebar overlay */}
+      {isMobile && mobileSidebarOpen && (
+        <>
+          <div
+            className="fixed inset-0 bg-black/40 z-40"
+            onClick={() => setMobileSidebarOpen(false)}
+          />
+          <div className="fixed inset-y-0 left-0 z-50 w-72">
+            <Sidebar mobile />
+          </div>
+        </>
+      )}
+
       <div className="flex flex-col flex-1 min-w-0">
         <Header />
-        <main className="flex-1 p-6 overflow-y-auto">
+        <main className="flex-1 p-4 md:p-6 overflow-y-auto">
           <Outlet />
         </main>
       </div>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { Search, User, ChevronDown, Check, LogOut, Eye, X } from 'lucide-react';
+import { Search, User, ChevronDown, Check, LogOut, Eye, X, Menu } from 'lucide-react';
 import { useCurrentPerson } from '@/contexts/CurrentPersonContext';
 import { useVocabulary } from '@/contexts/VocabularyContext';
 import { useAuth } from '@/contexts/AuthContext';
@@ -8,6 +8,7 @@ import { VOCABULARY_LABELS, type VocabularyId } from '@/vocabulary';
 import { NotificationBell } from '@/components/common/NotificationBell';
 import { useManagedEenheden } from '@/hooks/useOrganisatie';
 import { ORGANISATIE_TYPE_LABELS, formatFunctie } from '@/types';
+import { useUIStore } from '@/store/ui';
 
 const pageTitles: Record<string, string> = {
   '/': 'Inbox',
@@ -36,6 +37,7 @@ export function Header() {
     useCurrentPerson();
   const { vocabularyId, setVocabularyId } = useVocabulary();
   const { authenticated, oidcConfigured, person: authPerson, logout } = useAuth();
+  const toggleMobileSidebar = useUIStore((s) => s.toggleMobileSidebar);
   const [showPersonPicker, setShowPersonPicker] = useState(false);
   const [search, setSearch] = useState('');
   const pickerRef = useRef<HTMLDivElement>(null);
@@ -86,9 +88,15 @@ export function Header() {
   const authDisplayName = oidcConfigured ? (authPerson?.name || authPerson?.email || '') : '';
 
   return (
-    <header className="flex items-center justify-between h-16 px-6 bg-surface border-b border-border shrink-0">
-      {/* Left: Title / Breadcrumbs */}
+    <header className="flex items-center justify-between h-16 px-4 md:px-6 bg-surface border-b border-border shrink-0">
+      {/* Left: Hamburger + Title / Breadcrumbs */}
       <div className="flex items-center gap-2">
+        <button
+          onClick={toggleMobileSidebar}
+          className="md:hidden flex items-center justify-center h-10 w-10 -ml-1 rounded-lg text-text-secondary hover:bg-gray-100 hover:text-text transition-colors"
+        >
+          <Menu className="h-5 w-5" />
+        </button>
         {breadcrumbs ? (
           <nav className="flex items-center gap-1.5 text-sm">
             {breadcrumbs.map((crumb, i) => (
@@ -115,7 +123,7 @@ export function Header() {
       {/* Right: Actions */}
       <div className="flex items-center gap-3">
         {/* Vocabulary toggle */}
-        <div className="flex items-center rounded-lg border border-border text-xs overflow-hidden">
+        <div className="hidden sm:flex items-center rounded-lg border border-border text-xs overflow-hidden">
           {(Object.keys(VOCABULARY_LABELS) as VocabularyId[]).map((id) => (
             <button
               key={id}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -18,10 +18,17 @@ import { useCurrentPerson } from '@/contexts/CurrentPersonContext';
 import { useManagedEenheden } from '@/hooks/useOrganisatie';
 import { ORGANISATIE_TYPE_LABELS } from '@/types';
 
-export function Sidebar() {
-  const { sidebarOpen, toggleSidebar } = useUIStore();
+interface SidebarProps {
+  mobile?: boolean;
+}
+
+export function Sidebar({ mobile }: SidebarProps) {
+  const { sidebarOpen, toggleSidebar, setMobileSidebarOpen } = useUIStore();
   const { currentPerson } = useCurrentPerson();
   const { data: managedEenheden } = useManagedEenheden(currentPerson?.id);
+
+  // On mobile the sidebar is always expanded (with labels)
+  const expanded = mobile || sidebarOpen;
 
   const eenheidLabel = useMemo(() => {
     const first = managedEenheden?.[0];
@@ -40,11 +47,18 @@ export function Sidebar() {
     { to: '/search', icon: Search, label: 'Zoeken' },
   ], [eenheidLabel]);
 
+  const handleNavClick = () => {
+    if (mobile) {
+      setMobileSidebarOpen(false);
+    }
+  };
+
   return (
     <aside
       className={clsx(
-        'flex flex-col bg-primary-900 text-white transition-all duration-300 ease-in-out h-screen sticky top-0',
-        sidebarOpen ? 'w-60' : 'w-16',
+        'flex flex-col bg-primary-900 text-white transition-all duration-300 ease-in-out',
+        mobile ? 'w-72 h-full' : 'h-screen sticky top-0',
+        !mobile && (expanded ? 'w-60' : 'w-16'),
       )}
     >
       {/* Logo / Brand */}
@@ -52,7 +66,7 @@ export function Sidebar() {
         <div className="flex items-center justify-center h-8 w-8 rounded-lg bg-accent-500 shrink-0">
           <Building2 className="h-4.5 w-4.5 text-white" />
         </div>
-        {sidebarOpen && (
+        {expanded && (
           <span className="text-base font-semibold tracking-tight whitespace-nowrap">
             Bouwmeester
           </span>
@@ -66,42 +80,45 @@ export function Sidebar() {
             key={item.to}
             to={item.to}
             end={item.to === '/'}
+            onClick={handleNavClick}
             className={({ isActive }) =>
               clsx(
-                'flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-150',
+                'flex items-center gap-3 px-3 py-3 md:py-2.5 rounded-xl text-sm font-medium transition-all duration-150',
                 isActive
                   ? 'bg-white/15 text-white'
                   : 'text-white/65 hover:bg-white/8 hover:text-white/90',
-                !sidebarOpen && 'justify-center px-0',
+                !expanded && 'justify-center px-0',
               )
             }
           >
             <item.icon className="h-5 w-5 shrink-0" />
-            {sidebarOpen && <span>{item.label}</span>}
+            {expanded && <span>{item.label}</span>}
           </NavLink>
         ))}
       </nav>
 
-      {/* Collapse toggle */}
-      <div className="px-2 py-3 border-t border-white/10 shrink-0">
-        <button
-          onClick={toggleSidebar}
-          className={clsx(
-            'flex items-center gap-3 w-full px-3 py-2.5 rounded-xl text-sm font-medium',
-            'text-white/50 hover:bg-white/8 hover:text-white/80 transition-all duration-150',
-            !sidebarOpen && 'justify-center px-0',
-          )}
-        >
-          {sidebarOpen ? (
-            <>
-              <PanelLeftClose className="h-5 w-5 shrink-0" />
-              <span>Inklappen</span>
-            </>
-          ) : (
-            <PanelLeftOpen className="h-5 w-5 shrink-0" />
-          )}
-        </button>
-      </div>
+      {/* Collapse toggle — hidden on mobile */}
+      {!mobile && (
+        <div className="px-2 py-3 border-t border-white/10 shrink-0">
+          <button
+            onClick={toggleSidebar}
+            className={clsx(
+              'flex items-center gap-3 w-full px-3 py-2.5 rounded-xl text-sm font-medium',
+              'text-white/50 hover:bg-white/8 hover:text-white/80 transition-all duration-150',
+              !expanded && 'justify-center px-0',
+            )}
+          >
+            {expanded ? (
+              <>
+                <PanelLeftClose className="h-5 w-5 shrink-0" />
+                <span>Inklappen</span>
+              </>
+            ) : (
+              <PanelLeftOpen className="h-5 w-5 shrink-0" />
+            )}
+          </button>
+        </div>
+      )}
     </aside>
   );
 }

--- a/frontend/src/components/nodes/NodeDetail.tsx
+++ b/frontend/src/components/nodes/NodeDetail.tsx
@@ -188,7 +188,7 @@ export function NodeDetail({ nodeId }: NodeDetailProps) {
       </button>
 
       {/* Header */}
-      <div className="flex items-start justify-between gap-4">
+      <div className="flex flex-col sm:flex-row items-start sm:justify-between gap-3">
         <div>
           <div className="flex items-center gap-2 mb-2">
             <Badge variant={color as 'blue'} dot title={nodeAltLabel(node.node_type)}>
@@ -197,7 +197,7 @@ export function NodeDetail({ nodeId }: NodeDetailProps) {
             {node.status && <Badge variant="gray">{node.status}</Badge>}
           </div>
           <h1 className="text-2xl font-bold text-text">{node.title}</h1>
-          <div className="flex items-center gap-4 mt-2 text-xs text-text-secondary">
+          <div className="flex flex-wrap items-center gap-2 sm:gap-4 mt-2 text-xs text-text-secondary">
             <span className="inline-flex items-center gap-1">
               <Calendar className="h-3.5 w-3.5" />
               Aangemaakt: {formatDate(node.created_at)}
@@ -237,21 +237,23 @@ export function NodeDetail({ nodeId }: NodeDetailProps) {
       </div>
 
       {/* Tabs */}
-      <div className="flex items-center gap-1 border-b border-border">
-        {tabs.map((tab) => (
-          <button
-            key={tab.id}
-            onClick={() => setActiveTab(tab.id)}
-            className={clsx(
-              'px-4 py-2.5 text-sm font-medium border-b-2 transition-colors -mb-px',
-              activeTab === tab.id
-                ? 'border-primary-900 text-primary-900'
-                : 'border-transparent text-text-secondary hover:text-text hover:border-border',
-            )}
-          >
-            {tab.label}
-          </button>
-        ))}
+      <div className="overflow-x-auto scrollbar-hide">
+        <div className="flex items-center gap-1 border-b border-border">
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={clsx(
+                'px-4 py-2.5 text-sm font-medium border-b-2 transition-colors -mb-px whitespace-nowrap flex-shrink-0',
+                activeTab === tab.id
+                  ? 'border-primary-900 text-primary-900'
+                  : 'border-transparent text-text-secondary hover:text-text hover:border-border',
+              )}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
       </div>
 
       {/* Tab content */}
@@ -463,7 +465,7 @@ export function NodeDetail({ nodeId }: NodeDetailProps) {
             {/* Add stakeholder form */}
             <Card>
               <h4 className="text-sm font-medium text-text mb-3">Betrokkene toevoegen</h4>
-              <div className="flex items-end gap-3">
+              <div className="flex flex-col sm:flex-row items-stretch sm:items-end gap-3">
                 <div className="flex-1">
                   <CreatableSelect
                     label="Persoon"
@@ -483,7 +485,7 @@ export function NodeDetail({ nodeId }: NodeDetailProps) {
                     createLabel="Nieuwe persoon aanmaken"
                   />
                 </div>
-                <div className="w-48">
+                <div className="w-full sm:w-48">
                   <label className="block text-sm font-medium text-text mb-1.5">Rol</label>
                   <select
                     value={newStakeholderRol}

--- a/frontend/src/components/tasks/TaskBoard.tsx
+++ b/frontend/src/components/tasks/TaskBoard.tsx
@@ -63,14 +63,14 @@ export function TaskBoard({ tasks, onEditTask }: TaskBoardProps) {
   };
 
   return (
-    <div className="grid grid-cols-3 gap-4 min-h-[400px]">
+    <div className="-mx-4 px-4 md:mx-0 md:px-0 flex gap-4 min-h-[400px] overflow-x-auto pb-2 snap-x snap-mandatory md:grid md:grid-cols-3 md:overflow-x-visible md:snap-none md:pb-0">
       {BOARD_COLUMNS.map((status) => (
         <div
           key={status}
           onDragOver={(e) => handleDragOver(e, status)}
           onDragLeave={handleDragLeave}
           onDrop={(e) => handleDrop(e, status)}
-          className={`rounded-xl border border-border bg-gray-50/50 border-t-4 ${COLUMN_COLORS[status]} transition-colors ${
+          className={`rounded-xl border border-border bg-gray-50/50 border-t-4 w-[85vw] shrink-0 snap-center md:w-auto md:shrink md:flex-1 ${COLUMN_COLORS[status]} transition-colors ${
             dragOverColumn === status ? 'bg-primary-50/50 border-primary-200' : ''
           }`}
         >

--- a/frontend/src/components/tasks/TaskView.tsx
+++ b/frontend/src/components/tasks/TaskView.tsx
@@ -116,10 +116,10 @@ export function TaskView({ tasks, defaultNodeId }: TaskViewProps) {
   return (
     <div className="space-y-4">
       {/* Toolbar */}
-      <div className="flex items-center justify-between gap-4 flex-wrap">
-        {/* Left: Filters */}
-        <div className="flex items-center gap-3 flex-wrap">
-          <div className="w-44">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        {/* Filters */}
+        <div className="grid grid-cols-2 sm:flex sm:items-center gap-2 sm:gap-3">
+          <div className="w-full sm:w-44">
             <CreatableSelect
               value={statusFilter}
               onChange={setStatusFilter}
@@ -128,7 +128,7 @@ export function TaskView({ tasks, defaultNodeId }: TaskViewProps) {
             />
           </div>
 
-          <div className="w-44">
+          <div className="w-full sm:w-44">
             <CreatableSelect
               value={priorityFilter}
               onChange={setPriorityFilter}
@@ -137,7 +137,7 @@ export function TaskView({ tasks, defaultNodeId }: TaskViewProps) {
             />
           </div>
 
-          <div className="w-52">
+          <div className="w-full sm:w-52">
             <CreatableSelect
               value={personFilter}
               onChange={setPersonFilter}
@@ -146,7 +146,7 @@ export function TaskView({ tasks, defaultNodeId }: TaskViewProps) {
             />
           </div>
 
-          <div className="w-52">
+          <div className="w-full sm:w-52">
             <CreatableSelect
               value={eenheidFilter}
               onChange={setEenheidFilter}
@@ -156,7 +156,7 @@ export function TaskView({ tasks, defaultNodeId }: TaskViewProps) {
           </div>
         </div>
 
-        {/* Right: View toggle + New task */}
+        {/* View toggle + New task */}
         <div className="flex items-center gap-2">
           <div className="flex items-center rounded-xl border border-border bg-white p-0.5">
             <button

--- a/frontend/src/hooks/useMediaQuery.ts
+++ b/frontend/src/hooks/useMediaQuery.ts
@@ -1,0 +1,19 @@
+import { useState, useEffect } from 'react';
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() => window.matchMedia(query).matches);
+
+  useEffect(() => {
+    const mql = window.matchMedia(query);
+    const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
+    mql.addEventListener('change', handler);
+    setMatches(mql.matches);
+    return () => mql.removeEventListener('change', handler);
+  }, [query]);
+
+  return matches;
+}
+
+export function useIsMobile(): boolean {
+  return useMediaQuery('(max-width: 767px)');
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -66,6 +66,15 @@ body {
   background-color: var(--color-border-hover);
 }
 
+/* Hide scrollbar utility for horizontal tab scrolling */
+.scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}
+
 /* Smooth transitions for interactive elements */
 button, a, input, select, textarea {
   transition: all 0.15s ease-in-out;

--- a/frontend/src/pages/AuditLogPage.tsx
+++ b/frontend/src/pages/AuditLogPage.tsx
@@ -246,7 +246,7 @@ export function AuditLogPage() {
   }, [totalPages, page]);
 
   return (
-    <div className="p-6 space-y-4">
+    <div className="space-y-4">
       {/* Filters */}
       <div className="flex items-center gap-3">
         <select
@@ -265,8 +265,34 @@ export function AuditLogPage() {
         </select>
       </div>
 
-      {/* Table */}
-      <div className="border border-border rounded-xl overflow-hidden bg-white">
+      {/* Mobile card layout */}
+      <div className="md:hidden space-y-3">
+        {isLoading ? (
+          <p className="text-center text-text-secondary py-8">Laden...</p>
+        ) : isError ? (
+          <p className="text-center text-red-600 py-8">Fout bij laden van activiteiten</p>
+        ) : !data?.items.length ? (
+          <p className="text-center text-text-secondary py-8">Geen activiteit gevonden</p>
+        ) : (
+          data.items.map((item) => (
+            <div key={item.id} className="border border-border rounded-xl bg-white p-4 space-y-2">
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-xs text-text-secondary">{formatDate(item.created_at)}</span>
+                {item.actor_naam && (
+                  <span className="text-xs font-medium text-text">{item.actor_naam}</span>
+                )}
+              </div>
+              <div className="text-sm font-medium text-text">
+                {EVENT_TYPE_LABELS[item.event_type] || item.event_type}
+              </div>
+              <DetailCell item={item} onOpenNode={openNodeDetail} onOpenTask={openTaskDetail} />
+            </div>
+          ))
+        )}
+      </div>
+
+      {/* Desktop table */}
+      <div className="hidden md:block border border-border rounded-xl overflow-hidden bg-white">
         <table className="w-full text-sm">
           <thead>
             <tr className="bg-gray-50 border-b border-border">

--- a/frontend/src/pages/CorpusPage.tsx
+++ b/frontend/src/pages/CorpusPage.tsx
@@ -25,13 +25,13 @@ export function CorpusPage() {
   return (
     <div className="space-y-6">
       {/* Page header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <div>
           <p className="text-sm text-text-secondary">
             Bekijk en beheer alle beleidsdocumenten, dossiers en instrumenten.
           </p>
         </div>
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3 flex-wrap">
           {/* View mode toggle */}
           <div className="flex items-center bg-gray-100 rounded-xl p-0.5">
             <button

--- a/frontend/src/pages/EenheidOverzichtPage.tsx
+++ b/frontend/src/pages/EenheidOverzichtPage.tsx
@@ -115,11 +115,11 @@ export function EenheidOverzichtPage() {
                   <table className="w-full text-sm">
                     <thead>
                       <tr className="border-b border-border text-left text-text-secondary">
-                        <th className="px-5 py-3 font-medium">Persoon</th>
-                        <th className="px-5 py-3 font-medium text-right">Open</th>
-                        <th className="px-5 py-3 font-medium text-right">In uitvoering</th>
-                        <th className="px-5 py-3 font-medium text-right">Afgerond</th>
-                        <th className="px-5 py-3 font-medium text-right">Verlopen</th>
+                        <th className="px-3 md:px-5 py-3 font-medium">Persoon</th>
+                        <th className="px-3 md:px-5 py-3 font-medium text-right">Open</th>
+                        <th className="px-3 md:px-5 py-3 font-medium text-right">In uitvoering</th>
+                        <th className="px-3 md:px-5 py-3 font-medium text-right">Afgerond</th>
+                        <th className="px-3 md:px-5 py-3 font-medium text-right">Verlopen</th>
                       </tr>
                     </thead>
                     <tbody>

--- a/frontend/src/pages/OrganisatiePage.tsx
+++ b/frontend/src/pages/OrganisatiePage.tsx
@@ -174,9 +174,9 @@ export function OrganisatiePage() {
           }
         />
       ) : (
-        <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           {/* Left panel: Tree */}
-          <div className="xl:col-span-1">
+          <div className="lg:col-span-1">
             <Card>
               <div className="p-1">
                 <OrganisatieTree
@@ -191,7 +191,7 @@ export function OrganisatiePage() {
           </div>
 
           {/* Right panel: Detail */}
-          <div className="xl:col-span-2">
+          <div className="lg:col-span-2">
             {selectedId ? (
               <Card>
                 <div className="p-2">

--- a/frontend/src/pages/ParlementairPage.tsx
+++ b/frontend/src/pages/ParlementairPage.tsx
@@ -48,7 +48,7 @@ export function ParlementairPage() {
   return (
     <div className="space-y-6">
       {/* Page header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <p className="text-sm text-text-secondary">
           Beheer geïmporteerde kamerstukken uit de Tweede en Eerste Kamer.
         </p>
@@ -57,31 +57,38 @@ export function ParlementairPage() {
           onClick={() => triggerImport.mutate()}
           disabled={triggerImport.isPending}
         >
-          {triggerImport.isPending ? 'Importeren...' : 'Importeer nieuwe kamerstukken'}
+          <span className="hidden sm:inline">
+            {triggerImport.isPending ? 'Importeren...' : 'Importeer nieuwe kamerstukken'}
+          </span>
+          <span className="sm:hidden">
+            {triggerImport.isPending ? 'Laden...' : 'Importeren'}
+          </span>
         </Button>
       </div>
 
       {/* Filters */}
-      <div className="flex items-center gap-4 border-b border-border">
-        <div className="flex items-center gap-1">
-          {statusFilters.map((filter) => (
-            <button
-              key={filter.value}
-              onClick={() => setStatusFilter(filter.value)}
-              className={`px-4 py-2.5 text-sm font-medium border-b-2 transition-colors -mb-px ${
-                statusFilter === filter.value
-                  ? 'border-primary-900 text-primary-900'
-                  : 'border-transparent text-text-secondary hover:text-text hover:border-border'
-              }`}
-            >
-              {filter.label}
-            </button>
-          ))}
+      <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4 border-b border-border">
+        <div className="overflow-x-auto scrollbar-hide">
+          <div className="flex items-center gap-1">
+            {statusFilters.map((filter) => (
+              <button
+                key={filter.value}
+                onClick={() => setStatusFilter(filter.value)}
+                className={`px-4 py-2.5 text-sm font-medium border-b-2 transition-colors -mb-px whitespace-nowrap flex-shrink-0 ${
+                  statusFilter === filter.value
+                    ? 'border-primary-900 text-primary-900'
+                    : 'border-transparent text-text-secondary hover:text-text hover:border-border'
+                }`}
+              >
+                {filter.label}
+              </button>
+            ))}
+          </div>
         </div>
         <select
           value={typeFilter}
           onChange={(e) => setTypeFilter(e.target.value as ParlementairItemType | 'all')}
-          className="ml-auto text-sm border border-border rounded-lg px-3 py-1.5 bg-white text-text-secondary -mb-px"
+          className="sm:ml-auto text-sm border border-border rounded-lg px-3 py-1.5 bg-white text-text-secondary -mb-px"
         >
           {typeFilters.map((f) => (
             <option key={f.value} value={f.value}>{f.label}</option>

--- a/frontend/src/store/ui.ts
+++ b/frontend/src/store/ui.ts
@@ -6,6 +6,10 @@ interface UIState {
   toggleSidebar: () => void;
   setSidebarOpen: (open: boolean) => void;
 
+  mobileSidebarOpen: boolean;
+  toggleMobileSidebar: () => void;
+  setMobileSidebarOpen: (open: boolean) => void;
+
   selectedNodeType: NodeType | undefined;
   setSelectedNodeType: (nodeType: NodeType | undefined) => void;
 
@@ -20,6 +24,10 @@ export const useUIStore = create<UIState>((set) => ({
   sidebarOpen: true,
   toggleSidebar: () => set((state) => ({ sidebarOpen: !state.sidebarOpen })),
   setSidebarOpen: (open) => set({ sidebarOpen: open }),
+
+  mobileSidebarOpen: false,
+  toggleMobileSidebar: () => set((state) => ({ mobileSidebarOpen: !state.mobileSidebarOpen })),
+  setMobileSidebarOpen: (open) => set({ mobileSidebarOpen: open }),
 
   selectedNodeType: undefined,
   setSelectedNodeType: (nodeType) => set({ selectedNodeType: nodeType }),


### PR DESCRIPTION
## Summary

- **Mobile sidebar**: overlay with hamburger menu, backdrop, auto-close on navigation, Escape key support
- **Responsive filters**: task/graph filter dropdowns go full-width on mobile, 2-column grid layout
- **Board view**: horizontally scrollable columns (85vw each) with snap points on mobile
- **Audit log**: card-based layout on mobile, table on desktop
- **Tabs**: horizontally scrollable tab bars (NodeDetail, Parlementair)
- **Touch targets**: 44px minimum height on small buttons, larger notification bell
- **Layout polish**: responsive padding, breakpoint adjustments (xl→lg for Organisatie), modal sizing, page header toolbars wrap on mobile

## Files changed (20)

| Area | Files | Change |
|------|-------|--------|
| Foundation | `useMediaQuery.ts` (new), `store/ui.ts` | Media query hook, mobile sidebar state |
| Layout | `AppLayout.tsx`, `Sidebar.tsx`, `Header.tsx` | Mobile sidebar overlay, hamburger, responsive padding |
| Filters | `TaskView.tsx`, `CorpusGraph.tsx`, `NodeDetail.tsx`, `UnassignedTasksSection.tsx` | Full-width dropdowns on mobile |
| Board | `TaskBoard.tsx` | Horizontal scroll with snap, viewport-width columns |
| Tables | `AuditLogPage.tsx`, `EenheidOverzichtPage.tsx`, `PersonTasksRow.tsx` | Mobile cards, reduced padding |
| Graph | `CorpusGraph.tsx` | Smaller canvas, hidden MiniMap on mobile |
| Tabs | `NodeDetail.tsx`, `ParlementairPage.tsx` | Scrollable tab bars |
| Polish | `Modal.tsx`, `CorpusPage.tsx`, `ParlementairPage.tsx`, `Button.tsx`, `NotificationBell.tsx`, `index.css` | Touch targets, modal sizing, toolbar wrapping |

## Test plan

- [ ] Test at 375px (iPhone SE), 390px (iPhone 14), 768px (iPad), 1024px (iPad landscape), 1440px (desktop)
- [ ] Open/close mobile sidebar, verify overlay + backdrop + auto-close on nav
- [ ] Verify board view scrolls horizontally on mobile with snap
- [ ] Verify no horizontal overflow on any page
- [ ] Verify all interactive elements are reachable on mobile
- [ ] Run `just typecheck` — passes clean