### PR TITLE
Move Auditlog/Beheer to bottom sidebar, collapse toggle as icon

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -40,21 +40,26 @@ export function Sidebar({ mobile }: SidebarProps) {
   }, [managedEenheden]);
 
   const navItems = useMemo(() => {
-    const items = [
+    return [
       { to: '/', icon: Inbox, label: 'Inbox' },
       { to: '/corpus', icon: Network, label: 'Corpus' },
       { to: '/tasks', icon: CheckSquare, label: 'Taken' },
       { to: '/organisatie', icon: Building2, label: 'Organisatie' },
       { to: '/eenheid-overzicht', icon: Users, label: eenheidLabel },
       { to: '/parlementair', icon: ScrollText, label: 'Kamerstukken' },
-      { to: '/auditlog', icon: History, label: 'Auditlog' },
       { to: '/search', icon: Search, label: 'Zoeken' },
+    ];
+  }, [eenheidLabel]);
+
+  const bottomNavItems = useMemo(() => {
+    const items = [
+      { to: '/auditlog', icon: History, label: 'Auditlog' },
     ];
     if (!oidcConfigured || authPerson?.is_admin) {
       items.push({ to: '/admin', icon: Shield, label: 'Beheer' });
     }
     return items;
-  }, [eenheidLabel, oidcConfigured, authPerson?.is_admin]);
+  }, [oidcConfigured, authPerson?.is_admin]);
 
   const handleNavClick = () => {
     if (mobile) {
@@ -70,19 +75,37 @@ export function Sidebar({ mobile }: SidebarProps) {
         !mobile && (expanded ? 'w-60' : 'w-16'),
       )}
     >
-      {/* Logo / Brand */}
-      <div className="flex items-center gap-3 px-4 h-16 border-b border-white/10 shrink-0">
+      {/* Logo / Brand + Collapse toggle */}
+      <div className={clsx(
+        'flex items-center border-b border-white/10 shrink-0',
+        expanded ? 'gap-3 px-4 h-16' : 'flex-col gap-1 px-2 py-3',
+      )}>
         <div className="flex items-center justify-center h-8 w-8 rounded-lg bg-accent-500 shrink-0">
           <Building2 className="h-4.5 w-4.5 text-white" />
         </div>
         {expanded && (
-          <span className="text-base font-semibold tracking-tight whitespace-nowrap">
+          <span className="text-base font-semibold tracking-tight whitespace-nowrap flex-1">
             Bouwmeester
           </span>
         )}
+        {!mobile && (
+          <button
+            onClick={toggleSidebar}
+            className={clsx(
+              'flex items-center justify-center rounded-lg text-white/50 hover:bg-white/8 hover:text-white/80 transition-all duration-150 shrink-0',
+              expanded ? 'h-8 w-8' : 'h-8 w-8',
+            )}
+          >
+            {expanded ? (
+              <PanelLeftClose className="h-5 w-5" />
+            ) : (
+              <PanelLeftOpen className="h-5 w-5" />
+            )}
+          </button>
+        )}
       </div>
 
-      {/* Navigation */}
+      {/* Main navigation */}
       <nav className="flex-1 py-3 px-2 space-y-0.5 overflow-y-auto">
         {navItems.map((item) => (
           <NavLink
@@ -106,28 +129,29 @@ export function Sidebar({ mobile }: SidebarProps) {
         ))}
       </nav>
 
-      {/* Collapse toggle — hidden on mobile */}
-      {!mobile && (
-        <div className="px-2 py-3 border-t border-white/10 shrink-0">
-          <button
-            onClick={toggleSidebar}
-            className={clsx(
-              'flex items-center gap-3 w-full px-3 py-2.5 rounded-xl text-sm font-medium',
-              'text-white/50 hover:bg-white/8 hover:text-white/80 transition-all duration-150',
-              !expanded && 'justify-center px-0',
-            )}
+      {/* Bottom navigation — Auditlog & Beheer */}
+      <div className="px-2 py-3 border-t border-white/10 shrink-0 space-y-0.5">
+        {bottomNavItems.map((item) => (
+          <NavLink
+            key={item.to}
+            to={item.to}
+            onClick={handleNavClick}
+            className={({ isActive }) =>
+              clsx(
+                'flex items-center gap-3 px-3 py-3 md:py-2.5 rounded-xl text-sm font-medium transition-all duration-150',
+                isActive
+                  ? 'bg-white/15 text-white'
+                  : 'text-white/65 hover:bg-white/8 hover:text-white/90',
+                !expanded && 'justify-center px-0',
+              )
+            }
           >
-            {expanded ? (
-              <>
-                <PanelLeftClose className="h-5 w-5 shrink-0" />
-                <span>Inklappen</span>
-              </>
-            ) : (
-              <PanelLeftOpen className="h-5 w-5 shrink-0" />
-            )}
-          </button>
-        </div>
-      )}
+            <item.icon className="h-5 w-5 shrink-0" />
+            {expanded && <span>{item.label}</span>}
+          </NavLink>
+        ))}
+
+      </div>
     </aside>
   );
 }


### PR DESCRIPTION
## Summary
- **Auditlog** and **Beheer** menu items moved to the bottom of the sidebar, separated by a border
- **Inklappen** button replaced with an icon-only collapse/expand toggle next to "Bouwmeester" in the brand bar
- When collapsed, the brand area stacks vertically (logo + expand icon) so the toggle remains discoverable

## Test plan
- [ ] Verify Auditlog and Beheer appear at the bottom of the sidebar with a separator
- [ ] Verify collapse icon appears next to "Bouwmeester" text when expanded
- [ ] Verify expand icon appears below the logo when collapsed
- [ ] Verify Beheer only shows for admins / when OIDC is not configured
- [ ] Verify mobile sidebar still works (no collapse toggle, always expanded)