### PR TITLE
Show error banner on login page when auth_status fails silently

### DIFF
--- a/backend/bouwmeester/api/routes/auth.py
+++ b/backend/bouwmeester/api/routes/auth.py
@@ -252,6 +252,11 @@ async def auth_status(
     except Exception:
         logger.exception("Token validation failed in auth_status")
         authenticated = False
+        return {
+            "authenticated": False,
+            "oidc_configured": oidc_configured,
+            "error": "token_validation_failed",
+        }
 
     result: dict = {
         "authenticated": authenticated,
@@ -328,6 +333,7 @@ async def auth_status(
             return {
                 "authenticated": False,
                 "oidc_configured": oidc_configured,
+                "error": "person_resolution_failed",
             }
 
     return result

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -16,6 +16,7 @@ interface AuthState {
   oidcConfigured: boolean;
   person: AuthPerson | null;
   error: string | null;
+  authError: string | null;
   accessDenied: boolean;
   deniedEmail: string | null;
 }
@@ -47,6 +48,7 @@ async function fetchAuthStatus(): Promise<AuthState> {
         }
       : null,
     error: null,
+    authError: data.error ?? null,
     accessDenied: data.access_denied ?? false,
     deniedEmail: data.denied_email ?? null,
   };
@@ -59,6 +61,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     oidcConfigured: false,
     person: null,
     error: null,
+    authError: null,
     accessDenied: false,
     deniedEmail: null,
   });

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,7 +1,7 @@
 import { useAuth } from '@/contexts/AuthContext';
 
 export function LoginPage() {
-  const { login } = useAuth();
+  const { login, authError } = useAuth();
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50">
@@ -12,6 +12,11 @@ export function LoginPage() {
             Log in om door te gaan
           </p>
         </div>
+        {authError && (
+          <div className="rounded-lg bg-red-50 border border-red-200 p-4 text-sm text-red-700">
+            Er ging iets mis bij het inloggen. Probeer het opnieuw of neem contact op met een beheerder.
+          </div>
+        )}
         <button
           onClick={login}
           className="w-full flex justify-center py-2.5 px-4 border border-transparent rounded-lg shadow-sm text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 transition-colors"


### PR DESCRIPTION
## Summary

- Backend `auth_status` now returns an `"error"` field (`token_validation_failed` or `person_resolution_failed`) when it catches exceptions, instead of silently returning `authenticated: false`
- Frontend `AuthContext` exposes `authError` from the response
- `LoginPage` shows a red banner when `authError` is set: *"Er ging iets mis bij het inloggen. Probeer het opnieuw of neem contact op met een beheerder."*

## Test plan

- [ ] Backend: `uv run pytest` passes (449 tests)
- [ ] Frontend: `npx tsc --noEmit` passes
- [ ] Simulate token validation failure → verify login page shows error banner
- [ ] Normal login flow still works without banner