### PR TITLE
Add Markdown block-level support to RichTextEditor

### DIFF
--- a/frontend/src/components/common/RichTextDisplay.tsx
+++ b/frontend/src/components/common/RichTextDisplay.tsx
@@ -124,6 +124,36 @@ function renderNode(node: TipTapNode, key: number, handlers: MentionHandlers): R
       );
     }
 
+    case 'heading': {
+      const level = (node.attrs?.level as number) ?? 2;
+      const Tag = level === 2 ? 'h2' : 'h3';
+      const className = level === 2
+        ? 'text-lg font-semibold mt-3 mb-1'
+        : 'text-base font-semibold mt-2 mb-1';
+      return (
+        <Tag key={key} className={className}>
+          {node.content ? renderNodes(node.content, handlers) : null}
+        </Tag>
+      );
+    }
+
+    case 'blockquote':
+      return (
+        <blockquote key={key} className="border-l-3 border-gray-300 pl-3 text-gray-500 my-2">
+          {node.content ? renderNodes(node.content, handlers) : null}
+        </blockquote>
+      );
+
+    case 'codeBlock':
+      return (
+        <pre key={key} className="bg-gray-100 rounded-md px-3 py-2 my-2 font-mono text-xs overflow-x-auto">
+          <code>{node.content?.map((c) => c.text ?? '').join('\n')}</code>
+        </pre>
+      );
+
+    case 'horizontalRule':
+      return <hr key={key} className="border-t border-gray-200 my-3" />;
+
     case 'hardBreak':
       return <br key={key} />;
 

--- a/frontend/src/components/common/RichTextEditor.tsx
+++ b/frontend/src/components/common/RichTextEditor.tsx
@@ -375,10 +375,7 @@ export function RichTextEditor({
   const editor = useEditor({
     extensions: [
       StarterKit.configure({
-        heading: false,
-        codeBlock: false,
-        blockquote: false,
-        horizontalRule: false,
+        heading: { levels: [2, 3] },
       }),
       Placeholder.configure({ placeholder }),
       PersonMention,
@@ -469,6 +466,46 @@ export function RichTextEditor({
           padding: 0.1rem 0.3rem;
           font-weight: 500;
           text-decoration: none;
+        }
+        .rich-text-editor .ProseMirror h2 {
+          font-size: 1.25rem;
+          font-weight: 600;
+          line-height: 1.4;
+          margin-top: 0.75rem;
+          margin-bottom: 0.25rem;
+        }
+        .rich-text-editor .ProseMirror h3 {
+          font-size: 1.1rem;
+          font-weight: 600;
+          line-height: 1.4;
+          margin-top: 0.5rem;
+          margin-bottom: 0.25rem;
+        }
+        .rich-text-editor .ProseMirror blockquote {
+          border-left: 3px solid #d1d5db;
+          padding-left: 0.75rem;
+          color: #6b7280;
+          margin: 0.5rem 0;
+        }
+        .rich-text-editor .ProseMirror pre {
+          background-color: #f3f4f6;
+          border-radius: 0.375rem;
+          padding: 0.5rem 0.75rem;
+          margin: 0.5rem 0;
+          font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+          font-size: 0.8rem;
+          overflow-x: auto;
+        }
+        .rich-text-editor .ProseMirror pre code {
+          background: none;
+          padding: 0;
+          font-size: inherit;
+          color: inherit;
+        }
+        .rich-text-editor .ProseMirror hr {
+          border: none;
+          border-top: 1px solid #e5e7eb;
+          margin: 0.75rem 0;
         }
       `}</style>
     </div>

--- a/frontend/src/components/nodes/NodeCreateForm.tsx
+++ b/frontend/src/components/nodes/NodeCreateForm.tsx
@@ -129,7 +129,7 @@ export function NodeCreateForm({ open, onClose }: NodeCreateFormProps) {
           <RichTextEditor
             value={description}
             onChange={setDescription}
-            placeholder="Optionele beschrijving... Gebruik @ voor personen, # voor nodes/taken"
+            placeholder="Optionele beschrijving... Gebruik @ voor personen, # voor nodes/taken, **vet** voor opmaak"
             rows={4}
           />
         </div>

--- a/frontend/src/components/nodes/NodeEditForm.tsx
+++ b/frontend/src/components/nodes/NodeEditForm.tsx
@@ -91,7 +91,7 @@ export function NodeEditForm({ open, onClose, node }: NodeEditFormProps) {
           <RichTextEditor
             value={description}
             onChange={setDescription}
-            placeholder="Optionele beschrijving... Gebruik @ voor personen, # voor nodes/taken"
+            placeholder="Optionele beschrijving... Gebruik @ voor personen, # voor nodes/taken, **vet** voor opmaak"
             rows={4}
           />
         </div>

--- a/frontend/src/components/organisatie/OrganisatieForm.tsx
+++ b/frontend/src/components/organisatie/OrganisatieForm.tsx
@@ -195,7 +195,7 @@ export function OrganisatieForm({
           <RichTextEditor
             value={beschrijving}
             onChange={setBeschrijving}
-            placeholder="Optionele beschrijving... Gebruik @ voor personen, # voor nodes/taken"
+            placeholder="Optionele beschrijving... Gebruik @ voor personen, # voor nodes/taken, **vet** voor opmaak"
             rows={3}
           />
         </div>

--- a/frontend/src/components/tasks/TaskCreateForm.tsx
+++ b/frontend/src/components/tasks/TaskCreateForm.tsx
@@ -106,7 +106,7 @@ export function TaskCreateForm({ open, onClose, nodeId, parentId }: TaskCreateFo
             <RichTextEditor
               value={description}
               onChange={setDescription}
-              placeholder="Optionele beschrijving... Gebruik @ voor personen, # voor nodes/taken"
+              placeholder="Optionele beschrijving... Gebruik @ voor personen, # voor nodes/taken, **vet** voor opmaak"
               rows={3}
             />
           </div>

--- a/frontend/src/components/tasks/TaskEditForm.tsx
+++ b/frontend/src/components/tasks/TaskEditForm.tsx
@@ -158,7 +158,7 @@ export function TaskEditForm({ open, onClose, task }: TaskEditFormProps) {
             <RichTextEditor
               value={description}
               onChange={setDescription}
-              placeholder="Optionele beschrijving... Gebruik @ voor personen, # voor nodes/taken"
+              placeholder="Optionele beschrijving... Gebruik @ voor personen, # voor nodes/taken, **vet** voor opmaak"
               rows={3}
             />
           </div>


### PR DESCRIPTION
## Summary

- Re-enable heading (h2/h3), blockquote, code block, and horizontal rule extensions in TipTap StarterKit — activates Markdown input shortcuts (`## `, `> `, ` ``` `, `---`) with no new dependencies
- Add render cases for the new node types in `RichTextDisplay` and editor CSS styles
- Update placeholder text in all description fields to hint at formatting support

## Test plan

- [ ] Open any form with a description field (Task, Node, Organisatie)
- [ ] Verify existing features still work: `**bold**`, `*italic*`, `- list`, `@mention`, `#hashtag`
- [ ] Test `## heading` + space → renders as h2
- [ ] Test `### heading` + space → renders as h3
- [ ] Test `> ` at start of line → renders as blockquote
- [ ] Test triple backticks → renders as code block
- [ ] Test `---` → renders as horizontal rule
- [ ] Save content, reopen — verify RichTextDisplay renders all types correctly
- [ ] Verify `#hashtag` mention still works (no conflict with `## ` heading shortcut)