### PR TITLE
Fix CORS headers missing on middleware error responses

### DIFF
--- a/backend/bouwmeester/api/routes/auth.py
+++ b/backend/bouwmeester/api/routes/auth.py
@@ -323,7 +323,12 @@ async def auth_status(
             request.session.pop("person_db_id", None)
             request.session.pop("needs_onboarding", None)
             request.session.pop("is_admin", None)
-            raise
+            # Degrade gracefully instead of returning 500 — the frontend
+            # will see authenticated=False and redirect to login.
+            return {
+                "authenticated": False,
+                "oidc_configured": oidc_configured,
+            }
 
     return result
 


### PR DESCRIPTION
## Summary

- **Move CORSMiddleware to outermost position** in the middleware stack so ALL responses carry `Access-Control-Allow-Origin` headers — including 401/403 from Auth/CSRF middleware and any unhandled 500s
- **Degrade gracefully** in `auth_status` when person resolution fails (return `authenticated: false` instead of 500)

## Root cause

The middleware order was: Session (outermost) → Auth → CSRF → **CORS (innermost)** → Route. When Auth or CSRF middleware short-circuited with raw ASGI `send()` (e.g. 401 "Authentication required"), those responses bypassed CORSMiddleware entirely. The browser then blocked the response due to missing CORS headers, and JS only saw "Failed to fetch".

**New order**: CORS (outermost) → Session → Auth → CSRF → Route. CORS now wraps everything.

## Test plan

- [x] All 448 backend tests pass
- [x] Ruff lint + format clean
- [ ] Verify Eelco's browser no longer gets "Failed to fetch" after deploy

🤖 Generated with [Claude Code](https://claude.ai/code)