### PR TITLE
Fix: duplicaten-detectie toont nu ook inactieve personen

### DIFF
--- a/backend/bouwmeester/api/routes/people.py
+++ b/backend/bouwmeester/api/routes/people.py
@@ -879,10 +879,10 @@ async def list_duplicate_persons(
     Uses a SQL subquery to find only names that appear 2+ times, then loads
     details for those persons only (avoids fetching the entire person table).
     """
-    # Subquery: names with 2+ active persons
+    # Subquery: names with 2+ persons (including inactive, so admins can
+    # spot and merge deactivated duplicates too).
     dup_names_sq = (
         select(func.lower(func.trim(Person.naam)).label("lower_naam"))
-        .where(Person.is_active == True)  # noqa: E712
         .group_by(func.lower(func.trim(Person.naam)))
         .having(func.count() >= 2)
         .subquery()
@@ -892,7 +892,6 @@ async def list_duplicate_persons(
         select(Person)
         .options(selectinload(Person.emails))
         .where(
-            Person.is_active == True,  # noqa: E712
             func.lower(func.trim(Person.naam)).in_(select(dup_names_sq.c.lower_naam)),
         )
         .order_by(func.lower(Person.naam), Person.created_at.asc())

--- a/frontend/src/components/admin/DuplicateManager.tsx
+++ b/frontend/src/components/admin/DuplicateManager.tsx
@@ -7,6 +7,9 @@ function MemberLabel({ member }: { member: DuplicateGroupMember }) {
   return (
     <span>
       {member.naam}
+      {!member.is_active && (
+        <span className="ml-1 text-xs text-red-500 font-medium">(inactief)</span>
+      )}
       {member.email && <span className="text-text-secondary ml-1">({member.email})</span>}
       {member.functie && (
         <span className="text-text-secondary ml-1">- {member.functie}</span>


### PR DESCRIPTION
## Summary

- De `/api/people/duplicates` endpoint filterde op `is_active=true`, waardoor duplicaat-groepen waar een van de personen inactief was niet getoond werden in de Duplicaten-tab
- Inactieve personen worden nu meegenomen in de detectie en tonen een "(inactief)" label in de UI

## Test plan

- [ ] Maak twee personen met dezelfde naam, deactiveer er een
- [ ] Open Beheer > Duplicaten — beide moeten zichtbaar zijn als groep
- [ ] De inactieve persoon toont "(inactief)" label