### PR TITLE
Fix worker crashes: nullable TK API fields and process error handling

### DIFF
--- a/backend/bouwmeester/services/parlementair_import_service.py
+++ b/backend/bouwmeester/services/parlementair_import_service.py
@@ -11,7 +11,6 @@ from collections import Counter
 from datetime import date, datetime, timedelta
 
 import anthropic
-import httpx
 from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -142,13 +141,7 @@ class ParlementairImportService:
                 result = await self._process_item(item, strategy)
                 if result:
                     imported_count += 1
-            except (
-                httpx.HTTPError,
-                anthropic.APIError,
-                SQLAlchemyError,
-                ValueError,
-                KeyError,
-            ):
+            except Exception:
                 logger.exception(
                     f"Error processing {strategy.item_type} {item.zaak_id}"
                 )

--- a/backend/bouwmeester/services/tk_api_client.py
+++ b/backend/bouwmeester/services/tk_api_client.py
@@ -243,7 +243,7 @@ class TweedeKamerClient:
     async def _zaak_to_data(self, zaak: dict[str, Any], soort: str) -> ZaakData:
         """Convert a raw Zaak dict to ZaakData with enrichment."""
         zaak_id = zaak["Id"]
-        zaak_nummer = zaak.get("Nummer", "")
+        zaak_nummer = zaak.get("Nummer") or ""
 
         indieners = await self._fetch_indieners(zaak_id)
         document_tekst, document_url = await self._fetch_document_text(
@@ -267,8 +267,8 @@ class TweedeKamerClient:
         return ZaakData(
             zaak_id=zaak_id,
             zaak_nummer=zaak_nummer,
-            titel=zaak.get("Titel", ""),
-            onderwerp=zaak.get("Onderwerp", ""),
+            titel=zaak.get("Titel") or "",
+            onderwerp=zaak.get("Onderwerp") or "",
             soort=soort,
             datum=datum,
             indieners=indieners,


### PR DESCRIPTION
## Summary

- **Kamervraag crash**: The TK API returns `null` for `Titel`/`Onderwerp`/`Nummer` on some Zaak records. `dict.get("Titel", "")` returns `None` when the key exists with value `None`, causing a Pydantic `ValidationError`. Fixed by using `or ""` fallback instead.
- **Toezegging crash**: The `_process_item` loop only caught a specific list of exceptions (`httpx.HTTPError`, `anthropic.APIError`, `SQLAlchemyError`, `ValueError`, `KeyError`). Any other exception from a single item (e.g. Pydantic `ValidationError`) crashed the entire import cycle for all remaining items. Broadened to `Exception`.
- Removed unused `httpx` import from `parlementair_import_service.py`

## Test plan

- [ ] Deploy and verify kamervragen are fetched and processed without ValidationError
- [ ] Verify toezegging processing continues even if individual items fail
- [ ] Check logs confirm all three import types (motie, kamervraag, toezegging) complete