### PR TITLE
Fix empty kamerstukken page: commit each item individually

### DIFF
--- a/backend/bouwmeester/services/parlementair_import_service.py
+++ b/backend/bouwmeester/services/parlementair_import_service.py
@@ -139,13 +139,13 @@ class ParlementairImportService:
         for item in all_items:
             try:
                 result = await self._process_item(item, strategy)
+                await self.session.commit()
                 if result:
                     imported_count += 1
             except Exception:
                 logger.exception(
                     f"Error processing {strategy.item_type} {item.zaak_id}"
                 )
-                # Rollback so the session is usable for subsequent items
                 await self.session.rollback()
 
         return imported_count

--- a/backend/bouwmeester/worker.py
+++ b/backend/bouwmeester/worker.py
@@ -29,7 +29,6 @@ async def main() -> None:
 
                 service = ParlementairImportService(session)
                 count = await service.poll_and_import()
-                await session.commit()
                 logger.info(f"Import cycle complete: {count} items imported")
         except Exception:
             logger.exception("Error in parlementair import cycle")


### PR DESCRIPTION
## Summary

- Items were being flushed but only committed once at the end of the entire import cycle in `worker.py`
- When any item failed and triggered `session.rollback()`, it wiped out **all** previously flushed records (moties, kamervragen, toezeggingen) from that cycle
- This is why the kamerstukken page showed nothing despite the logs showing successful processing
- Now each item is committed immediately after `_process_item`, so successful imports are persisted regardless of later failures
- Removed the single `session.commit()` from `worker.py` since commits now happen per-item

## Test plan

- [ ] Deploy and verify items appear on the kamerstukken page
- [ ] Verify out_of_scope items appear on the "Buiten scope" tab
- [ ] Confirm a failed item doesn't prevent other items from being persisted