### PR TITLE
Consolideer lead-UIs: inline editing + gedeeld layout

### DIFF
--- a/frontend/src/components/common/InlineEditableField.tsx
+++ b/frontend/src/components/common/InlineEditableField.tsx
@@ -1,0 +1,220 @@
+import { useState, useRef, useEffect, useCallback, type ReactNode } from 'react';
+import { Pencil, Check, X, Loader2 } from 'lucide-react';
+import { CreatableSelect } from '@/components/common/CreatableSelect';
+import type { SelectOption } from '@/components/common/CreatableSelect';
+import { RichTextFormField } from '@/components/common/RichTextFormField';
+
+interface InlineEditableFieldProps {
+  type: 'text' | 'date' | 'select' | 'richtext';
+  value: string | null;
+  onSave: (newValue: string | null) => Promise<void>;
+  displayValue?: ReactNode;
+  placeholder?: string;
+  options?: SelectOption[];
+  onCreate?: (name: string) => Promise<string | null>;
+  createLabel?: string;
+  clearable?: boolean;
+  label?: string;
+  rows?: number;
+}
+
+export function InlineEditableField({
+  type,
+  value,
+  onSave,
+  displayValue,
+  placeholder = 'Klik om te bewerken...',
+  options,
+  onCreate,
+  createLabel,
+  clearable,
+  label,
+  rows = 3,
+}: InlineEditableFieldProps) {
+  const [editing, setEditing] = useState(false);
+  const [editValue, setEditValue] = useState(value ?? '');
+  const [saving, setSaving] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (editing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [editing]);
+
+  const startEdit = useCallback(() => {
+    setEditValue(value ?? '');
+    setEditing(true);
+  }, [value]);
+
+  const save = useCallback(async (newValue: string) => {
+    const trimmed = newValue.trim();
+    const saveValue = trimmed || null;
+    if (saveValue === (value ?? null)) {
+      setEditing(false);
+      return;
+    }
+    setSaving(true);
+    try {
+      await onSave(saveValue);
+    } finally {
+      setSaving(false);
+      setEditing(false);
+    }
+  }, [value, onSave]);
+
+  const cancel = useCallback(() => {
+    setEditing(false);
+    setEditValue(value ?? '');
+  }, [value]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && type !== 'richtext') {
+      e.preventDefault();
+      save(editValue);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      cancel();
+    }
+  }, [editValue, save, cancel, type]);
+
+  // Click outside for richtext
+  useEffect(() => {
+    if (!editing || type !== 'richtext') return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        save(editValue);
+      }
+    };
+    // Slight delay to avoid immediate close on the click that opened editing
+    const timer = setTimeout(() => {
+      document.addEventListener('mousedown', handleClickOutside);
+    }, 100);
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [editing, type, editValue, save]);
+
+  if (!editing) {
+    return (
+      <div>
+        {label && (
+          <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-1">
+            {label}
+          </h4>
+        )}
+        <button
+          type="button"
+          onClick={startEdit}
+          className="group w-full text-left rounded-lg px-2 py-1 -mx-2 -my-1 hover:bg-gray-50 transition-colors cursor-pointer"
+        >
+          <span className="inline-flex items-center gap-1.5">
+            {displayValue ?? (
+              <span className={value ? 'text-text' : 'text-text-secondary italic text-sm'}>
+                {value || placeholder}
+              </span>
+            )}
+            <Pencil className="h-3 w-3 text-text-secondary opacity-0 group-hover:opacity-100 transition-opacity" />
+            {saving && <Loader2 className="h-3 w-3 text-text-secondary animate-spin" />}
+          </span>
+        </button>
+      </div>
+    );
+  }
+
+  if (type === 'select') {
+    return (
+      <div>
+        {label && (
+          <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-1">
+            {label}
+          </h4>
+        )}
+        <CreatableSelect
+          value={editValue}
+          onChange={async (v) => {
+            setEditValue(v);
+            setSaving(true);
+            try {
+              await onSave(v || null);
+            } finally {
+              setSaving(false);
+              setEditing(false);
+            }
+          }}
+          options={options ?? []}
+          placeholder={placeholder}
+          onCreate={onCreate}
+          createLabel={createLabel}
+          onClear={clearable ? async () => {
+            setSaving(true);
+            try {
+              await onSave(null);
+            } finally {
+              setSaving(false);
+              setEditing(false);
+            }
+          } : undefined}
+        />
+      </div>
+    );
+  }
+
+  if (type === 'richtext') {
+    return (
+      <div ref={wrapperRef}>
+        {label && (
+          <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-1">
+            {label}
+          </h4>
+        )}
+        <RichTextFormField
+          value={editValue}
+          onChange={setEditValue}
+          rows={rows}
+          placeholder={placeholder}
+        />
+        <div className="flex items-center gap-1 mt-1">
+          <button
+            type="button"
+            onClick={() => save(editValue)}
+            className="p-1 rounded text-green-600 hover:bg-green-50"
+          >
+            <Check className="h-3.5 w-3.5" />
+          </button>
+          <button
+            type="button"
+            onClick={cancel}
+            className="p-1 rounded text-text-secondary hover:bg-gray-100"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // text and date
+  return (
+    <div>
+      {label && (
+        <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-1">
+          {label}
+        </h4>
+      )}
+      <input
+        ref={inputRef}
+        type={type === 'date' ? 'date' : 'text'}
+        value={editValue}
+        onChange={(e) => setEditValue(e.target.value)}
+        onBlur={() => save(editValue)}
+        onKeyDown={handleKeyDown}
+        className="w-full rounded-lg border border-primary-300 px-2 py-1 text-sm focus:outline-none focus:border-primary-400 bg-white"
+        placeholder={placeholder}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/common/InlineEditableField.tsx
+++ b/frontend/src/components/common/InlineEditableField.tsx
@@ -36,6 +36,12 @@ export function InlineEditableField({
   const [saving, setSaving] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const selectWrapperRef = useRef<HTMLDivElement>(null);
+  const editValueRef = useRef(editValue);
+
+  useEffect(() => {
+    editValueRef.current = editValue;
+  }, [editValue]);
 
   useEffect(() => {
     if (editing && inputRef.current) {
@@ -80,12 +86,12 @@ export function InlineEditableField({
     }
   }, [editValue, save, cancel, type]);
 
-  // Click outside for richtext
+  // Click outside for richtext — use ref to avoid stale closure over editValue
   useEffect(() => {
     if (!editing || type !== 'richtext') return;
     const handleClickOutside = (e: MouseEvent) => {
       if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
-        save(editValue);
+        save(editValueRef.current);
       }
     };
     // Slight delay to avoid immediate close on the click that opened editing
@@ -96,7 +102,24 @@ export function InlineEditableField({
       clearTimeout(timer);
       document.removeEventListener('mousedown', handleClickOutside);
     };
-  }, [editing, type, editValue, save]);
+  }, [editing, type, save]);
+
+  // Click outside for select — cancel without saving
+  useEffect(() => {
+    if (!editing || type !== 'select') return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (selectWrapperRef.current && !selectWrapperRef.current.contains(e.target as Node)) {
+        cancel();
+      }
+    };
+    const timer = setTimeout(() => {
+      document.addEventListener('mousedown', handleClickOutside);
+    }, 100);
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [editing, type, cancel]);
 
   if (!editing) {
     return (
@@ -127,7 +150,7 @@ export function InlineEditableField({
 
   if (type === 'select') {
     return (
-      <div>
+      <div ref={selectWrapperRef}>
         {label && (
           <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-1">
             {label}

--- a/frontend/src/components/common/RichTextFormField.tsx
+++ b/frontend/src/components/common/RichTextFormField.tsx
@@ -1,7 +1,7 @@
 import { RichTextEditor } from '@/components/common/RichTextEditor';
 
 interface RichTextFormFieldProps {
-  label: string;
+  label?: string;
   value: string;
   onChange: (value: string) => void;
   rows?: number;
@@ -19,7 +19,7 @@ export function RichTextFormField({
 }: RichTextFormFieldProps) {
   return (
     <div className="space-y-1.5">
-      <label className="block text-sm font-medium text-text">{label}</label>
+      {label && <label className="block text-sm font-medium text-text">{label}</label>}
       <RichTextEditor
         value={value}
         onChange={onChange}

--- a/frontend/src/components/leads/LeadContentLayout.tsx
+++ b/frontend/src/components/leads/LeadContentLayout.tsx
@@ -1,0 +1,603 @@
+import { useState, useMemo, useRef, useCallback, type ReactNode } from 'react';
+import { User, Calendar, X } from 'lucide-react';
+import { InlineEditableField } from '@/components/common/InlineEditableField';
+import { RichTextDisplay } from '@/components/common/RichTextDisplay';
+import { Badge } from '@/components/common/Badge';
+import { usePeople } from '@/hooks/usePeople';
+import { useInitiatieven, useCreateInitiatief } from '@/hooks/useInitiatieven';
+import { useTags } from '@/hooks/useTags';
+import { useCurrentPerson } from '@/contexts/CurrentPersonContext';
+import { buildPersonOptions } from '@/utils/personOptions';
+import { createPerson } from '@/api/people';
+import { isOverdue, formatDateLong } from '@/utils/dates';
+import {
+  LeadStage,
+  LEAD_STAGE_LABELS,
+  LEAD_STAGE_COLORS,
+  LEAD_STAGE_ORDER,
+  INITIATIEF_COLORS,
+  formatFunctie,
+} from '@/types';
+
+export interface LeadContentLayoutProps {
+  // Lead data
+  title: string;
+  stage: LeadStage;
+  description: string | null;
+  organization: string | null;
+  assigneeId: string | null;
+  assigneeName: string | null;
+  broughtById: string | null;
+  broughtByName: string | null;
+  initiatiefId: string | null;
+  initiatiefName: string | null;
+  initiatiefKleur: string | null;
+  nextAction: string | null;
+  nextActionDate: string | null;
+  createdAt: string | null;
+  tags: string[];
+
+  // Per-field save callbacks (omit to make read-only)
+  onTitleChange?: (value: string) => Promise<void>;
+  onStageChange?: (value: LeadStage) => Promise<void>;
+  onDescriptionChange?: (value: string | null) => Promise<void>;
+  onOrganizationChange?: (value: string | null) => Promise<void>;
+  onAssigneeChange?: (value: string | null) => Promise<void>;
+  onBroughtByChange?: (value: string | null) => Promise<void>;
+  onInitiatiefChange?: (value: string | null) => Promise<void>;
+  onNextActionChange?: (value: string | null) => Promise<void>;
+  onNextActionDateChange?: (value: string | null) => Promise<void>;
+  onTagsChange?: (tags: string[]) => Promise<void>;
+
+  // Context-specific sections
+  rightColumnChildren?: ReactNode;
+  bottomChildren?: ReactNode;
+}
+
+function StagePills({
+  value,
+  onChange,
+}: {
+  value: LeadStage;
+  onChange?: (stage: LeadStage) => Promise<void>;
+}) {
+  const [saving, setSaving] = useState(false);
+
+  if (!onChange) {
+    return (
+      <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${LEAD_STAGE_COLORS[value]}`}>
+        {LEAD_STAGE_LABELS[value]}
+      </span>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {LEAD_STAGE_ORDER.map((s) => (
+        <button
+          key={s}
+          type="button"
+          disabled={saving}
+          onClick={async () => {
+            if (s === value) return;
+            setSaving(true);
+            try {
+              await onChange(s);
+            } finally {
+              setSaving(false);
+            }
+          }}
+          className={`rounded-full px-3 py-1 text-xs font-medium transition-all ${
+            value === s
+              ? `${LEAD_STAGE_COLORS[s]} ring-2 ring-offset-1 ring-current`
+              : 'bg-gray-100 text-text-secondary hover:bg-gray-200'
+          }`}
+        >
+          {LEAD_STAGE_LABELS[s]}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function TagsEditor({
+  tags,
+  onChange,
+}: {
+  tags: string[];
+  onChange?: (tags: string[]) => Promise<void>;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [search, setSearch] = useState('');
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const { data: allTags } = useTags();
+
+  const filteredTags = useMemo(
+    () =>
+      (allTags ?? [])
+        .filter((t) => !tags.includes(t.name))
+        .filter((t) => search ? t.name.toLowerCase().includes(search.toLowerCase()) : false),
+    [allTags, tags, search],
+  );
+
+  const addTag = useCallback(async (name: string) => {
+    if (!onChange || tags.includes(name)) return;
+    const newTags = [...tags, name];
+    setSaving(true);
+    try {
+      await onChange(newTags);
+    } finally {
+      setSaving(false);
+    }
+  }, [onChange, tags]);
+
+  const removeTag = useCallback(async (name: string) => {
+    if (!onChange) return;
+    const newTags = tags.filter((t) => t !== name);
+    setSaving(true);
+    try {
+      await onChange(newTags);
+    } finally {
+      setSaving(false);
+    }
+  }, [onChange, tags]);
+
+  // Close dropdown on click outside
+  const handleClickOutside = useCallback((e: MouseEvent) => {
+    if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+      setEditing(false);
+      setDropdownOpen(false);
+      setSearch('');
+    }
+  }, []);
+
+  // Attach/detach click outside listener
+  const prevEditing = useRef(false);
+  if (editing !== prevEditing.current) {
+    if (editing) {
+      document.addEventListener('mousedown', handleClickOutside);
+    } else {
+      document.removeEventListener('mousedown', handleClickOutside);
+    }
+    prevEditing.current = editing;
+  }
+
+  if (!onChange) {
+    if (tags.length === 0) return null;
+    return (
+      <div className="flex flex-wrap gap-1.5">
+        {tags.map((tag) => (
+          <Badge key={tag} variant="gray">{tag}</Badge>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div ref={containerRef}>
+      <div className="flex flex-wrap gap-1.5 mb-1">
+        {tags.map((tag) => (
+          <span
+            key={tag}
+            title={tag}
+            className="inline-flex items-center gap-1 rounded-full bg-slate-100 text-slate-700 px-2.5 py-0.5 text-xs font-medium"
+          >
+            {tag.includes('/') ? tag.split('/').pop() : tag}
+            <button
+              type="button"
+              onClick={() => removeTag(tag)}
+              className="hover:text-red-500"
+              disabled={saving}
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </span>
+        ))}
+      </div>
+
+      {editing ? (
+        <div className="relative">
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => {
+              setSearch(e.target.value);
+              setDropdownOpen(true);
+            }}
+            onFocus={() => { if (search) setDropdownOpen(true); }}
+            placeholder="Zoek of typ een tag..."
+            className="w-full rounded-lg border border-primary-300 px-3 py-2 text-sm focus:outline-none focus:border-primary-400"
+            autoFocus
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && search.trim()) {
+                e.preventDefault();
+                addTag(search.trim());
+                setSearch('');
+                setDropdownOpen(false);
+              } else if (e.key === 'Escape') {
+                setEditing(false);
+                setSearch('');
+                setDropdownOpen(false);
+              }
+            }}
+          />
+          {dropdownOpen && search && filteredTags.length > 0 && (
+            <div className="absolute z-10 mt-1 w-full bg-white border border-border rounded-lg shadow-lg max-h-40 overflow-y-auto">
+              {filteredTags.slice(0, 10).map((tag) => (
+                <button
+                  key={tag.id}
+                  type="button"
+                  onClick={() => {
+                    addTag(tag.name);
+                    setSearch('');
+                    setDropdownOpen(false);
+                  }}
+                  className="w-full text-left px-3 py-2 text-sm hover:bg-gray-50 transition-colors"
+                >
+                  {tag.name}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setEditing(true)}
+          className="text-xs text-text-secondary hover:text-primary-600 transition-colors"
+        >
+          + Tag toevoegen
+        </button>
+      )}
+    </div>
+  );
+}
+
+export function LeadContentLayout({
+  title,
+  stage,
+  description,
+  organization,
+  assigneeId,
+  assigneeName,
+  broughtById,
+  broughtByName,
+  initiatiefId,
+  initiatiefName,
+  initiatiefKleur,
+  nextAction,
+  nextActionDate,
+  createdAt,
+  tags,
+  onTitleChange,
+  onStageChange,
+  onDescriptionChange,
+  onOrganizationChange,
+  onAssigneeChange,
+  onBroughtByChange,
+  onInitiatiefChange,
+  onNextActionChange,
+  onNextActionDateChange,
+  onTagsChange,
+  rightColumnChildren,
+  bottomChildren,
+}: LeadContentLayoutProps) {
+  const { data: people } = usePeople();
+  const { data: initiatieven } = useInitiatieven();
+  const createInitiatief = useCreateInitiatief();
+  const { currentPerson } = useCurrentPerson();
+
+  const overdue = nextActionDate && isOverdue(nextActionDate);
+
+  const personOptions = useMemo(
+    () => buildPersonOptions(people ?? [], currentPerson, (p) => ({
+      value: p.id,
+      label: p.naam,
+      description: formatFunctie(p.functie),
+    })),
+    [people, currentPerson],
+  );
+
+  const initiatiefOptions = useMemo(
+    () => [
+      { value: '', label: 'Geen initiatief' },
+      ...(initiatieven?.map((i) => ({ value: i.id, label: i.naam })) ?? []),
+    ],
+    [initiatieven],
+  );
+
+  return (
+    <div className="space-y-5">
+      {/* Title */}
+      {onTitleChange ? (
+        <InlineEditableField
+          type="text"
+          value={title}
+          onSave={async (v) => { if (v) await onTitleChange(v); }}
+          displayValue={<span className="text-lg font-semibold text-text">{title}</span>}
+          placeholder="Titel van de lead"
+        />
+      ) : (
+        <h2 className="text-lg font-semibold text-text">{title}</h2>
+      )}
+
+      {/* Stage */}
+      <div className="flex items-center gap-2 flex-wrap">
+        <StagePills value={stage} onChange={onStageChange} />
+        {nextActionDate && !onStageChange && (
+          <span className={`inline-flex items-center gap-1 text-sm ${overdue ? 'text-red-600 font-medium bg-red-50 rounded-md px-2 py-0.5' : 'text-text-secondary'}`}>
+            <Calendar className="h-4 w-4" />
+            {formatDateLong(nextActionDate)}
+          </span>
+        )}
+      </div>
+
+      {/* Two-column layout */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4">
+        {/* LEFT COLUMN */}
+        <div className="space-y-4">
+          {/* Description */}
+          {onDescriptionChange ? (
+            <InlineEditableField
+              type="richtext"
+              label="Beschrijving"
+              value={description}
+              onSave={onDescriptionChange}
+              displayValue={
+                description ? (
+                  <div className="text-sm text-text">
+                    <RichTextDisplay content={description} />
+                  </div>
+                ) : undefined
+              }
+              placeholder="Voeg een beschrijving toe..."
+              rows={5}
+            />
+          ) : description ? (
+            <div>
+              <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-1">
+                Beschrijving
+              </h4>
+              <div className="text-sm text-text">
+                <RichTextDisplay content={description} />
+              </div>
+            </div>
+          ) : null}
+
+          {/* Metadata fields */}
+          <div className="grid grid-cols-2 gap-4 text-sm">
+            {/* Organization */}
+            <div>
+              {onOrganizationChange ? (
+                <InlineEditableField
+                  type="text"
+                  label="Organisatie"
+                  value={organization}
+                  onSave={onOrganizationChange}
+                  placeholder="Naam van de organisatie"
+                />
+              ) : (
+                <>
+                  <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-1">
+                    Organisatie
+                  </h4>
+                  <span className="text-text-secondary">{organization ?? 'Onbekend'}</span>
+                </>
+              )}
+            </div>
+
+            {/* Initiatief */}
+            <div>
+              {onInitiatiefChange ? (
+                <InlineEditableField
+                  type="select"
+                  label="Initiatief"
+                  value={initiatiefId}
+                  onSave={async (v) => onInitiatiefChange(v)}
+                  displayValue={
+                    initiatiefName ? (
+                      <span
+                        className="inline-block rounded-full px-2 py-0.5 text-xs font-medium text-white"
+                        style={{ backgroundColor: initiatiefKleur || '#6B7280' }}
+                      >
+                        {initiatiefName}
+                      </span>
+                    ) : undefined
+                  }
+                  options={initiatiefOptions}
+                  placeholder="Selecteer initiatief..."
+                  clearable={!!initiatiefId}
+                  onCreate={async (name) => {
+                    const kleur = INITIATIEF_COLORS[Math.floor(Math.random() * INITIATIEF_COLORS.length)];
+                    const result = await createInitiatief.mutateAsync({ naam: name, kleur });
+                    return result.id;
+                  }}
+                  createLabel="Nieuw initiatief"
+                />
+              ) : initiatiefName ? (
+                <>
+                  <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-1">
+                    Initiatief
+                  </h4>
+                  <span
+                    className="inline-block rounded-full px-2 py-0.5 text-xs font-medium text-white"
+                    style={{ backgroundColor: initiatiefKleur || '#6B7280' }}
+                  >
+                    {initiatiefName}
+                  </span>
+                </>
+              ) : null}
+            </div>
+          </div>
+
+          {/* Next action + date */}
+          {(onNextActionChange || nextAction) && (
+            <div className="grid grid-cols-2 gap-4 text-sm">
+              <div>
+                {onNextActionChange ? (
+                  <InlineEditableField
+                    type="text"
+                    label="Volgende actie"
+                    value={nextAction}
+                    onSave={onNextActionChange}
+                    placeholder="Beschrijf de volgende actie..."
+                  />
+                ) : (
+                  <>
+                    <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-1">
+                      Volgende actie
+                    </h4>
+                    <span className="text-text-secondary">{nextAction ?? '-'}</span>
+                  </>
+                )}
+              </div>
+              <div>
+                {onNextActionDateChange ? (
+                  <InlineEditableField
+                    type="date"
+                    label="Actiedatum"
+                    value={nextActionDate}
+                    onSave={onNextActionDateChange}
+                    displayValue={
+                      nextActionDate ? (
+                        <span className={`inline-flex items-center gap-1 ${overdue ? 'text-red-600 font-medium' : 'text-text-secondary'}`}>
+                          <Calendar className="h-4 w-4" />
+                          {formatDateLong(nextActionDate)}
+                        </span>
+                      ) : undefined
+                    }
+                    placeholder="Kies een datum..."
+                  />
+                ) : nextActionDate ? (
+                  <>
+                    <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-1">
+                      Actiedatum
+                    </h4>
+                    <span className={`inline-flex items-center gap-1 ${overdue ? 'text-red-600 font-medium' : 'text-text-secondary'}`}>
+                      <Calendar className="h-4 w-4" />
+                      {formatDateLong(nextActionDate)}
+                    </span>
+                  </>
+                ) : null}
+              </div>
+            </div>
+          )}
+
+          {/* Tags */}
+          <div>
+            <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-1">
+              Tags
+            </h4>
+            <TagsEditor tags={tags} onChange={onTagsChange} />
+          </div>
+
+          {/* Created at (always read-only) */}
+          {createdAt && (
+            <div className="text-sm">
+              <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-1">
+                Aangemaakt
+              </h4>
+              <span className="inline-flex items-center gap-1.5 text-text-secondary">
+                <Calendar className="h-4 w-4" />
+                {formatDateLong(createdAt)}
+              </span>
+            </div>
+          )}
+        </div>
+
+        {/* RIGHT COLUMN */}
+        <div className="space-y-4">
+          {/* Toegewezen aan */}
+          <div>
+            {onAssigneeChange ? (
+              <InlineEditableField
+                type="select"
+                label="Toegewezen aan"
+                value={assigneeId}
+                onSave={async (v) => onAssigneeChange(v)}
+                displayValue={
+                  assigneeName ? (
+                    <span className="inline-flex items-center gap-1.5 text-text">
+                      <User className="h-4 w-4 text-text-secondary" />
+                      {assigneeName}
+                    </span>
+                  ) : undefined
+                }
+                options={[
+                  { value: '', label: 'Niet toegewezen' },
+                  ...personOptions,
+                ]}
+                placeholder="Zoek een persoon..."
+                clearable={!!assigneeId}
+                onCreate={async (name) => {
+                  const result = await createPerson({ naam: name }, true);
+                  return result?.id ?? null;
+                }}
+                createLabel="Nieuwe persoon aanmaken"
+              />
+            ) : (
+              <>
+                <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-1">
+                  Toegewezen aan
+                </h4>
+                {assigneeName ? (
+                  <span className="inline-flex items-center gap-1.5 text-text">
+                    <User className="h-4 w-4 text-text-secondary" />
+                    {assigneeName}
+                  </span>
+                ) : (
+                  <span className="text-text-secondary">Niet toegewezen</span>
+                )}
+              </>
+            )}
+          </div>
+
+          {/* Binnengebracht door */}
+          <div>
+            {onBroughtByChange ? (
+              <InlineEditableField
+                type="select"
+                label="Binnengebracht door"
+                value={broughtById}
+                onSave={async (v) => onBroughtByChange(v)}
+                displayValue={
+                  broughtByName ? (
+                    <span className="inline-flex items-center gap-1.5 text-text">
+                      <User className="h-4 w-4 text-text-secondary" />
+                      {broughtByName}
+                    </span>
+                  ) : undefined
+                }
+                options={personOptions}
+                placeholder="Zoek een teamlid..."
+                clearable={!!broughtById}
+              />
+            ) : (
+              <>
+                <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-1">
+                  Binnengebracht door
+                </h4>
+                {broughtByName ? (
+                  <span className="inline-flex items-center gap-1.5 text-text">
+                    <User className="h-4 w-4 text-text-secondary" />
+                    {broughtByName}
+                  </span>
+                ) : (
+                  <span className="text-text-secondary">Onbekend</span>
+                )}
+              </>
+            )}
+          </div>
+
+          {/* Context-specific right column content */}
+          {rightColumnChildren}
+        </div>
+      </div>
+
+      {/* Full-width bottom sections */}
+      {bottomChildren}
+    </div>
+  );
+}

--- a/frontend/src/components/leads/LeadContentLayout.tsx
+++ b/frontend/src/components/leads/LeadContentLayout.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useRef, useCallback, type ReactNode } from 'react';
+import { useState, useMemo, useRef, useEffect, useCallback, type ReactNode } from 'react';
 import { User, Calendar, X } from 'lucide-react';
 import { InlineEditableField } from '@/components/common/InlineEditableField';
 import { RichTextDisplay } from '@/components/common/RichTextDisplay';
@@ -48,6 +48,7 @@ export interface LeadContentLayoutProps {
   onNextActionChange?: (value: string | null) => Promise<void>;
   onNextActionDateChange?: (value: string | null) => Promise<void>;
   onTagsChange?: (tags: string[]) => Promise<void>;
+  onCreatedAtChange?: (value: string | null) => Promise<void>;
 
   // Context-specific sections
   rightColumnChildren?: ReactNode;
@@ -145,24 +146,18 @@ function TagsEditor({
   }, [onChange, tags]);
 
   // Close dropdown on click outside
-  const handleClickOutside = useCallback((e: MouseEvent) => {
-    if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-      setEditing(false);
-      setDropdownOpen(false);
-      setSearch('');
-    }
-  }, []);
-
-  // Attach/detach click outside listener
-  const prevEditing = useRef(false);
-  if (editing !== prevEditing.current) {
-    if (editing) {
-      document.addEventListener('mousedown', handleClickOutside);
-    } else {
-      document.removeEventListener('mousedown', handleClickOutside);
-    }
-    prevEditing.current = editing;
-  }
+  useEffect(() => {
+    if (!editing) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setEditing(false);
+        setDropdownOpen(false);
+        setSearch('');
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [editing]);
 
   if (!onChange) {
     if (tags.length === 0) return null;
@@ -281,6 +276,7 @@ export function LeadContentLayout({
   onNextActionChange,
   onNextActionDateChange,
   onTagsChange,
+  onCreatedAtChange,
   rightColumnChildren,
   bottomChildren,
 }: LeadContentLayoutProps) {
@@ -493,16 +489,36 @@ export function LeadContentLayout({
             <TagsEditor tags={tags} onChange={onTagsChange} />
           </div>
 
-          {/* Created at (always read-only) */}
-          {createdAt && (
+          {/* Created at */}
+          {(onCreatedAtChange || createdAt) && (
             <div className="text-sm">
-              <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-1">
-                Aangemaakt
-              </h4>
-              <span className="inline-flex items-center gap-1.5 text-text-secondary">
-                <Calendar className="h-4 w-4" />
-                {formatDateLong(createdAt)}
-              </span>
+              {onCreatedAtChange ? (
+                <InlineEditableField
+                  type="date"
+                  label="Datum"
+                  value={createdAt}
+                  onSave={onCreatedAtChange}
+                  displayValue={
+                    createdAt ? (
+                      <span className="inline-flex items-center gap-1.5 text-text-secondary">
+                        <Calendar className="h-4 w-4" />
+                        {formatDateLong(createdAt)}
+                      </span>
+                    ) : undefined
+                  }
+                  placeholder="Kies een datum..."
+                />
+              ) : (
+                <>
+                  <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-1">
+                    Aangemaakt
+                  </h4>
+                  <span className="inline-flex items-center gap-1.5 text-text-secondary">
+                    <Calendar className="h-4 w-4" />
+                    {formatDateLong(createdAt!)}
+                  </span>
+                </>
+              )}
             </div>
           )}
         </div>

--- a/frontend/src/components/leads/LeadContentLayout.tsx
+++ b/frontend/src/components/leads/LeadContentLayout.tsx
@@ -312,7 +312,15 @@ export function LeadContentLayout({
           type="text"
           value={title}
           onSave={async (v) => { if (v) await onTitleChange(v); }}
-          displayValue={<span className="text-lg font-semibold text-text">{title}</span>}
+          displayValue={
+            title ? (
+              <span className="text-lg font-semibold text-text">{title}</span>
+            ) : (
+              <span className="text-lg italic text-text-secondary border-b border-dashed border-gray-300 pb-0.5">
+                Titel van de lead
+              </span>
+            )
+          }
           placeholder="Titel van de lead"
         />
       ) : (

--- a/frontend/src/components/leads/LeadDetailPanel.tsx
+++ b/frontend/src/components/leads/LeadDetailPanel.tsx
@@ -1,9 +1,7 @@
-import { useState, useMemo, useRef, useEffect } from 'react';
+import { useState, useMemo, useRef, useEffect, useCallback } from 'react';
 import {
   Trash2,
-  Pencil,
   User,
-  Calendar,
   Paperclip,
   Download,
   X,
@@ -20,19 +18,19 @@ import { Modal } from '@/components/common/Modal';
 import { ConfirmDialog } from '@/components/common/ConfirmDialog';
 import { Button } from '@/components/common/Button';
 import { CreatableSelect } from '@/components/common/CreatableSelect';
-import { RichTextFormField } from '@/components/common/RichTextFormField';
 import { RichTextEditor } from '@/components/common/RichTextEditor';
 import { RichTextDisplay } from '@/components/common/RichTextDisplay';
 import { createPerson } from '@/api/people';
 import { Badge } from '@/components/common/Badge';
 import { DetailSection } from '@/components/common/DetailSection';
-import { DetailMetadataGrid } from '@/components/common/DetailMetadataGrid';
 import { DetailModalFooter } from '@/components/common/DetailModalFooter';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
+import { LeadContentLayout } from '@/components/leads/LeadContentLayout';
 import {
   useLead,
   useUpdateLead,
   useDeleteLead,
+  useMoveLead,
   useCreateLeadActivity,
   useAddLeadContact,
   useRemoveLeadContact,
@@ -45,21 +43,16 @@ import {
   useRemoveTagFromLead,
 } from '@/hooks/useLeads';
 import { usePeople } from '@/hooks/usePeople';
-import { useInitiatieven, useCreateInitiatief } from '@/hooks/useInitiatieven';
 import { useNodes } from '@/hooks/useNodes';
 import { getLeadAttachmentDownloadUrl } from '@/api/leads';
-import { isOverdue, formatDateLong, timeAgo } from '@/utils/dates';
+import { timeAgo } from '@/utils/dates';
 import {
   LeadStage,
-  LEAD_STAGE_LABELS,
-  LEAD_STAGE_COLORS,
-  LEAD_STAGE_ORDER,
   LeadActivityType,
   LEAD_ACTIVITY_TYPE_LABELS,
-  INITIATIEF_COLORS,
   LEAD_CONTACT_ROL_LABELS,
 } from '@/types';
-import type { LeadUpdate, LeadActivityCreate } from '@/types';
+import type { LeadActivityCreate } from '@/types';
 
 interface LeadDetailPanelProps {
   leadId: string | null;
@@ -79,8 +72,6 @@ const ACTIVITY_ICONS: Record<LeadActivityType, React.ReactNode> = {
 export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPanelProps) {
   const { data: lead, isLoading } = useLead(leadId);
   const { data: people } = usePeople();
-  const { data: initiatieven } = useInitiatieven();
-  const createInitiatief = useCreateInitiatief();
   const { data: nodes } = useNodes();
 
   const contactPersonOptions = useMemo(
@@ -92,6 +83,7 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
   );
 
   const updateLead = useUpdateLead();
+  const moveLeadMutation = useMoveLead();
   const deleteLead = useDeleteLead();
   const createActivity = useCreateLeadActivity();
   const addContact = useAddLeadContact();
@@ -103,17 +95,6 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
   const { data: leadTags } = useLeadTags(leadId);
   const addTagToLead = useAddTagToLead();
   const removeTagFromLead = useRemoveTagFromLead();
-
-  const [editing, setEditing] = useState(false);
-  const [editTitle, setEditTitle] = useState('');
-  const [editDescription, setEditDescription] = useState('');
-  const [editOrganization, setEditOrganization] = useState('');
-  const [editStage, setEditStage] = useState<LeadStage>(LeadStage.VERKENNEN);
-  const [editAssignee, setEditAssignee] = useState('');
-  const [editNextAction, setEditNextAction] = useState('');
-  const [editNextActionDate, setEditNextActionDate] = useState('');
-  const [editInitiatiefId, setEditInitiatiefId] = useState('');
-  const [editTags, setEditTags] = useState('');
 
   // Activity form
   const [activityContent, setActivityContent] = useState('');
@@ -141,69 +122,74 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [lightboxSrc]);
 
+  // Inline save handlers
+  const handleSaveTitle = useCallback(async (value: string | null) => {
+    if (!lead || !value) return;
+    await updateLead.mutateAsync({ id: lead.id, data: { title: value } });
+  }, [lead, updateLead]);
+
+  const handleSaveStage = useCallback(async (stage: LeadStage) => {
+    if (!lead) return;
+    await moveLeadMutation.mutateAsync({ id: lead.id, stage });
+  }, [lead, moveLeadMutation]);
+
+  const handleSaveDescription = useCallback(async (value: string | null) => {
+    if (!lead) return;
+    await updateLead.mutateAsync({ id: lead.id, data: { description: value } });
+  }, [lead, updateLead]);
+
+  const handleSaveOrganization = useCallback(async (value: string | null) => {
+    if (!lead) return;
+    await updateLead.mutateAsync({ id: lead.id, data: { organization: value } });
+  }, [lead, updateLead]);
+
+  const handleSaveAssignee = useCallback(async (value: string | null) => {
+    if (!lead) return;
+    await updateLead.mutateAsync({ id: lead.id, data: { assignee_id: value } });
+  }, [lead, updateLead]);
+
+  const handleSaveBroughtBy = useCallback(async (value: string | null) => {
+    if (!lead) return;
+    await updateLead.mutateAsync({ id: lead.id, data: { brought_by_id: value } });
+  }, [lead, updateLead]);
+
+  const handleSaveInitiatief = useCallback(async (value: string | null) => {
+    if (!lead) return;
+    await updateLead.mutateAsync({ id: lead.id, data: { initiatief_id: value } });
+  }, [lead, updateLead]);
+
+  const handleSaveNextAction = useCallback(async (value: string | null) => {
+    if (!lead) return;
+    await updateLead.mutateAsync({ id: lead.id, data: { next_action: value } });
+  }, [lead, updateLead]);
+
+  const handleSaveNextActionDate = useCallback(async (value: string | null) => {
+    if (!lead) return;
+    await updateLead.mutateAsync({ id: lead.id, data: { next_action_date: value } });
+  }, [lead, updateLead]);
+
+  const handleSaveTags = useCallback(async (newTags: string[]) => {
+    if (!lead) return;
+    const currentNames = (leadTags ?? []).map((lt) => lt.tag.name);
+    const toRemove = (leadTags ?? []).filter((lt) => !newTags.includes(lt.tag.name));
+    const toAdd = newTags.filter((name) => !currentNames.includes(name));
+    for (const lt of toRemove) {
+      try {
+        await removeTagFromLead.mutateAsync({ leadId: lead.id, tagId: lt.tag.id });
+      } catch {
+        // Non-critical
+      }
+    }
+    for (const name of toAdd) {
+      try {
+        await addTagToLead.mutateAsync({ leadId: lead.id, data: { tag_name: name } });
+      } catch {
+        // Non-critical
+      }
+    }
+  }, [lead, leadTags, addTagToLead, removeTagFromLead]);
+
   if (!open) return null;
-
-  const startEditing = () => {
-    if (!lead) return;
-    setEditTitle(lead.title);
-    setEditDescription(lead.description ?? '');
-    setEditOrganization(lead.organization ?? '');
-    setEditStage(lead.stage);
-    setEditAssignee(lead.assignee_id ?? '');
-    setEditNextAction(lead.next_action ?? '');
-    setEditNextActionDate(lead.next_action_date ?? '');
-    setEditInitiatiefId(lead.initiatief_id ?? '');
-    setEditTags((leadTags ?? []).map((lt) => lt.tag.name).join(', '));
-    setEditing(true);
-  };
-
-  const saveEdit = async () => {
-    if (!lead) return;
-    const tagList = editTags
-      .split(',')
-      .map((t) => t.trim())
-      .filter(Boolean);
-
-    const data: LeadUpdate = {
-      title: editTitle.trim(),
-      description: editDescription.trim() || null,
-      organization: editOrganization.trim() || null,
-      stage: editStage,
-      assignee_id: editAssignee || null,
-      next_action: editNextAction.trim() || null,
-      next_action_date: editNextActionDate || null,
-      initiatief_id: editInitiatiefId || null,
-    };
-
-    // Update lead fields
-    updateLead.mutate(
-      { id: lead.id, data },
-      {
-        onSuccess: async () => {
-          // Sync tags: remove tags not in the new list, add new ones
-          const currentTagNames = (leadTags ?? []).map((lt) => lt.tag.name);
-          const toRemove = (leadTags ?? []).filter((lt) => !tagList.includes(lt.tag.name));
-          const toAdd = tagList.filter((name) => !currentTagNames.includes(name));
-
-          for (const lt of toRemove) {
-            try {
-              await removeTagFromLead.mutateAsync({ leadId: lead.id, tagId: lt.tag.id });
-            } catch {
-              // Non-critical
-            }
-          }
-          for (const name of toAdd) {
-            try {
-              await addTagToLead.mutateAsync({ leadId: lead.id, data: { tag_name: name } });
-            } catch {
-              // Non-critical
-            }
-          }
-          setEditing(false);
-        },
-      },
-    );
-  };
 
   const handleDelete = () => {
     if (!lead) return;
@@ -276,50 +262,30 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
     e.target.value = '';
   };
 
-  const overdue = lead?.next_action_date && isOverdue(lead.next_action_date);
-
   return (
     <>
     <Modal
       open={open}
       onClose={onClose}
-      title={isLoading ? 'Laden...' : lead?.title ?? 'Lead niet gevonden'}
-      size="lg"
+      title={isLoading ? 'Laden...' : 'Lead'}
+      size="xl"
       zIndex={zIndex}
       entityLabel="Lead"
       footer={
-        editing ? (
-          <div className="flex items-center justify-end gap-2">
-            <Button variant="ghost" onClick={() => setEditing(false)}>Annuleren</Button>
-            <Button onClick={saveEdit} loading={updateLead.isPending}>Opslaan</Button>
-          </div>
-        ) : (
-          <DetailModalFooter
-            onClose={onClose}
-            actions={
-              <div className="flex items-center gap-2">
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  icon={<Pencil className="h-4 w-4" />}
-                  onClick={startEditing}
-                  disabled={!lead}
-                >
-                  Bewerken
-                </Button>
-                <Button
-                  variant="danger"
-                  size="sm"
-                  icon={<Trash2 className="h-4 w-4" />}
-                  onClick={handleDelete}
-                  disabled={!lead}
-                >
-                  Verwijderen
-                </Button>
-              </div>
-            }
-          />
-        )
+        <DetailModalFooter
+          onClose={onClose}
+          actions={
+            <Button
+              variant="danger"
+              size="sm"
+              icon={<Trash2 className="h-4 w-4" />}
+              onClick={handleDelete}
+              disabled={!lead}
+            >
+              Verwijderen
+            </Button>
+          }
+        />
       }
     >
       {isLoading ? (
@@ -328,493 +294,325 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
         <div className="flex items-center justify-center py-8 text-text-secondary text-sm">
           Lead niet gevonden.
         </div>
-      ) : editing ? (
-        /* Edit mode */
-        <div className="space-y-4">
-          <div>
-            <label className="block text-sm font-medium text-text mb-1">Titel</label>
-            <input
-              type="text"
-              value={editTitle}
-              onChange={(e) => setEditTitle(e.target.value)}
-              className="w-full rounded-lg border border-border px-3 py-2 text-sm focus:outline-none focus:border-primary-400"
-            />
-          </div>
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <CreatableSelect
-                label="Stage"
-                value={editStage}
-                onChange={(v) => setEditStage(v as LeadStage)}
-                options={LEAD_STAGE_ORDER.map((s) => ({
-                  value: s,
-                  label: LEAD_STAGE_LABELS[s],
-                }))}
-                placeholder="Selecteer stage..."
-                searchable={false}
-              />
-            </div>
-            <div>
-              <CreatableSelect
-                label="Toegewezen aan"
-                value={editAssignee}
-                onChange={setEditAssignee}
-                options={[
-                  { value: '', label: 'Niet toegewezen' },
-                  ...(people?.map((p) => ({
-                    value: p.id,
-                    label: p.naam,
-                    description: p.functie ?? undefined,
-                  })) ?? []),
-                ]}
-                placeholder="Zoek een persoon..."
-                onCreate={async (name) => {
-                  const result = await createPerson({ naam: name }, true);
-                  return result?.id ?? null;
-                }}
-                createLabel="Nieuwe persoon aanmaken"
-                onClear={editAssignee ? () => setEditAssignee('') : undefined}
-              />
-            </div>
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-text mb-1">Organisatie</label>
-            <input
-              type="text"
-              value={editOrganization}
-              onChange={(e) => setEditOrganization(e.target.value)}
-              className="w-full rounded-lg border border-border px-3 py-2 text-sm focus:outline-none focus:border-primary-400"
-            />
-          </div>
-          <div>
-            <CreatableSelect
-              label="Initiatief"
-              value={editInitiatiefId}
-              onChange={setEditInitiatiefId}
-              options={[
-                { value: '', label: 'Geen initiatief' },
-                ...(initiatieven?.map((i) => ({ value: i.id, label: i.naam })) ?? []),
-              ]}
-              placeholder="Selecteer initiatief..."
-              onClear={editInitiatiefId ? () => setEditInitiatiefId('') : undefined}
-              onCreate={async (name) => {
-                const kleur = INITIATIEF_COLORS[Math.floor(Math.random() * INITIATIEF_COLORS.length)];
-                const result = await createInitiatief.mutateAsync({ naam: name, kleur });
-                return result.id;
-              }}
-              createLabel="Nieuw initiatief"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-text mb-1">Volgende actie</label>
-            <input
-              type="text"
-              value={editNextAction}
-              onChange={(e) => setEditNextAction(e.target.value)}
-              className="w-full rounded-lg border border-border px-3 py-2 text-sm focus:outline-none focus:border-primary-400"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-text mb-1">Actiedatum</label>
-            <input
-              type="date"
-              value={editNextActionDate}
-              onChange={(e) => setEditNextActionDate(e.target.value)}
-              className="w-full rounded-lg border border-border px-3 py-2 text-sm focus:outline-none focus:border-primary-400"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-text mb-1">Tags</label>
-            <input
-              type="text"
-              value={editTags}
-              onChange={(e) => setEditTags(e.target.value)}
-              className="w-full rounded-lg border border-border px-3 py-2 text-sm focus:outline-none focus:border-primary-400"
-              placeholder="Komma-gescheiden tags"
-            />
-          </div>
-          <RichTextFormField
-            label="Beschrijving"
-            value={editDescription}
-            onChange={setEditDescription}
-            rows={5}
-          />
-        </div>
       ) : (
-        /* View mode */
-        <div className="space-y-5">
-          {/* Stage badge + next action */}
-          <div className="flex items-center gap-2 flex-wrap">
-            <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${LEAD_STAGE_COLORS[lead.stage]}`}>
-              {LEAD_STAGE_LABELS[lead.stage]}
-            </span>
-            {lead.next_action_date && (
-              <span className={`inline-flex items-center gap-1 text-sm ${overdue ? 'text-red-600 font-medium bg-red-50 rounded-md px-2 py-0.5' : 'text-text-secondary'}`}>
-                <Calendar className="h-4 w-4" />
-                {formatDateLong(lead.next_action_date)}
-              </span>
-            )}
-          </div>
-
-          {/* Description */}
-          {lead.description && (
-            <DetailSection title="Beschrijving">
-              <div className="text-sm text-text">
-                <RichTextDisplay content={lead.description} />
-              </div>
-            </DetailSection>
-          )}
-
-          {/* Metadata */}
-          <DetailMetadataGrid
-            items={[
-              {
-                label: 'Organisatie',
-                value: lead.externe_organisatie?.naam ?? lead.organization ?? 'Onbekend',
-              },
-              {
-                label: 'Toegewezen aan',
-                value: lead.assignee ? (
-                  <span className="inline-flex items-center gap-1.5 text-text">
-                    <User className="h-4 w-4 text-text-secondary" />
-                    {lead.assignee.naam}
-                  </span>
-                ) : (
-                  <span className="text-text-secondary">Niet toegewezen</span>
-                ),
-              },
-              {
-                label: 'Binnengebracht door',
-                value: lead.brought_by ? (
-                  <span className="inline-flex items-center gap-1.5 text-text">
-                    <User className="h-4 w-4 text-text-secondary" />
-                    {lead.brought_by.naam}
-                  </span>
-                ) : (
-                  <span className="text-text-secondary">Onbekend</span>
-                ),
-              },
-              {
-                label: 'Initiatief',
-                value: lead.initiatief ? (
-                  <span
-                    className="inline-block rounded-full px-2 py-0.5 text-xs font-medium text-white"
-                    style={{ backgroundColor: lead.initiatief.kleur || '#6B7280' }}
+        <LeadContentLayout
+          title={lead.title}
+          stage={lead.stage}
+          description={lead.description}
+          organization={lead.externe_organisatie?.naam ?? lead.organization}
+          assigneeId={lead.assignee_id}
+          assigneeName={lead.assignee?.naam ?? null}
+          broughtById={lead.brought_by_id}
+          broughtByName={lead.brought_by?.naam ?? null}
+          initiatiefId={lead.initiatief_id}
+          initiatiefName={lead.initiatief?.naam ?? null}
+          initiatiefKleur={lead.initiatief?.kleur ?? null}
+          nextAction={lead.next_action}
+          nextActionDate={lead.next_action_date}
+          createdAt={lead.created_at}
+          tags={(leadTags ?? []).map((lt) => lt.tag.name)}
+          onTitleChange={handleSaveTitle}
+          onStageChange={handleSaveStage}
+          onDescriptionChange={handleSaveDescription}
+          onOrganizationChange={handleSaveOrganization}
+          onAssigneeChange={handleSaveAssignee}
+          onBroughtByChange={handleSaveBroughtBy}
+          onInitiatiefChange={handleSaveInitiatief}
+          onNextActionChange={handleSaveNextAction}
+          onNextActionDateChange={handleSaveNextActionDate}
+          onTagsChange={handleSaveTags}
+          rightColumnChildren={
+            <>
+              {/* Contactpersonen */}
+              <DetailSection
+                title="Contactpersonen"
+                icon={<User className="h-3.5 w-3.5" />}
+                count={lead.contacts.length}
+                separated
+                action={
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    icon={<Plus className="h-3.5 w-3.5" />}
+                    onClick={() => setShowAddContact(true)}
                   >
-                    {lead.initiatief.naam}
-                  </span>
-                ) : (
-                  '-'
-                ),
-              },
-              {
-                label: 'Volgende actie',
-                value: lead.next_action ?? '-',
-              },
-              {
-                label: 'Aangemaakt',
-                value: formatDateLong(lead.created_at),
-                icon: <Calendar className="h-4 w-4" />,
-              },
-            ]}
-          />
-
-          {/* Tags */}
-          {(leadTags ?? []).length > 0 && (
-            <DetailSection title="Tags">
-              <div className="flex flex-wrap gap-1.5">
-                {(leadTags ?? []).map((lt) => (
-                  <Badge key={lt.id} variant="gray">{lt.tag.name}</Badge>
-                ))}
-              </div>
-            </DetailSection>
-          )}
-
-          {/* Bijlagen */}
-          <DetailSection
-            title="Bijlagen"
-            icon={<Paperclip className="h-3.5 w-3.5" />}
-            count={lead.attachments.length}
-            separated
-            action={
-              <label className="cursor-pointer">
-                <input
-                  type="file"
-                  multiple
-                  className="hidden"
-                  ref={fileInputRef}
-                  onChange={handleFileUpload}
-                />
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  icon={<Upload className="h-3.5 w-3.5" />}
-                  onClick={() => fileInputRef.current?.click()}
-                >
-                  Uploaden
-                </Button>
-              </label>
-            }
-          >
-            {lead.attachments.length > 0 ? (
-              <div className="space-y-1">
-                {lead.attachments.map((att) => (
-                  <div key={att.id}>
-                    <div className={`flex items-center gap-2 text-sm rounded-lg px-2 py-1.5 hover:bg-gray-50 ${!att.bestand_beschikbaar ? 'opacity-50' : ''}`}>
-                      <Paperclip className="h-3.5 w-3.5 text-text-secondary shrink-0" />
-                      <span className="flex-1 truncate text-text">{att.bestandsnaam}</span>
-                      {!att.bestand_beschikbaar ? (
-                        <span className="text-xs text-red-500">Bestand niet beschikbaar</span>
-                      ) : (
-                        <>
-                          <span className="text-xs text-text-secondary">{Math.round(att.bestandsgrootte / 1024)} KB</span>
-                          <a
-                            href={getLeadAttachmentDownloadUrl(lead.id, att.id)}
-                            className="p-1 text-text-secondary hover:text-primary-600 transition-colors"
-                            title="Downloaden"
-                          >
-                            <Download className="h-3.5 w-3.5" />
-                          </a>
-                        </>
-                      )}
-                      <button
-                        onClick={() => deleteAttachment.mutate({ leadId: lead.id, attachmentId: att.id })}
-                        className="p-1 text-text-secondary hover:text-red-500 transition-colors"
-                        title="Verwijderen"
-                      >
-                        <X className="h-3.5 w-3.5" />
-                      </button>
-                    </div>
-                    {att.bestand_beschikbaar && att.content_type?.startsWith('image/') && (
-                      <button
-                        onClick={() => setLightboxSrc({
-                          src: getLeadAttachmentDownloadUrl(lead.id, att.id),
-                          alt: att.bestandsnaam,
-                        })}
-                        className="relative group mt-2 ml-2 block"
-                      >
-                        <img
-                          src={getLeadAttachmentDownloadUrl(lead.id, att.id)}
-                          alt={att.bestandsnaam}
-                          className="rounded-lg border border-border max-h-48 object-contain"
-                        />
-                        <div className="absolute inset-0 rounded-lg bg-black/0 group-hover:bg-black/20 transition-colors flex items-center justify-center">
-                          <ZoomIn className="h-6 w-6 text-white opacity-0 group-hover:opacity-100 transition-opacity drop-shadow-md" />
-                        </div>
-                      </button>
-                    )}
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <p className="text-sm text-text-secondary">Geen bijlagen</p>
-            )}
-          </DetailSection>
-
-          {/* Contactpersonen */}
-          <DetailSection
-            title="Contactpersonen"
-            icon={<User className="h-3.5 w-3.5" />}
-            count={lead.contacts.length}
-            separated
-            action={
-              <Button
-                variant="ghost"
-                size="sm"
-                icon={<Plus className="h-3.5 w-3.5" />}
-                onClick={() => setShowAddContact(true)}
-              >
-                Toevoegen
-              </Button>
-            }
-          >
-            {lead.contacts.length > 0 ? (
-              <div className="space-y-1">
-                {lead.contacts.map((contact) => (
-                  <div key={contact.id} className="flex items-center gap-2 text-sm rounded-lg px-2 py-1.5 hover:bg-gray-50">
-                    <User className="h-3.5 w-3.5 text-text-secondary shrink-0" />
-                    <span className="flex-1 text-text">{contact.person_naam}</span>
-                    <Badge variant="gray">{LEAD_CONTACT_ROL_LABELS[contact.rol] ?? contact.rol}</Badge>
-                    <button
-                      onClick={() => removeContact.mutate({ leadId: lead.id, contactId: contact.id })}
-                      className="p-1 text-text-secondary hover:text-red-500 transition-colors"
-                      title="Verwijderen"
-                    >
-                      <X className="h-3.5 w-3.5" />
-                    </button>
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <p className="text-sm text-text-secondary">Geen contactpersonen</p>
-            )}
-
-            {showAddContact && (
-              <div className="space-y-2 mt-2">
-                <div className="flex items-end gap-2">
-                  <div className="flex-1">
-                    <CreatableSelect
-                      value={contactPersonId}
-                      onChange={setContactPersonId}
-                      options={contactPersonOptions}
-                      placeholder="Zoek of typ een naam..."
-                      onCreate={async (name) => {
-                        const newPerson = await createPerson({ naam: name }, true);
-                        return newPerson.id;
-                      }}
-                      createLabel="Nieuw contact"
-                    />
-                  </div>
-                  <input
-                    type="text"
-                    value={contactRol}
-                    onChange={(e) => setContactRol(e.target.value)}
-                    placeholder="Rol"
-                    className="w-32 rounded-lg border border-border px-2 py-1.5 text-sm focus:outline-none focus:border-primary-400"
-                  />
-                </div>
-                <div className="flex items-center gap-2">
-                  <Button size="sm" onClick={handleAddContact} disabled={!contactPersonId}>
                     Toevoegen
                   </Button>
-                  <Button variant="ghost" size="sm" onClick={() => setShowAddContact(false)}>
-                    Annuleren
-                  </Button>
-                </div>
-              </div>
-            )}
-          </DetailSection>
-
-          {/* Gelinkte nodes */}
-          <DetailSection
-            title="Gelinkte nodes"
-            icon={<LinkIcon className="h-3.5 w-3.5" />}
-            count={lead.linked_nodes.length}
-            separated
-            action={
-              <Button
-                variant="ghost"
-                size="sm"
-                icon={<Plus className="h-3.5 w-3.5" />}
-                onClick={() => setShowLinkNode(true)}
+                }
               >
-                Koppelen
-              </Button>
-            }
-          >
-            {lead.linked_nodes.length > 0 ? (
-              <div className="space-y-1">
-                {lead.linked_nodes.map((ln) => (
-                  <div key={ln.id} className="flex items-center gap-2 text-sm rounded-lg px-2 py-1.5 hover:bg-gray-50">
-                    <LinkIcon className="h-3.5 w-3.5 text-text-secondary shrink-0" />
-                    <span className="flex-1 text-text">{ln.node_title}</span>
-                    <Badge variant="gray">{ln.node_type}</Badge>
-                    <button
-                      onClick={() => unlinkNode.mutate({ leadId: lead.id, linkId: ln.id })}
-                      className="p-1 text-text-secondary hover:text-red-500 transition-colors"
-                      title="Ontkoppelen"
+                {lead.contacts.length > 0 ? (
+                  <div className="space-y-1">
+                    {lead.contacts.map((contact) => (
+                      <div key={contact.id} className="flex items-center gap-2 text-sm rounded-lg px-2 py-1.5 hover:bg-gray-50">
+                        <User className="h-3.5 w-3.5 text-text-secondary shrink-0" />
+                        <span className="flex-1 text-text">{contact.person_naam}</span>
+                        <Badge variant="gray">{LEAD_CONTACT_ROL_LABELS[contact.rol] ?? contact.rol}</Badge>
+                        <button
+                          onClick={() => removeContact.mutate({ leadId: lead.id, contactId: contact.id })}
+                          className="p-1 text-text-secondary hover:text-red-500 transition-colors"
+                          title="Verwijderen"
+                        >
+                          <X className="h-3.5 w-3.5" />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-sm text-text-secondary">Geen contactpersonen</p>
+                )}
+
+                {showAddContact && (
+                  <div className="space-y-2 mt-2">
+                    <div className="flex items-end gap-2">
+                      <div className="flex-1">
+                        <CreatableSelect
+                          value={contactPersonId}
+                          onChange={setContactPersonId}
+                          options={contactPersonOptions}
+                          placeholder="Zoek of typ een naam..."
+                          onCreate={async (name) => {
+                            const newPerson = await createPerson({ naam: name }, true);
+                            return newPerson.id;
+                          }}
+                          createLabel="Nieuw contact"
+                        />
+                      </div>
+                      <input
+                        type="text"
+                        value={contactRol}
+                        onChange={(e) => setContactRol(e.target.value)}
+                        placeholder="Rol"
+                        className="w-32 rounded-lg border border-border px-2 py-1.5 text-sm focus:outline-none focus:border-primary-400"
+                      />
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Button size="sm" onClick={handleAddContact} disabled={!contactPersonId}>
+                        Toevoegen
+                      </Button>
+                      <Button variant="ghost" size="sm" onClick={() => setShowAddContact(false)}>
+                        Annuleren
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </DetailSection>
+
+              {/* Gelinkte nodes */}
+              <DetailSection
+                title="Gelinkte nodes"
+                icon={<LinkIcon className="h-3.5 w-3.5" />}
+                count={lead.linked_nodes.length}
+                separated
+                action={
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    icon={<Plus className="h-3.5 w-3.5" />}
+                    onClick={() => setShowLinkNode(true)}
+                  >
+                    Koppelen
+                  </Button>
+                }
+              >
+                {lead.linked_nodes.length > 0 ? (
+                  <div className="space-y-1">
+                    {lead.linked_nodes.map((ln) => (
+                      <div key={ln.id} className="flex items-center gap-2 text-sm rounded-lg px-2 py-1.5 hover:bg-gray-50">
+                        <LinkIcon className="h-3.5 w-3.5 text-text-secondary shrink-0" />
+                        <span className="flex-1 text-text">{ln.node_title}</span>
+                        <Badge variant="gray">{ln.node_type}</Badge>
+                        <button
+                          onClick={() => unlinkNode.mutate({ leadId: lead.id, linkId: ln.id })}
+                          className="p-1 text-text-secondary hover:text-red-500 transition-colors"
+                          title="Ontkoppelen"
+                        >
+                          <X className="h-3.5 w-3.5" />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-sm text-text-secondary">Geen gelinkte nodes</p>
+                )}
+
+                {showLinkNode && (
+                  <div className="flex items-center gap-2 mt-2">
+                    <div className="flex-1">
+                      <CreatableSelect
+                        value={linkNodeId}
+                        onChange={setLinkNodeId}
+                        options={nodes?.map((n) => ({
+                          value: n.id,
+                          label: n.title,
+                          description: n.node_type?.replace(/_/g, ' ') ?? undefined,
+                        })) ?? []}
+                        placeholder="Zoek een node..."
+                      />
+                    </div>
+                    <Button size="sm" onClick={handleLinkNode} disabled={!linkNodeId}>
+                      Koppelen
+                    </Button>
+                    <Button variant="ghost" size="sm" onClick={() => setShowLinkNode(false)}>
+                      Annuleren
+                    </Button>
+                  </div>
+                )}
+              </DetailSection>
+            </>
+          }
+          bottomChildren={
+            <>
+              {/* Bijlagen */}
+              <DetailSection
+                title="Bijlagen"
+                icon={<Paperclip className="h-3.5 w-3.5" />}
+                count={lead.attachments.length}
+                separated
+                action={
+                  <label className="cursor-pointer">
+                    <input
+                      type="file"
+                      multiple
+                      className="hidden"
+                      ref={fileInputRef}
+                      onChange={handleFileUpload}
+                    />
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      icon={<Upload className="h-3.5 w-3.5" />}
+                      onClick={() => fileInputRef.current?.click()}
                     >
-                      <X className="h-3.5 w-3.5" />
-                    </button>
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <p className="text-sm text-text-secondary">Geen gelinkte nodes</p>
-            )}
-
-            {showLinkNode && (
-              <div className="flex items-center gap-2 mt-2">
-                <div className="flex-1">
-                  <CreatableSelect
-                    value={linkNodeId}
-                    onChange={setLinkNodeId}
-                    options={nodes?.map((n) => ({
-                      value: n.id,
-                      label: n.title,
-                      description: n.node_type?.replace(/_/g, ' ') ?? undefined,
-                    })) ?? []}
-                    placeholder="Zoek een node..."
-                  />
-                </div>
-                <Button size="sm" onClick={handleLinkNode} disabled={!linkNodeId}>
-                  Koppelen
-                </Button>
-                <Button variant="ghost" size="sm" onClick={() => setShowLinkNode(false)}>
-                  Annuleren
-                </Button>
-              </div>
-            )}
-          </DetailSection>
-
-          {/* Activiteiten */}
-          <DetailSection
-            title="Activiteiten"
-            icon={<MessageSquare className="h-3.5 w-3.5" />}
-            count={lead.activities.length}
-            separated
-          >
-            {/* Add activity form */}
-            <div className="space-y-2 mb-4">
-              <RichTextEditor
-                value={activityContent}
-                onChange={setActivityContent}
-                placeholder="Voeg een notitie of activiteit toe... Gebruik @ voor personen, # voor nodes/taken"
-                rows={2}
-              />
-              <div className="flex items-center gap-2">
-                <div className="w-36">
-                  <CreatableSelect
-                    value={activityType}
-                    onChange={(v) => setActivityType(v as LeadActivityType)}
-                    options={Object.entries(LEAD_ACTIVITY_TYPE_LABELS)
-                      .filter(([value]) => value !== LeadActivityType.STAGE_CHANGE)
-                      .map(([value, label]) => ({ value, label }))}
-                    placeholder="Type..."
-                    searchable={false}
-                  />
-                </div>
-                <Button
-                  size="sm"
-                  onClick={handleAddActivity}
-                  disabled={isActivityEmpty}
-                  loading={createActivity.isPending}
-                >
-                  Toevoegen
-                </Button>
-              </div>
-            </div>
-
-            {/* Activity list */}
-            {lead.activities.length > 0 ? (
-              <div className="space-y-3">
-                {[...lead.activities].reverse().map((activity) => (
-                  <div key={activity.id} className="flex gap-2.5">
-                    <div className="mt-0.5 flex items-center justify-center h-6 w-6 rounded-full bg-gray-100 text-text-secondary shrink-0">
-                      {ACTIVITY_ICONS[activity.activity_type]}
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2 text-xs text-text-secondary">
-                        {activity.author_naam && (
-                          <span className="font-medium text-text">{activity.author_naam}</span>
+                      Uploaden
+                    </Button>
+                  </label>
+                }
+              >
+                {lead.attachments.length > 0 ? (
+                  <div className="space-y-1">
+                    {lead.attachments.map((att) => (
+                      <div key={att.id}>
+                        <div className={`flex items-center gap-2 text-sm rounded-lg px-2 py-1.5 hover:bg-gray-50 ${!att.bestand_beschikbaar ? 'opacity-50' : ''}`}>
+                          <Paperclip className="h-3.5 w-3.5 text-text-secondary shrink-0" />
+                          <span className="flex-1 truncate text-text">{att.bestandsnaam}</span>
+                          {!att.bestand_beschikbaar ? (
+                            <span className="text-xs text-red-500">Bestand niet beschikbaar</span>
+                          ) : (
+                            <>
+                              <span className="text-xs text-text-secondary">{Math.round(att.bestandsgrootte / 1024)} KB</span>
+                              <a
+                                href={getLeadAttachmentDownloadUrl(lead.id, att.id)}
+                                className="p-1 text-text-secondary hover:text-primary-600 transition-colors"
+                                title="Downloaden"
+                              >
+                                <Download className="h-3.5 w-3.5" />
+                              </a>
+                            </>
+                          )}
+                          <button
+                            onClick={() => deleteAttachment.mutate({ leadId: lead.id, attachmentId: att.id })}
+                            className="p-1 text-text-secondary hover:text-red-500 transition-colors"
+                            title="Verwijderen"
+                          >
+                            <X className="h-3.5 w-3.5" />
+                          </button>
+                        </div>
+                        {att.bestand_beschikbaar && att.content_type?.startsWith('image/') && (
+                          <button
+                            onClick={() => setLightboxSrc({
+                              src: getLeadAttachmentDownloadUrl(lead.id, att.id),
+                              alt: att.bestandsnaam,
+                            })}
+                            className="relative group mt-2 ml-2 block"
+                          >
+                            <img
+                              src={getLeadAttachmentDownloadUrl(lead.id, att.id)}
+                              alt={att.bestandsnaam}
+                              className="rounded-lg border border-border max-h-48 object-contain"
+                            />
+                            <div className="absolute inset-0 rounded-lg bg-black/0 group-hover:bg-black/20 transition-colors flex items-center justify-center">
+                              <ZoomIn className="h-6 w-6 text-white opacity-0 group-hover:opacity-100 transition-opacity drop-shadow-md" />
+                            </div>
+                          </button>
                         )}
-                        <Badge variant="gray">
-                          {LEAD_ACTIVITY_TYPE_LABELS[activity.activity_type]}
-                        </Badge>
-                        <span>{timeAgo(activity.created_at)}</span>
                       </div>
-                      <div className="mt-0.5">
-                        <RichTextDisplay content={activity.content} fallback="" />
-                      </div>
-                    </div>
+                    ))}
                   </div>
-                ))}
-              </div>
-            ) : (
-              <p className="text-sm text-text-secondary">Nog geen activiteiten</p>
-            )}
-          </DetailSection>
-        </div>
+                ) : (
+                  <p className="text-sm text-text-secondary">Geen bijlagen</p>
+                )}
+              </DetailSection>
+
+              {/* Activiteiten */}
+              <DetailSection
+                title="Activiteiten"
+                icon={<MessageSquare className="h-3.5 w-3.5" />}
+                count={lead.activities.length}
+                separated
+              >
+                {/* Add activity form */}
+                <div className="space-y-2 mb-4">
+                  <RichTextEditor
+                    value={activityContent}
+                    onChange={setActivityContent}
+                    placeholder="Voeg een notitie of activiteit toe... Gebruik @ voor personen, # voor nodes/taken"
+                    rows={2}
+                  />
+                  <div className="flex items-center gap-2">
+                    <div className="w-36">
+                      <CreatableSelect
+                        value={activityType}
+                        onChange={(v) => setActivityType(v as LeadActivityType)}
+                        options={Object.entries(LEAD_ACTIVITY_TYPE_LABELS)
+                          .filter(([value]) => value !== LeadActivityType.STAGE_CHANGE)
+                          .map(([value, label]) => ({ value, label }))}
+                        placeholder="Type..."
+                        searchable={false}
+                      />
+                    </div>
+                    <Button
+                      size="sm"
+                      onClick={handleAddActivity}
+                      disabled={isActivityEmpty}
+                      loading={createActivity.isPending}
+                    >
+                      Toevoegen
+                    </Button>
+                  </div>
+                </div>
+
+                {/* Activity list */}
+                {lead.activities.length > 0 ? (
+                  <div className="space-y-3">
+                    {[...lead.activities].reverse().map((activity) => (
+                      <div key={activity.id} className="flex gap-2.5">
+                        <div className="mt-0.5 flex items-center justify-center h-6 w-6 rounded-full bg-gray-100 text-text-secondary shrink-0">
+                          {ACTIVITY_ICONS[activity.activity_type]}
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2 text-xs text-text-secondary">
+                            {activity.author_naam && (
+                              <span className="font-medium text-text">{activity.author_naam}</span>
+                            )}
+                            <Badge variant="gray">
+                              {LEAD_ACTIVITY_TYPE_LABELS[activity.activity_type]}
+                            </Badge>
+                            <span>{timeAgo(activity.created_at)}</span>
+                          </div>
+                          <div className="mt-0.5">
+                            <RichTextDisplay content={activity.content} fallback="" />
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-sm text-text-secondary">Nog geen activiteiten</p>
+                )}
+              </DetailSection>
+            </>
+          }
+        />
       )}
     </Modal>
 

--- a/frontend/src/components/leads/LeadIntakeDialog.tsx
+++ b/frontend/src/components/leads/LeadIntakeDialog.tsx
@@ -645,32 +645,36 @@ export function LeadIntakeDialog({ open, onClose, defaultInitiatiefId, sharedPar
                       </div>
                     )}
 
-                    <CreatableSelect
-                      label={index === 0 ? "Contactpersoon (extern)" : "Contactpersoon"}
-                      value={contact.personId}
-                      onChange={(val) => {
-                        const person = people?.find((p) => p.id === val);
-                        updateContact(index, { personId: val, name: person?.naam ?? contact.name });
-                      }}
-                      options={contactOptions}
-                      placeholder="Zoek of typ een naam..."
-                      onCreate={async (name) => {
-                        updateContact(index, { name, personId: '' });
-                        return null;
-                      }}
-                      createLabel="Nieuw contact"
-                      displayValue={!contact.personId && contact.name ? contact.name : undefined}
-                      onClear={() => {
-                        updateContact(index, emptyContact());
-                      }}
-                    />
+                    <div>
+                      <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-1">
+                        {index === 0 ? "Contactpersoon (extern)" : "Contactpersoon"}
+                      </h4>
+                      <CreatableSelect
+                        value={contact.personId}
+                        onChange={(val) => {
+                          const person = people?.find((p) => p.id === val);
+                          updateContact(index, { personId: val, name: person?.naam ?? contact.name });
+                        }}
+                        options={contactOptions}
+                        placeholder="Zoek of typ een naam..."
+                        onCreate={async (name) => {
+                          updateContact(index, { name, personId: '' });
+                          return null;
+                        }}
+                        createLabel="Nieuw contact"
+                        displayValue={!contact.personId && contact.name ? contact.name : undefined}
+                        onClear={() => {
+                          updateContact(index, emptyContact());
+                        }}
+                      />
+                    </div>
 
                     {(contact.personId || contact.name) && (
                       <div className="grid grid-cols-2 gap-3">
                         <div>
-                          <label className="block text-sm font-medium text-text mb-1">
+                          <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-1">
                             E-mail
-                          </label>
+                          </h4>
                           <input
                             type="email"
                             value={contact.email}
@@ -680,9 +684,9 @@ export function LeadIntakeDialog({ open, onClose, defaultInitiatiefId, sharedPar
                           />
                         </div>
                         <div>
-                          <label className="block text-sm font-medium text-text mb-1">
+                          <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-1">
                             Telefoon
-                          </label>
+                          </h4>
                           <input
                             type="tel"
                             value={contact.phone}

--- a/frontend/src/components/leads/LeadIntakeDialog.tsx
+++ b/frontend/src/components/leads/LeadIntakeDialog.tsx
@@ -4,10 +4,9 @@ import { Modal } from '@/components/common/Modal';
 import { Button } from '@/components/common/Button';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
 import { CreatableSelect } from '@/components/common/CreatableSelect';
-import { RichTextFormField } from '@/components/common/RichTextFormField';
+import { LeadContentLayout } from '@/components/leads/LeadContentLayout';
 import { useCreateLead, useParseLeadIntake, useCheckDuplicates } from '@/hooks/useLeads';
 import { addTagToLead as addTagToLeadApi, uploadLeadAttachment as uploadLeadAttachmentApi, addLeadContact as addLeadContactApi } from '@/api/leads';
-import { useTags } from '@/hooks/useTags';
 import { isEmailFile, parseEmailFile, emailToRawText } from '@/utils/emailParser';
 import type { ParsedEmail } from '@/utils/emailParser';
 import { useToast } from '@/contexts/ToastContext';
@@ -16,9 +15,8 @@ import { useInitiatieven, useCreateInitiatief } from '@/hooks/useInitiatieven';
 import { createPerson } from '@/api/people';
 import { useCurrentPerson } from '@/contexts/CurrentPersonContext';
 import { useLeadDetail } from '@/contexts/LeadDetailContext';
-import { LeadStage, LEAD_STAGE_ORDER, LEAD_STAGE_LABELS, LEAD_STAGE_COLORS, INITIATIEF_COLORS, formatFunctie } from '@/types';
+import { LeadStage, LEAD_STAGE_LABELS, INITIATIEF_COLORS, formatFunctie } from '@/types';
 import type { LeadParseResult } from '@/types';
-import { buildPersonOptions } from '@/utils/personOptions';
 
 interface LeadIntakeDialogProps {
   open: boolean;
@@ -65,8 +63,6 @@ export function LeadIntakeDialog({ open, onClose, defaultInitiatiefId, sharedPar
   const [organization, setOrganization] = useState('');
   const [description, setDescription] = useState('');
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
-  const [tagSearch, setTagSearch] = useState('');
-  const [tagDropdownOpen, setTagDropdownOpen] = useState(false);
   const [stage, setStage] = useState<LeadStage>(LeadStage.INBOX);
   const [contacts, setContacts] = useState<ContactEntry[]>([emptyContact()]);
   const updateContact = useCallback((index: number, updates: Partial<ContactEntry>) => {
@@ -84,20 +80,8 @@ export function LeadIntakeDialog({ open, onClose, defaultInitiatiefId, sharedPar
   const { data: initiatieven } = useInitiatieven();
   const createInitiatiefMutation = useCreateInitiatief();
   const { data: people } = usePeople();
-  const { data: allTags } = useTags();
   const { openLeadDetail } = useLeadDetail();
   const { data: duplicates } = useCheckDuplicates(title, organization || undefined);
-  const tagContainerRef = useRef<HTMLDivElement>(null);
-
-  // Assignee options: current person first (with "(mij)")
-  const assigneeOptions = useMemo(
-    () => buildPersonOptions(people ?? [], currentPerson, (p) => ({
-      value: p.id,
-      label: p.naam,
-      description: formatFunctie(p.functie),
-    })),
-    [people, currentPerson],
-  );
 
   // Contact options: plain alphabetical, no "mij" at top
   const contactOptions = useMemo(
@@ -268,26 +252,6 @@ export function LeadIntakeDialog({ open, onClose, defaultInitiatiefId, sharedPar
     }
   }, [firstContactName, people, updateContact]);
 
-  // Filter tags for search dropdown
-  const filteredTags = useMemo(
-    () =>
-      (allTags ?? [])
-        .filter((t) => !selectedTags.includes(t.name))
-        .filter((t) => (tagSearch ? t.name.toLowerCase().includes(tagSearch.toLowerCase()) : false)),
-    [allTags, selectedTags, tagSearch],
-  );
-
-  // Close tag dropdown on click outside
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (tagContainerRef.current && !tagContainerRef.current.contains(e.target as Node)) {
-        setTagDropdownOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
-
   const reset = useCallback(() => {
     setStep('input');
     setRawText('');
@@ -300,8 +264,6 @@ export function LeadIntakeDialog({ open, onClose, defaultInitiatiefId, sharedPar
     setOrganization('');
     setDescription('');
     setSelectedTags([]);
-    setTagSearch('');
-    setTagDropdownOpen(false);
     setStage(LeadStage.INBOX);
     setContacts([emptyContact()]);
     setAssigneeId('');
@@ -616,287 +578,143 @@ export function LeadIntakeDialog({ open, onClose, defaultInitiatiefId, sharedPar
             </p>
           )}
 
-          {/* Two-column layout */}
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4">
-            {/* LEFT COLUMN: Lead info */}
-            <div className="space-y-4">
-              <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wide">Lead</h4>
-
-              <div>
-                <label className="block text-sm font-medium text-text mb-1">
-                  Titel <span className="text-red-500">*</span>
-                </label>
-                <input
-                  type="text"
-                  value={title}
-                  onChange={(e) => setTitle(e.target.value)}
-                  className="w-full rounded-lg border border-border px-3 py-2 text-sm focus:outline-none focus:border-primary-400"
-                  placeholder="Titel van de lead"
-                  autoFocus
-                />
-              </div>
-
-              {duplicates && duplicates.length > 0 && (
-                <div className="rounded-lg border border-amber-200 bg-amber-50 p-3">
-                  <p className="text-sm font-medium text-amber-800 mb-1">
-                    Vergelijkbare leads gevonden:
-                  </p>
-                  <ul className="space-y-1">
-                    {duplicates.map((d) => (
-                      <li key={d.id} className="text-sm">
-                        <button
-                          type="button"
-                          onClick={() => { openLeadDetail(d.id); handleClose(); }}
-                          className="text-primary-600 hover:underline"
-                        >
-                          {d.title}
-                        </button>
-                        <span className="text-text-secondary ml-1">
-                          ({d.organization ?? 'geen organisatie'} - {LEAD_STAGE_LABELS[d.stage as LeadStage]})
-                        </span>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-
-              <div>
-                <label className="block text-sm font-medium text-text mb-1">
-                  Status
-                </label>
-                <div className="flex flex-wrap gap-1.5">
-                  {LEAD_STAGE_ORDER.map((s) => (
+          {duplicates && duplicates.length > 0 && (
+            <div className="rounded-lg border border-amber-200 bg-amber-50 p-3">
+              <p className="text-sm font-medium text-amber-800 mb-1">
+                Vergelijkbare leads gevonden:
+              </p>
+              <ul className="space-y-1">
+                {duplicates.map((d) => (
+                  <li key={d.id} className="text-sm">
                     <button
-                      key={s}
                       type="button"
-                      onClick={() => setStage(s)}
-                      className={`rounded-full px-3 py-1 text-xs font-medium transition-all ${
-                        stage === s
-                          ? `${LEAD_STAGE_COLORS[s]} ring-2 ring-offset-1 ring-current`
-                          : 'bg-gray-100 text-text-secondary hover:bg-gray-200'
-                      }`}
+                      onClick={() => { openLeadDetail(d.id); handleClose(); }}
+                      className="text-primary-600 hover:underline"
                     >
-                      {LEAD_STAGE_LABELS[s]}
+                      {d.title}
                     </button>
-                  ))}
-                </div>
-              </div>
-
-              <div className="grid grid-cols-2 gap-3">
-                <div>
-                  <label className="block text-sm font-medium text-text mb-1">
-                    Datum
-                  </label>
-                  <input
-                    type="date"
-                    value={leadDate}
-                    onChange={(e) => setLeadDate(e.target.value)}
-                    className="w-full rounded-lg border border-border px-3 py-2 text-sm focus:outline-none focus:border-primary-400"
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-text mb-1">
-                    Organisatie
-                  </label>
-                  <input
-                    type="text"
-                    value={organization}
-                    onChange={(e) => setOrganization(e.target.value)}
-                    className="w-full rounded-lg border border-border px-3 py-2 text-sm focus:outline-none focus:border-primary-400"
-                    placeholder="Naam van de organisatie"
-                  />
-                </div>
-              </div>
-
-              <RichTextFormField
-                label="Beschrijving"
-                value={description}
-                onChange={setDescription}
-                rows={5}
-                placeholder="Korte beschrijving... Gebruik @ voor personen, # voor nodes/taken"
-              />
-
-              <div>
-                <label className="block text-sm font-medium text-text mb-1">
-                  Tags
-                </label>
-
-                {/* Selected tags as removable chips */}
-                {selectedTags.length > 0 && (
-                  <div className="flex flex-wrap gap-1.5 mb-2">
-                    {selectedTags.map((tag) => (
-                      <span
-                        key={tag}
-                        title={tag}
-                        className="inline-flex items-center gap-1 rounded-full bg-slate-100 text-slate-700 px-2.5 py-0.5 text-xs font-medium"
-                      >
-                        {tag.includes('/') ? tag.split('/').pop() : tag}
-                        <button
-                          type="button"
-                          onClick={() => setSelectedTags((prev) => prev.filter((t) => t !== tag))}
-                          className="hover:text-red-500"
-                        >
-                          <X className="h-3 w-3" />
-                        </button>
-                      </span>
-                    ))}
-                  </div>
-                )}
-
-                {/* Search input for adding tags */}
-                <div className="relative" ref={tagContainerRef}>
-                  <input
-                    type="text"
-                    value={tagSearch}
-                    onChange={(e) => {
-                      setTagSearch(e.target.value);
-                      setTagDropdownOpen(true);
-                    }}
-                    onFocus={() => { if (tagSearch) setTagDropdownOpen(true); }}
-                    placeholder="Zoek of typ een tag..."
-                    className="w-full rounded-lg border border-border px-3 py-2 text-sm focus:outline-none focus:border-primary-400"
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' && tagSearch.trim()) {
-                        e.preventDefault();
-                        if (!selectedTags.includes(tagSearch.trim())) {
-                          setSelectedTags((prev) => [...prev, tagSearch.trim()]);
-                        }
-                        setTagSearch('');
-                        setTagDropdownOpen(false);
-                      }
-                    }}
-                  />
-
-                  {/* Dropdown with matching existing tags */}
-                  {tagDropdownOpen && tagSearch && filteredTags.length > 0 && (
-                    <div className="absolute z-10 mt-1 w-full bg-white border border-border rounded-lg shadow-lg max-h-40 overflow-y-auto">
-                      {filteredTags.slice(0, 10).map((tag) => (
-                        <button
-                          key={tag.id}
-                          type="button"
-                          onClick={() => {
-                            setSelectedTags((prev) => [...prev, tag.name]);
-                            setTagSearch('');
-                            setTagDropdownOpen(false);
-                          }}
-                          className="w-full text-left px-3 py-2 text-sm hover:bg-gray-50 transition-colors"
-                        >
-                          {tag.name}
-                        </button>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              </div>
+                    <span className="text-text-secondary ml-1">
+                      ({d.organization ?? 'geen organisatie'} - {LEAD_STAGE_LABELS[d.stage as LeadStage]})
+                    </span>
+                  </li>
+                ))}
+              </ul>
             </div>
-
-            {/* RIGHT COLUMN: People */}
-            <div className="space-y-4">
-              <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wide">Personen</h4>
-
-              <CreatableSelect
-                label="Binnengebracht door"
-                value={broughtById}
-                onChange={setBroughtById}
-                options={assigneeOptions}
-                placeholder="Zoek een teamlid..."
-              />
-
-              <CreatableSelect
-                label="Verantwoordelijke"
-                value={assigneeId}
-                onChange={setAssigneeId}
-                options={assigneeOptions}
-                placeholder="Zoek een persoon..."
-                onClear={() => setAssigneeId('')}
-              />
-
-              {contacts.map((contact, index) => (
-                <div key={index} className="space-y-4">
-                  {index > 0 && (
-                    <div className="flex items-center justify-between pt-2 border-t border-border">
-                      <span className="text-xs font-medium text-text-secondary">Extra contactpersoon</span>
-                      <button
-                        type="button"
-                        onClick={() => setContacts(prev => prev.filter((_, i) => i !== index))}
-                        className="p-0.5 text-text-secondary hover:text-red-500 transition-colors"
-                        title="Verwijderen"
-                      >
-                        <X className="h-3.5 w-3.5" />
-                      </button>
-                    </div>
-                  )}
-
-                  <CreatableSelect
-                    label={index === 0 ? "Contactpersoon (extern)" : "Contactpersoon"}
-                    value={contact.personId}
-                    onChange={(val) => {
-                      const person = people?.find((p) => p.id === val);
-                      updateContact(index, { personId: val, name: person?.naam ?? contact.name });
-                    }}
-                    options={contactOptions}
-                    placeholder="Zoek of typ een naam..."
-                    onCreate={async (name) => {
-                      updateContact(index, { name, personId: '' });
-                      return null;
-                    }}
-                    createLabel="Nieuw contact"
-                    displayValue={!contact.personId && contact.name ? contact.name : undefined}
-                    onClear={() => {
-                      updateContact(index, emptyContact());
-                    }}
-                  />
-
-                  {(contact.personId || contact.name) && (
-                    <div className="grid grid-cols-2 gap-3">
-                      <div>
-                        <label className="block text-sm font-medium text-text mb-1">
-                          E-mail
-                        </label>
-                        <input
-                          type="email"
-                          value={contact.email}
-                          onChange={(e) => updateContact(index, { email: e.target.value })}
-                          className="w-full rounded-lg border border-border px-3 py-2 text-sm focus:outline-none focus:border-primary-400"
-                          placeholder="email@organisatie.nl"
-                        />
-                      </div>
-                      <div>
-                        <label className="block text-sm font-medium text-text mb-1">
-                          Telefoon
-                        </label>
-                        <input
-                          type="tel"
-                          value={contact.phone}
-                          onChange={(e) => updateContact(index, { phone: e.target.value })}
-                          className="w-full rounded-lg border border-border px-3 py-2 text-sm focus:outline-none focus:border-primary-400"
-                          placeholder="06-12345678"
-                        />
-                      </div>
-                    </div>
-                  )}
-                </div>
-              ))}
-
-              {contacts.length < 2 && (
-                <button
-                  type="button"
-                  onClick={() => setContacts(prev => [...prev, emptyContact()])}
-                  className="inline-flex items-center gap-1.5 text-sm text-text-secondary hover:text-primary-600 transition-colors"
-                >
-                  <Plus className="h-3.5 w-3.5" />
-                  Extra contactpersoon toevoegen
-                </button>
-              )}
-            </div>
-          </div>
-
-          {/* Files + buttons below both columns */}
-          {files.length > 0 && (
-            <p className="text-xs text-text-secondary">
-              {files.length} {files.length === 1 ? 'bijlage' : 'bijlagen'} worden meegestuurd
-            </p>
           )}
+
+          <LeadContentLayout
+            title={title}
+            stage={stage}
+            description={description}
+            organization={organization}
+            assigneeId={assigneeId}
+            assigneeName={assigneeId ? (people?.find(p => p.id === assigneeId)?.naam ?? null) : null}
+            broughtById={broughtById}
+            broughtByName={broughtById ? (people?.find(p => p.id === broughtById)?.naam ?? null) : null}
+            initiatiefId={initiatiefId}
+            initiatiefName={initiatiefId ? (initiatieven?.find(i => i.id === initiatiefId)?.naam ?? null) : null}
+            initiatiefKleur={initiatiefId ? (initiatieven?.find(i => i.id === initiatiefId)?.kleur ?? null) : null}
+            nextAction={null}
+            nextActionDate={null}
+            createdAt={leadDate}
+            tags={selectedTags}
+            onTitleChange={async (v) => setTitle(v ?? '')}
+            onStageChange={async (v) => setStage(v)}
+            onDescriptionChange={async (v) => setDescription(v ?? '')}
+            onOrganizationChange={async (v) => setOrganization(v ?? '')}
+            onAssigneeChange={async (v) => setAssigneeId(v ?? '')}
+            onBroughtByChange={async (v) => setBroughtById(v ?? '')}
+            onInitiatiefChange={async (v) => setInitiatiefId(v ?? '')}
+            onTagsChange={async (tags) => setSelectedTags(tags)}
+            rightColumnChildren={
+              <div className="space-y-4">
+                {contacts.map((contact, index) => (
+                  <div key={index} className="space-y-4">
+                    {index > 0 && (
+                      <div className="flex items-center justify-between pt-2 border-t border-border">
+                        <span className="text-xs font-medium text-text-secondary">Extra contactpersoon</span>
+                        <button
+                          type="button"
+                          onClick={() => setContacts(prev => prev.filter((_, i) => i !== index))}
+                          className="p-0.5 text-text-secondary hover:text-red-500 transition-colors"
+                          title="Verwijderen"
+                        >
+                          <X className="h-3.5 w-3.5" />
+                        </button>
+                      </div>
+                    )}
+
+                    <CreatableSelect
+                      label={index === 0 ? "Contactpersoon (extern)" : "Contactpersoon"}
+                      value={contact.personId}
+                      onChange={(val) => {
+                        const person = people?.find((p) => p.id === val);
+                        updateContact(index, { personId: val, name: person?.naam ?? contact.name });
+                      }}
+                      options={contactOptions}
+                      placeholder="Zoek of typ een naam..."
+                      onCreate={async (name) => {
+                        updateContact(index, { name, personId: '' });
+                        return null;
+                      }}
+                      createLabel="Nieuw contact"
+                      displayValue={!contact.personId && contact.name ? contact.name : undefined}
+                      onClear={() => {
+                        updateContact(index, emptyContact());
+                      }}
+                    />
+
+                    {(contact.personId || contact.name) && (
+                      <div className="grid grid-cols-2 gap-3">
+                        <div>
+                          <label className="block text-sm font-medium text-text mb-1">
+                            E-mail
+                          </label>
+                          <input
+                            type="email"
+                            value={contact.email}
+                            onChange={(e) => updateContact(index, { email: e.target.value })}
+                            className="w-full rounded-lg border border-border px-3 py-2 text-sm focus:outline-none focus:border-primary-400"
+                            placeholder="email@organisatie.nl"
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-sm font-medium text-text mb-1">
+                            Telefoon
+                          </label>
+                          <input
+                            type="tel"
+                            value={contact.phone}
+                            onChange={(e) => updateContact(index, { phone: e.target.value })}
+                            className="w-full rounded-lg border border-border px-3 py-2 text-sm focus:outline-none focus:border-primary-400"
+                            placeholder="06-12345678"
+                          />
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                ))}
+
+                {contacts.length < 2 && (
+                  <button
+                    type="button"
+                    onClick={() => setContacts(prev => [...prev, emptyContact()])}
+                    className="inline-flex items-center gap-1.5 text-sm text-text-secondary hover:text-primary-600 transition-colors"
+                  >
+                    <Plus className="h-3.5 w-3.5" />
+                    Extra contactpersoon toevoegen
+                  </button>
+                )}
+              </div>
+            }
+            bottomChildren={
+              files.length > 0 ? (
+                <p className="text-xs text-text-secondary">
+                  {files.length} {files.length === 1 ? 'bijlage' : 'bijlagen'} worden meegestuurd
+                </p>
+              ) : undefined
+            }
+          />
 
           <div className="flex items-center justify-end gap-2 pt-4">
             <Button variant="ghost" onClick={() => setStep('input')}>

--- a/frontend/src/components/leads/LeadIntakeDialog.tsx
+++ b/frontend/src/components/leads/LeadIntakeDialog.tsx
@@ -64,7 +64,9 @@ export function LeadIntakeDialog({ open, onClose, defaultInitiatiefId, sharedPar
   const [description, setDescription] = useState('');
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [stage, setStage] = useState<LeadStage>(LeadStage.INBOX);
-  const [contacts, setContacts] = useState<ContactEntry[]>([emptyContact()]);
+  const [contacts, setContacts] = useState<ContactEntry[]>([]);
+  const [addingContact, setAddingContact] = useState(false);
+  const [newContact, setNewContact] = useState<ContactEntry>(emptyContact());
   const updateContact = useCallback((index: number, updates: Partial<ContactEntry>) => {
     setContacts(prev => prev.map((c, i) => i === index ? { ...c, ...updates } : c));
   }, []);
@@ -198,6 +200,13 @@ export function LeadIntakeDialog({ open, onClose, defaultInitiatiefId, sharedPar
           else setFiles((prev) => [...prev, ...combined]);
           if (email.senderName || email.senderEmail) {
             setContacts(prev => {
+              if (prev.length === 0) {
+                return [{
+                  ...emptyContact(),
+                  name: email.senderName || '',
+                  email: email.senderEmail || '',
+                }];
+              }
               const updated = [...prev];
               updated[0] = {
                 ...updated[0],
@@ -265,7 +274,9 @@ export function LeadIntakeDialog({ open, onClose, defaultInitiatiefId, sharedPar
     setDescription('');
     setSelectedTags([]);
     setStage(LeadStage.INBOX);
-    setContacts([emptyContact()]);
+    setContacts([]);
+    setAddingContact(false);
+    setNewContact(emptyContact());
     setAssigneeId('');
     setBroughtById(currentPerson?.id ?? '');
     setLeadDate(new Date().toISOString().split('T')[0]);
@@ -628,86 +639,114 @@ export function LeadIntakeDialog({ open, onClose, defaultInitiatiefId, sharedPar
             onTagsChange={async (tags) => setSelectedTags(tags)}
             onCreatedAtChange={async (v) => setLeadDate(v ?? '')}
             rightColumnChildren={
-              <div className="space-y-4">
-                {contacts.map((contact, index) => (
-                  <div key={index} className="space-y-4">
-                    {index > 0 && (
-                      <div className="flex items-center justify-between pt-2 border-t border-border">
-                        <span className="text-xs font-medium text-text-secondary">Extra contactpersoon</span>
+              <div>
+                <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-2">
+                  Contactpersonen
+                </h4>
+
+                {/* Existing contacts */}
+                {contacts.length > 0 && (
+                  <div className="space-y-2 mb-2">
+                    {contacts.map((contact, index) => (
+                      <div key={index} className="flex items-start gap-2 rounded-lg bg-gray-50 px-3 py-2">
+                        <div className="flex-1 min-w-0">
+                          <div className="text-sm font-medium text-text truncate">
+                            {contact.personId
+                              ? (people?.find(p => p.id === contact.personId)?.naam ?? contact.name)
+                              : contact.name || 'Naamloos'}
+                          </div>
+                          {(contact.email || contact.phone) && (
+                            <div className="text-xs text-text-secondary truncate">
+                              {[contact.email, contact.phone].filter(Boolean).join(' · ')}
+                            </div>
+                          )}
+                        </div>
                         <button
                           type="button"
                           onClick={() => setContacts(prev => prev.filter((_, i) => i !== index))}
-                          className="p-0.5 text-text-secondary hover:text-red-500 transition-colors"
+                          className="p-0.5 text-text-secondary hover:text-red-500 transition-colors shrink-0 mt-0.5"
                           title="Verwijderen"
                         >
                           <X className="h-3.5 w-3.5" />
                         </button>
                       </div>
-                    )}
+                    ))}
+                  </div>
+                )}
 
-                    <div>
-                      <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-1">
-                        {index === 0 ? "Contactpersoon (extern)" : "Contactpersoon"}
-                      </h4>
-                      <CreatableSelect
-                        value={contact.personId}
-                        onChange={(val) => {
-                          const person = people?.find((p) => p.id === val);
-                          updateContact(index, { personId: val, name: person?.naam ?? contact.name });
-                        }}
-                        options={contactOptions}
-                        placeholder="Zoek of typ een naam..."
-                        onCreate={async (name) => {
-                          updateContact(index, { name, personId: '' });
-                          return null;
-                        }}
-                        createLabel="Nieuw contact"
-                        displayValue={!contact.personId && contact.name ? contact.name : undefined}
-                        onClear={() => {
-                          updateContact(index, emptyContact());
-                        }}
-                      />
-                    </div>
-
-                    {(contact.personId || contact.name) && (
-                      <div className="grid grid-cols-2 gap-3">
-                        <div>
-                          <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-1">
-                            E-mail
-                          </h4>
-                          <input
-                            type="email"
-                            value={contact.email}
-                            onChange={(e) => updateContact(index, { email: e.target.value })}
-                            className="w-full rounded-lg border border-border px-3 py-2 text-sm focus:outline-none focus:border-primary-400"
-                            placeholder="email@organisatie.nl"
-                          />
-                        </div>
-                        <div>
-                          <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-1">
-                            Telefoon
-                          </h4>
-                          <input
-                            type="tel"
-                            value={contact.phone}
-                            onChange={(e) => updateContact(index, { phone: e.target.value })}
-                            className="w-full rounded-lg border border-border px-3 py-2 text-sm focus:outline-none focus:border-primary-400"
-                            placeholder="06-12345678"
-                          />
-                        </div>
+                {/* Add contact form */}
+                {addingContact ? (
+                  <div className="space-y-3 rounded-lg border border-border p-3">
+                    <CreatableSelect
+                      value={newContact.personId}
+                      onChange={(val) => {
+                        const person = people?.find((p) => p.id === val);
+                        setNewContact(prev => ({
+                          ...prev,
+                          personId: val,
+                          name: person?.naam ?? prev.name,
+                        }));
+                      }}
+                      options={contactOptions}
+                      placeholder="Zoek of typ een naam..."
+                      onCreate={async (name) => {
+                        setNewContact(prev => ({ ...prev, name, personId: '' }));
+                        return null;
+                      }}
+                      createLabel="Nieuw contact"
+                      displayValue={!newContact.personId && newContact.name ? newContact.name : undefined}
+                      onClear={() => setNewContact(emptyContact())}
+                    />
+                    {(newContact.personId || newContact.name) && (
+                      <div className="grid grid-cols-2 gap-2">
+                        <input
+                          type="email"
+                          value={newContact.email}
+                          onChange={(e) => setNewContact(prev => ({ ...prev, email: e.target.value }))}
+                          className="rounded-lg border border-border px-2 py-1.5 text-sm focus:outline-none focus:border-primary-400"
+                          placeholder="E-mail"
+                        />
+                        <input
+                          type="tel"
+                          value={newContact.phone}
+                          onChange={(e) => setNewContact(prev => ({ ...prev, phone: e.target.value }))}
+                          className="rounded-lg border border-border px-2 py-1.5 text-sm focus:outline-none focus:border-primary-400"
+                          placeholder="Telefoon"
+                        />
                       </div>
                     )}
+                    <div className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => {
+                          if (newContact.personId || newContact.name) {
+                            setContacts(prev => [...prev, newContact]);
+                            setNewContact(emptyContact());
+                            setAddingContact(false);
+                          }
+                        }}
+                        disabled={!newContact.personId && !newContact.name}
+                        className="text-sm font-medium text-primary-600 hover:text-primary-700 disabled:text-text-secondary disabled:cursor-not-allowed"
+                      >
+                        Toevoegen
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => { setAddingContact(false); setNewContact(emptyContact()); }}
+                        className="text-sm text-text-secondary hover:text-text"
+                      >
+                        Annuleren
+                      </button>
+                    </div>
                   </div>
-                ))}
-
-                {contacts.length < 2 && (
+                ) : (
                   <button
                     type="button"
-                    onClick={() => setContacts(prev => [...prev, emptyContact()])}
-                    className="inline-flex items-center gap-1.5 text-sm text-text-secondary hover:text-primary-600 transition-colors"
+                    onClick={() => setAddingContact(true)}
+                    className="inline-flex items-center gap-1.5 text-xs text-text-secondary hover:text-primary-600 transition-colors"
                   >
                     <Plus className="h-3.5 w-3.5" />
-                    Extra contactpersoon toevoegen
+                    Contactpersoon toevoegen
                   </button>
                 )}
               </div>

--- a/frontend/src/components/leads/LeadIntakeDialog.tsx
+++ b/frontend/src/components/leads/LeadIntakeDialog.tsx
@@ -626,6 +626,7 @@ export function LeadIntakeDialog({ open, onClose, defaultInitiatiefId, sharedPar
             onBroughtByChange={async (v) => setBroughtById(v ?? '')}
             onInitiatiefChange={async (v) => setInitiatiefId(v ?? '')}
             onTagsChange={async (tags) => setSelectedTags(tags)}
+            onCreatedAtChange={async (v) => setLeadDate(v ?? '')}
             rightColumnChildren={
               <div className="space-y-4">
                 {contacts.map((contact, index) => (


### PR DESCRIPTION
## Summary

- Vervangt drie aparte lead-UIs (aanmaken confirm, detail view, detail edit mode) door twee met identieke twee-koloms layout
- Nieuw `InlineEditableField` component: klik-om-te-bewerken voor text, date, select, richtext velden
- Nieuw `LeadContentLayout` component: gedeeld layout met stage pills, tag chip editor, inline editing per veld
- Detail panel: edit mode en "Bewerken"-knop verwijderd, alle velden direct klikbaar
- Intake confirm-stap: hergebruikt dezelfde `LeadContentLayout`, contactpersonen als rechterkolom children
- Netto ~400 regels minder code door het elimineren van gedupliceerde formuliervelden

## Test plan

- [ ] Open een bestaande lead - twee-koloms layout, alle velden klikbaar
- [ ] Klik op titel/organisatie/volgende actie - inline text edit, blur slaat op
- [ ] Klik op stage badge - pill-buttons verschijnen, klik slaat op met activity log
- [ ] Klik op tags - chip+dropdown, add/remove direct opgeslagen
- [ ] Klik op beschrijving - rich text editor, click-outside slaat op
- [ ] Klik op toegewezen aan / binnengebracht door / initiatief - dropdown select
- [ ] Escape annuleert inline editing zonder opslaan
- [ ] Contactpersonen, bijlagen, gelinkte nodes, activiteiten werken ongewijzigd
- [ ] Intake flow: tekst invoeren → AI parsen → confirm toont zelfde layout als detail view
- [ ] Intake confirm: contactpersonen rechts met email/telefoon, tags en stage werken
- [ ] Lead aanmaken via intake → lead verschijnt correct
- [ ] Footer detail panel: alleen "Verwijderen" + "Sluiten" (geen "Bewerken" meer)