### PR TITLE
Format raw enum values as human-readable labels

### DIFF
--- a/frontend/src/components/nodes/NodeCard.tsx
+++ b/frontend/src/components/nodes/NodeCard.tsx
@@ -2,8 +2,8 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { ArrowRight, Link as LinkIcon } from 'lucide-react';
 import { Card } from '@/components/common/Card';
 import { Badge } from '@/components/common/Badge';
-import type { CorpusNode } from '@/types';
-import { NODE_TYPE_COLORS } from '@/types';
+import type { CorpusNode, NodeStatus } from '@/types';
+import { NODE_TYPE_COLORS, NODE_STATUS_LABELS } from '@/types';
 import { useVocabulary } from '@/contexts/VocabularyContext';
 import { richTextToPlain } from '@/utils/richtext';
 import { formatDateShort } from '@/utils/dates';
@@ -30,7 +30,7 @@ export function NodeCard({ node }: NodeCardProps) {
               {nodeLabel(node.node_type)}
             </Badge>
             {node.status && (
-              <Badge variant="gray">{node.status}</Badge>
+              <Badge variant="gray">{NODE_STATUS_LABELS[node.status as NodeStatus] ?? node.status}</Badge>
             )}
           </div>
 

--- a/frontend/src/components/nodes/NodeDetail.tsx
+++ b/frontend/src/components/nodes/NodeDetail.tsx
@@ -20,7 +20,7 @@ import { useNodeTags, useAddTagToNode, useRemoveTagFromNode, useTags } from '@/h
 import { useReferences } from '@/hooks/useMentions';
 import { useTaskDetail } from '@/contexts/TaskDetailContext';
 import { CreatableSelect } from '@/components/common/CreatableSelect';
-import { NODE_TYPE_COLORS, STAKEHOLDER_ROL_LABELS, BRON_TYPE_LABELS, NodeType, formatFunctie, titleCase } from '@/types';
+import { NODE_TYPE_COLORS, NODE_STATUS_LABELS, STAKEHOLDER_ROL_LABELS, BRON_TYPE_LABELS, NodeType, type NodeStatus, formatFunctie, titleCase } from '@/types';
 import { uploadBijlage, deleteBijlage, getBijlageDownloadUrl, updateNodeBronDetail } from '@/api/nodes';
 import { useVocabulary } from '@/contexts/VocabularyContext';
 import { formatDate } from '@/utils/dates';
@@ -203,7 +203,7 @@ export function NodeDetail({ nodeId }: NodeDetailProps) {
             <Badge variant={color as 'blue'} dot title={nodeAltLabel(node.node_type)}>
               {nodeLabel(node.node_type)}
             </Badge>
-            {node.status && <Badge variant="gray">{node.status}</Badge>}
+            {node.status && <Badge variant="gray">{NODE_STATUS_LABELS[node.status as NodeStatus] ?? node.status}</Badge>}
           </div>
           <h1 className="text-2xl font-bold text-text">{node.title}</h1>
           <div className="flex flex-wrap items-center gap-2 sm:gap-4 mt-2 text-xs text-text-secondary">
@@ -839,7 +839,7 @@ export function NodeDetail({ nodeId }: NodeDetailProps) {
                         ) : (
                           <span className="inline-block w-2 h-2 rounded-full bg-gray-300 shrink-0" title="Vorig" />
                         )}
-                        <Badge variant="gray">{record.status}</Badge>
+                        <Badge variant="gray">{NODE_STATUS_LABELS[record.status as NodeStatus] ?? record.status}</Badge>
                       </div>
                       <span className="text-xs text-text-secondary shrink-0 ml-3">
                         {formatDate(record.geldig_van)}

--- a/frontend/src/components/nodes/NodeDetailModal.tsx
+++ b/frontend/src/components/nodes/NodeDetailModal.tsx
@@ -24,9 +24,11 @@ import { useQuery } from '@tanstack/react-query';
 import { getTasks } from '@/api/tasks';
 import {
   NODE_TYPE_COLORS,
+  NODE_STATUS_LABELS,
   STAKEHOLDER_ROL_LABELS,
   TASK_PRIORITY_COLORS,
   TaskStatus,
+  type NodeStatus,
 } from '@/types';
 import type { Task } from '@/types';
 import { useVocabulary } from '@/contexts/VocabularyContext';
@@ -141,7 +143,7 @@ export function NodeDetailModal({ nodeId, open, onClose }: NodeDetailModalProps)
             <Badge variant={(NODE_TYPE_COLORS[node.node_type] ?? 'gray') as 'blue'} dot title={nodeAltLabel(node.node_type)}>
               {nodeLabel(node.node_type)}
             </Badge>
-            {node.status && <Badge variant="gray">{node.status}</Badge>}
+            {node.status && <Badge variant="gray">{NODE_STATUS_LABELS[node.status as NodeStatus] ?? node.status}</Badge>}
             {node.edge_count != null && (
               <span className="inline-flex items-center gap-1 text-sm text-text-secondary">
                 <LinkIcon className="h-4 w-4" />

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -13,9 +13,33 @@ import { richTextToPlain } from '@/utils/richtext';
 import {
   SEARCH_RESULT_TYPE_LABELS,
   SEARCH_RESULT_TYPE_COLORS,
+  NODE_TYPE_LABELS,
+  NODE_STATUS_LABELS,
+  TASK_STATUS_LABELS,
+  ORGANISATIE_TYPE_LABELS,
+  PARLEMENTAIR_TYPE_LABELS,
+  formatFunctie,
   type SearchResultType,
   type SearchResult,
 } from '@/types';
+
+const SUBTITLE_LABEL_MAPS: Partial<
+  Record<SearchResultType, Record<string, string>>
+> = {
+  corpus_node: { ...NODE_TYPE_LABELS, ...NODE_STATUS_LABELS },
+  task: TASK_STATUS_LABELS,
+  organisatie_eenheid: ORGANISATIE_TYPE_LABELS,
+  parlementair_item: PARLEMENTAIR_TYPE_LABELS,
+};
+
+function formatSubtitle(result: SearchResult): string | undefined {
+  if (!result.subtitle) return undefined;
+  if (result.result_type === 'person') {
+    return formatFunctie(result.subtitle);
+  }
+  const map = SUBTITLE_LABEL_MAPS[result.result_type];
+  return map?.[result.subtitle] ?? result.subtitle;
+}
 
 const ALL_RESULT_TYPES: SearchResultType[] = [
   'corpus_node',
@@ -149,7 +173,7 @@ export function SearchPage() {
                           </Badge>
                           {result.subtitle && (
                             <span className="text-xs text-text-secondary">
-                              {result.subtitle}
+                              {formatSubtitle(result)}
                             </span>
                           )}
                         </div>


### PR DESCRIPTION
## Summary

- **Search subtitles**: Raw snake_case values like `staff_engineer`, `in_progress`, `directoraat_generaal` now display as proper labels ("Staff Engineer", "In uitvoering", "Directoraat-Generaal") using existing label maps per result type
- **Node status badges**: `node.status` displayed as raw enum in NodeCard, NodeDetail, NodeDetailModal — now uses `NODE_STATUS_LABELS` (e.g. "concept" -> "Concept", "gepauzeerd" -> "Gepauzeerd")

## Test plan

- [ ] Search for a person — subtitle should show formatted functie (e.g. "Staff Engineer" not "staff_engineer")
- [ ] Search for a task — subtitle should show Dutch status label (e.g. "In uitvoering" not "in_progress")
- [ ] Search for an organisatie — subtitle should show formatted type (e.g. "Directoraat-Generaal" not "directoraat_generaal")
- [ ] Search for a parlementair item — subtitle should show formatted type (e.g. "Kamervraag" not "kamervraag")
- [ ] Open a corpus node — status badge should show proper label
- [ ] Node card in corpus list — status badge should show proper label
- [ ] Node detail modal (from search) — status badge should show proper label