### PR TITLE
Add parlementair import worker to production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,16 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+
+[program:worker]
+command=uv run python -m bouwmeester.worker
+directory=/app
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
 SUPERVISOR_CONF
 
 EXPOSE 80


### PR DESCRIPTION
## Summary
- The background worker that polls TK/EK parliamentary APIs was only running in local dev (docker-compose) but missing from the production Dockerfile
- Added it as a third Supervisor process alongside nginx and uvicorn in the production container

## Test plan
- [ ] Verify worker starts alongside backend in production container
- [ ] Verify worker logs appear in container stdout
- [ ] Verify Supervisor restarts worker on crash