### PR TITLE
Add edge types and tags as reference data in Alembic migration

### DIFF
--- a/backend/bouwmeester/migrations/versions/e1bfb6704ba8_seed_reference_data_edge_types_and_tags.py
+++ b/backend/bouwmeester/migrations/versions/e1bfb6704ba8_seed_reference_data_edge_types_and_tags.py
@@ -6,15 +6,15 @@ Create Date: 2026-02-13 07:24:03.800806
 
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
 from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "e1bfb6704ba8"
-down_revision: Union[str, None] = "97ccf3b922b4"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = "97ccf3b922b4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 # -- Reference data ----------------------------------------------------------
 
@@ -152,9 +152,11 @@ GRANDCHILD_TAGS = [
 def upgrade() -> None:
     # -- Edge types (idempotent) ----------------------------------------------
     for id_, label_nl, label_en, description in EDGE_TYPES:
+        vals = f"{_q(id_)}, {_q(label_nl)}, {_q(label_en)}, {_q(description)}, false"
         op.execute(
-            f"INSERT INTO edge_type (id, label_nl, label_en, description, is_custom) "
-            f"VALUES ({_q(id_)}, {_q(label_nl)}, {_q(label_en)}, {_q(description)}, false) "
+            f"INSERT INTO edge_type "
+            f"(id, label_nl, label_en, description, is_custom) "
+            f"VALUES ({vals}) "
             f"ON CONFLICT (id) DO NOTHING"
         )
 


### PR DESCRIPTION
## Summary

- Adds Alembic migration that inserts 12 system edge types and 36 hierarchical tags as reference data
- Fixes production deployments where `alembic upgrade head` runs without seed, leaving `edge_type` and `tag` tables empty (users couldn't create edges between nodes)
- Uses `ON CONFLICT DO NOTHING` for idempotency — safe to run on databases that already have this data from the seed script
- Downgrade safely skips rows that are referenced by existing edges or node_tags

## Test plan

- [ ] `just nuke && docker compose up -d db && just migrate` → verify `SELECT count(*) FROM edge_type` returns 12, `SELECT count(*) FROM tag` returns 36
- [ ] `just reset-db` (with seed) → verify seed still works on top of migration data
- [ ] Re-run `just migrate` on existing seeded DB → no errors (idempotent)