### PR TITLE
Fix bijlagen path: use /data instead of /app

### DIFF
--- a/backend/bouwmeester/api/routes/bijlage.py
+++ b/backend/bouwmeester/api/routes/bijlage.py
@@ -24,7 +24,7 @@ def _default_bijlagen_root() -> str:
     data_path = os.environ.get("DATA_PATH")
     if data_path:
         return os.path.join(data_path, "bijlagen")
-    return "/app/bijlagen"
+    return "/data/bijlagen"
 
 
 BIJLAGEN_ROOT = Path(os.environ.get("BIJLAGEN_ROOT", _default_bijlagen_root()))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,9 +31,10 @@ services:
       SESSION_SECRET_KEY: ${SESSION_SECRET_KEY:-local-dev-secret-key}
       FRONTEND_URL: http://localhost:5173
       BACKEND_URL: http://localhost:8000
+      DATA_PATH: /data
     volumes:
       - ./backend:/app
-      - bijlagen:/app/bijlagen
+      - bijlagen:/data/bijlagen
     entrypoint: []
     command: uv run uvicorn bouwmeester.core.app:create_app --factory --host 0.0.0.0 --port 8000 --reload
 
@@ -60,9 +61,10 @@ services:
     environment:
       DATABASE_URL: postgresql+asyncpg://bouwmeester:bouwmeester@db:5432/bouwmeester
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      DATA_PATH: /data
     volumes:
       - ./backend:/app
-      - bijlagen:/app/bijlagen
+      - bijlagen:/data/bijlagen
     entrypoint: []
     command: uv run python -m bouwmeester.worker
 


### PR DESCRIPTION
## Summary

- Default bijlagen storage path was `/app/bijlagen` which is read-only in prod
- Changed default to `/data/bijlagen` to match the writable volume
- Set `DATA_PATH=/data` in docker-compose for local dev consistency

Fixes: `Permission denied: '/app/bijlagen'` on file upload