### PR TITLE
Enable uvicorn proxy-headers for correct rate limiting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:backend]
-command=uv run uvicorn bouwmeester.core.app:create_app --factory --host 127.0.0.1 --port 8000
+command=uv run uvicorn bouwmeester.core.app:create_app --factory --host 127.0.0.1 --port 8000 --proxy-headers --forwarded-allow-ips='*'
 directory=/app
 autostart=true
 autorestart=true

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -12,4 +12,4 @@ echo "Starting parlementair import worker..."
 python -m bouwmeester.worker &
 
 echo "Starting uvicorn..."
-exec uvicorn bouwmeester.core.app:create_app --factory --host 0.0.0.0 --port 8080
+exec uvicorn bouwmeester.core.app:create_app --factory --host 0.0.0.0 --port 8080 --proxy-headers --forwarded-allow-ips='*'


### PR DESCRIPTION
## Summary

- Add `--proxy-headers --forwarded-allow-ips='*'` to uvicorn in both `backend/entrypoint.sh` (ZAD deployment) and root `Dockerfile` (supervisord deployment)

## Root cause

Behind the ZAD k8s ingress, `request.client.host` was the **proxy/ingress IP** for all users, not the user's real IP. This caused the auth rate limiter to share a single 30-req/60s bucket across ALL users. Once anyone exhausted it, everyone got 429 "Too many requests".

With `--proxy-headers`, uvicorn reads `X-Forwarded-For` from the trusted proxy and sets `request.client.host` to the real client IP.

## Test plan

- [x] Backend tests pass (no test changes needed — this is infra config)
- [ ] Verify Eelco can log in after deploy
- [ ] Verify rate limiter tracks per-user IPs (not proxy IP)

🤖 Generated with [Claude Code](https://claude.ai/code)