### PR TITLE
Include age-recipients.txt in backend Docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,6 +30,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Copy age-recipients.txt into backend context
+        if: matrix.image == 'backend'
+        run: cp age-recipients.txt backend/age-recipients.txt
+
       - uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -24,6 +24,9 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 WORKDIR /app
 
 COPY --from=builder --chown=appuser:appuser /app /app
+# age-recipients.txt is copied into the build context by CI; wildcard
+# makes it optional for local builds where encryption is not needed.
+COPY --chown=appuser:appuser age-recipients.tx[t] /app/
 
 USER 1001
 


### PR DESCRIPTION
## Summary

- Backup exports from production were unencrypted despite `AGE_SECRET_KEY` being set
- Root cause: `age-recipients.txt` lives in the repo root, but the backend Docker build context is `./backend` — the file was never included in the image
- `_read_age_recipients()` returned `[]`, so `_age_encrypt()` silently skipped encryption
- Fix: CI step copies `age-recipients.txt` into `backend/` before building; Dockerfile uses wildcard COPY (`age-recipients.tx[t]`) so local builds without the file still succeed

## Test plan

- [ ] CI build succeeds (no COPY failure)
- [ ] After deploy: database export produces `.tar.gz.age` file (encrypted)
- [ ] Local `docker compose build` still works (no file = no encryption, expected)