### PR TITLE
Fix import-export API using wrong BASE_URL

### DIFF
--- a/frontend/src/api/import-export.ts
+++ b/frontend/src/api/import-export.ts
@@ -1,4 +1,4 @@
-const BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
+import { BASE_URL } from '@/api/client';
 
 export interface ImportResult {
   imported: number;


### PR DESCRIPTION
## Summary

- `import-export.ts` had its own local `BASE_URL = import.meta.env.VITE_API_BASE_URL || ''` which always resolved to empty string in production
- This meant all database export/import/reset/info API calls went to the frontend origin instead of the backend (`component-2.*.rijks.app`)
- Nginx served `index.html` for these unmatched routes, causing "Kon database-informatie niet ophalen"
- Fix: use the shared `BASE_URL` from `client.ts` which correctly detects the backend origin

## Test plan

- [ ] Database tab on admin page shows migration version (no error)
- [ ] Export, import, and reset all hit the correct backend URL