### PR TITLE
Expose Content-Disposition header in CORS for export filename

### DIFF
--- a/backend/bouwmeester/core/app.py
+++ b/backend/bouwmeester/core/app.py
@@ -65,6 +65,7 @@ def create_app() -> FastAPI:
         allow_credentials=True,
         allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
         allow_headers=["Content-Type", "Authorization", "X-CSRF-Token"],
+        expose_headers=["Content-Disposition"],
     )
 
     app.add_middleware(

--- a/frontend/src/api/import-export.ts
+++ b/frontend/src/api/import-export.ts
@@ -99,7 +99,7 @@ export async function exportDatabase(): Promise<void> {
   }
   const disposition = response.headers.get('Content-Disposition') || '';
   const match = disposition.match(/filename=(.+)/);
-  const filename = match ? match[1] : 'bouwmeester-backup.tar.gz';
+  const filename = match ? match[1] : 'bouwmeester-backup.tar.gz.age';
   const blob = await response.blob();
   const url = URL.createObjectURL(blob);
   const link = document.createElement('a');


### PR DESCRIPTION
## Summary

- Encrypted exports downloaded with `.tar.gz` filename instead of `.tar.gz.age`
- Root cause: `Content-Disposition` header not exposed in CORS, so cross-origin JS couldn't read the filename
- Fix: add `expose_headers=["Content-Disposition"]` to CORSMiddleware
- Also change fallback filename to `.tar.gz.age` (production always encrypts)

## Test plan

- [ ] Export downloads with correct `.tar.gz.age` filename
- [ ] Import still accepts both `.tar.gz` and `.tar.gz.age` files