### PR TITLE
Add CSRF token to import-export POST requests

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,4 @@
-function getCsrfToken(): string {
+export function getCsrfToken(): string {
   const match = document.cookie.match(/(?:^|;\s*)bm_csrf=([^;]*)/);
   return match ? match[1] : '';
 }

--- a/frontend/src/api/import-export.ts
+++ b/frontend/src/api/import-export.ts
@@ -1,4 +1,4 @@
-import { BASE_URL } from '@/api/client';
+import { BASE_URL, getCsrfToken } from '@/api/client';
 
 export interface ImportResult {
   imported: number;
@@ -12,7 +12,9 @@ export async function importPolitiekeInputs(file: File): Promise<ImportResult> {
 
   const response = await fetch(`${BASE_URL}/api/import/politieke-inputs`, {
     method: 'POST',
+    headers: { 'X-CSRF-Token': getCsrfToken() },
     body: formData,
+    credentials: 'include',
   });
 
   if (!response.ok) {
@@ -28,7 +30,9 @@ export async function importNodes(file: File): Promise<ImportResult> {
 
   const response = await fetch(`${BASE_URL}/api/import/nodes`, {
     method: 'POST',
+    headers: { 'X-CSRF-Token': getCsrfToken() },
     body: formData,
+    credentials: 'include',
   });
 
   if (!response.ok) {
@@ -44,7 +48,9 @@ export async function importEdges(file: File): Promise<ImportResult> {
 
   const response = await fetch(`${BASE_URL}/api/import/edges`, {
     method: 'POST',
+    headers: { 'X-CSRF-Token': getCsrfToken() },
     body: formData,
+    credentials: 'include',
   });
 
   if (!response.ok) {
@@ -129,7 +135,7 @@ export interface DatabaseResetResult {
 export async function resetDatabase(confirm: string): Promise<DatabaseResetResult> {
   const response = await fetch(`${BASE_URL}/api/admin/database/reset`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': getCsrfToken() },
     body: JSON.stringify({ confirm }),
     credentials: 'include',
   });
@@ -148,6 +154,7 @@ export async function importDatabase(file: File): Promise<DatabaseRestoreResult>
 
   const response = await fetch(`${BASE_URL}/api/admin/database/import`, {
     method: 'POST',
+    headers: { 'X-CSRF-Token': getCsrfToken() },
     body: formData,
     credentials: 'include',
   });


### PR DESCRIPTION
## Summary

- All POST requests in `import-export.ts` were missing the `X-CSRF-Token` header
- Previously worked because the broken `BASE_URL` sent requests to the same origin (no CORS, no CSRF enforcement)
- Now that `BASE_URL` correctly targets cross-origin backend, CSRF middleware rejects with 403
- Fix: export `getCsrfToken` from `client.ts` and include `X-CSRF-Token` on all mutating fetch calls

Affects: database import, database reset, node/edge/politieke-input CSV imports

## Test plan

- [ ] Database import works (no CORS/403 error)
- [ ] Database reset works
- [ ] CSV imports (nodes, edges, politieke inputs) work