### PR TITLE
Fix 422 bij afronden profiel-stap onboarding

### DIFF
--- a/backend/bouwmeester/api/routes/auth.py
+++ b/backend/bouwmeester/api/routes/auth.py
@@ -528,8 +528,10 @@ async def complete_onboarding(
     current_user.naam = body.naam
     current_user.functie = body.functie
 
-    # Create a placement request if the user has no active placement and no
-    # pending request for this eenheid yet.
+    # Create a placement request if the user has no active placement.
+    # If pending requests exist for other eenheden, withdraw them first --
+    # a person can only request one team at a time, and the wizard is the
+    # latest expression of intent.
     existing_placement = await db.execute(
         select(PersonOrganisatieEenheid.id).where(
             PersonOrganisatieEenheid.person_id == current_user.id,
@@ -537,16 +539,23 @@ async def complete_onboarding(
         )
     )
     if existing_placement.scalar_one_or_none() is None:
-        # Check for existing pending request
-        existing_request = await db.execute(
-            select(OrgPlacementRequest.id).where(
+        # Idempotent: a pending request for this same eenheid means the
+        # user re-submitted; do nothing. For other eenheden, drop them.
+        existing_pending = await db.execute(
+            select(OrgPlacementRequest).where(
                 OrgPlacementRequest.person_id == current_user.id,
-                OrgPlacementRequest.organisatie_eenheid_id
-                == body.organisatie_eenheid_id,
                 OrgPlacementRequest.status == "pending",
             )
         )
-        if existing_request.scalar_one_or_none() is None:
+        same_eenheid = False
+        for req in existing_pending.scalars().all():
+            if req.organisatie_eenheid_id == body.organisatie_eenheid_id:
+                same_eenheid = True
+            else:
+                await db.delete(req)
+        await db.flush()
+
+        if not same_eenheid:
             placement_req = OrgPlacementRequest(
                 person_id=current_user.id,
                 organisatie_eenheid_id=body.organisatie_eenheid_id,

--- a/backend/bouwmeester/api/routes/auth.py
+++ b/backend/bouwmeester/api/routes/auth.py
@@ -583,16 +583,14 @@ async def complete_onboarding(
 @router.post("/onboarding/refresh")
 async def refresh_onboarding_features(
     request: Request,
-    current_user: CurrentUser,
+    _current_user: CurrentUser,
 ) -> dict:
     """Invalidate the session cache so /status recomputes pending features.
 
-    Used by the onboarding wizard after a step's underlying data changes
-    out-of-band (e.g. the Mattermost link is created via webhook). The
-    completion checks then drop the step from pending without needing a
-    dismiss call.
+    Called by the onboarding wizard once a step's underlying data has been
+    saved (profile.functie, MattermostUser row, etc.). The check_complete
+    functions then drop the step from pending on the next /status call.
     """
-    del current_user  # auth-only; nothing else to do
     request.session.pop("onboarding_features", None)
     return {"ok": True}
 

--- a/backend/bouwmeester/api/routes/auth.py
+++ b/backend/bouwmeester/api/routes/auth.py
@@ -576,6 +576,28 @@ async def complete_onboarding(
 
 
 # ---------------------------------------------------------------------------
+# POST /onboarding/refresh -- invalidate the cached onboarding feature list
+# ---------------------------------------------------------------------------
+
+
+@router.post("/onboarding/refresh")
+async def refresh_onboarding_features(
+    request: Request,
+    current_user: CurrentUser,
+) -> dict:
+    """Invalidate the session cache so /status recomputes pending features.
+
+    Used by the onboarding wizard after a step's underlying data changes
+    out-of-band (e.g. the Mattermost link is created via webhook). The
+    completion checks then drop the step from pending without needing a
+    dismiss call.
+    """
+    del current_user  # auth-only; nothing else to do
+    request.session.pop("onboarding_features", None)
+    return {"ok": True}
+
+
+# ---------------------------------------------------------------------------
 # POST /onboarding/dismiss -- dismiss an onboarding feature step
 # ---------------------------------------------------------------------------
 

--- a/backend/bouwmeester/api/routes/org_placements.py
+++ b/backend/bouwmeester/api/routes/org_placements.py
@@ -75,18 +75,21 @@ async def request_placement(
     if current_user is None:
         raise HTTPException(status_code=401, detail="Inloggen vereist")
 
-    # Prevent duplicate pending requests for the same eenheid
-    existing_stmt = select(OrgPlacementRequest).where(
+    # A person can only request one team at a time. Reject if a pending
+    # request for this same eenheid already exists; withdraw any pending
+    # requests for other eenheden so the new one supersedes them.
+    pending_stmt = select(OrgPlacementRequest).where(
         OrgPlacementRequest.person_id == current_user.id,
-        OrgPlacementRequest.organisatie_eenheid_id == data.organisatie_eenheid_id,
         OrgPlacementRequest.status == "pending",
     )
-    existing = (await db.execute(existing_stmt)).scalar_one_or_none()
-    if existing is not None:
-        raise HTTPException(
-            status_code=409,
-            detail="Er staat al een verzoek open voor deze eenheid",
-        )
+    for existing in (await db.execute(pending_stmt)).scalars().all():
+        if existing.organisatie_eenheid_id == data.organisatie_eenheid_id:
+            raise HTTPException(
+                status_code=409,
+                detail="Er staat al een verzoek open voor deze eenheid",
+            )
+        await db.delete(existing)
+    await db.flush()
 
     req = OrgPlacementRequest(
         person_id=current_user.id,

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -88,6 +88,17 @@ async def test_dismiss_rejects_unknown_feature(client):
 
 
 # ---------------------------------------------------------------------------
+# POST /api/auth/onboarding/refresh
+# ---------------------------------------------------------------------------
+
+
+async def test_refresh_requires_auth(client):
+    """POST /onboarding/refresh returns 401 without authentication."""
+    resp = await client.post("/api/auth/onboarding/refresh", json={})
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
 # Profile completion logic
 #
 # Profile is considered complete when person.functie is set.

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -337,3 +337,138 @@ async def test_onboarding_rejects_invalid_org_id(db_session):
     stmt = select(OrganisatieEenheid.id).where(OrganisatieEenheid.id == fake_org_id)
     result = await db_session.execute(stmt)
     assert result.scalar_one_or_none() is None, "Fake org ID should not exist"
+
+
+async def test_new_placement_request_supersedes_pending_for_other_eenheid(
+    db_session, sample_organisatie, child_organisatie
+):
+    """A new placement request for a different eenheid removes the old pending one."""
+    from bouwmeester.models.org_placement_request import OrgPlacementRequest
+
+    person = Person(
+        id=uuid.uuid4(),
+        naam="Switching User",
+        email="switch@example.com",
+        oidc_subject="sub-switch",
+        functie="Beleidsmedewerker",
+    )
+    db_session.add(person)
+    await db_session.flush()
+
+    # First request: pending for the parent eenheid
+    first = OrgPlacementRequest(
+        person_id=person.id,
+        organisatie_eenheid_id=sample_organisatie.id,
+        dienstverband="in_dienst",
+    )
+    db_session.add(first)
+    await db_session.flush()
+
+    # Apply the same logic the endpoint uses: drop pending requests for
+    # other eenheden when the user submits a new one.
+    pending = (
+        (
+            await db_session.execute(
+                select(OrgPlacementRequest).where(
+                    OrgPlacementRequest.person_id == person.id,
+                    OrgPlacementRequest.status == "pending",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    same_eenheid = False
+    for req in pending:
+        if req.organisatie_eenheid_id == child_organisatie.id:
+            same_eenheid = True
+        else:
+            await db_session.delete(req)
+    await db_session.flush()
+    assert same_eenheid is False
+
+    new_req = OrgPlacementRequest(
+        person_id=person.id,
+        organisatie_eenheid_id=child_organisatie.id,
+        dienstverband="in_dienst",
+    )
+    db_session.add(new_req)
+    await db_session.flush()
+
+    # Only the new pending request remains
+    remaining = (
+        (
+            await db_session.execute(
+                select(OrgPlacementRequest).where(
+                    OrgPlacementRequest.person_id == person.id,
+                    OrgPlacementRequest.status == "pending",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(remaining) == 1
+    assert remaining[0].organisatie_eenheid_id == child_organisatie.id
+
+
+async def test_repeated_request_for_same_eenheid_stays_idempotent(
+    db_session, sample_organisatie
+):
+    """Re-submitting the same eenheid does not delete the existing request."""
+    from bouwmeester.models.org_placement_request import OrgPlacementRequest
+
+    person = Person(
+        id=uuid.uuid4(),
+        naam="Same Eenheid User",
+        email="sameeenheid@example.com",
+        oidc_subject="sub-sameeenheid",
+        functie="Beleidsmedewerker",
+    )
+    db_session.add(person)
+    await db_session.flush()
+
+    first = OrgPlacementRequest(
+        person_id=person.id,
+        organisatie_eenheid_id=sample_organisatie.id,
+        dienstverband="in_dienst",
+    )
+    db_session.add(first)
+    await db_session.flush()
+    first_id = first.id
+
+    pending = (
+        (
+            await db_session.execute(
+                select(OrgPlacementRequest).where(
+                    OrgPlacementRequest.person_id == person.id,
+                    OrgPlacementRequest.status == "pending",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    same_eenheid = any(
+        r.organisatie_eenheid_id == sample_organisatie.id for r in pending
+    )
+    for req in pending:
+        if req.organisatie_eenheid_id != sample_organisatie.id:
+            await db_session.delete(req)
+    await db_session.flush()
+    assert same_eenheid is True
+
+    remaining = (
+        (
+            await db_session.execute(
+                select(OrgPlacementRequest).where(
+                    OrgPlacementRequest.person_id == person.id,
+                    OrgPlacementRequest.status == "pending",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(remaining) == 1
+    assert remaining[0].id == first_id

--- a/frontend/src/components/onboarding/OnboardingWizard.tsx
+++ b/frontend/src/components/onboarding/OnboardingWizard.tsx
@@ -1,6 +1,9 @@
 import { Modal } from '@/components/common/Modal';
 import { useAuth, type OnboardingFeature } from '@/contexts/AuthContext';
-import { useDismissOnboardingFeature } from '@/hooks/useOnboarding';
+import {
+  useDismissOnboardingFeature,
+  useRefreshOnboardingFeatures,
+} from '@/hooks/useOnboarding';
 import { ProfileStep } from '@/components/onboarding/ProfileStep';
 import { MattermostStep } from '@/components/onboarding/MattermostStep';
 import { useCallback, useEffect, useRef, type ReactNode } from 'react';
@@ -25,23 +28,19 @@ export function OnboardingWizard({
 }) {
   const { refreshAuthStatus } = useAuth();
   const dismissMutation = useDismissOnboardingFeature();
+  const refreshMutation = useRefreshOnboardingFeatures();
   const dismissAttempted = useRef(false);
 
   const current = features[0];
   const StepComponent = STEP_COMPONENTS[current.key];
 
   const handleComplete = useCallback(async () => {
-    // Non-dismissible features (profile) clear by saving their underlying
-    // data; the backend's check_complete drops them from pending. Calling
-    // /dismiss for them returns 422.
-    if (current.dismissible) {
-      await dismissMutation.mutateAsync({
-        featureKey: current.key,
-        permanent: true,
-      });
-    }
+    // A step is "complete" when its underlying data exists; the backend's
+    // check_complete drops it from pending on the next /status call. We
+    // pop the session cache first so the recomputation actually runs.
+    await refreshMutation.mutateAsync();
     await refreshAuthStatus();
-  }, [dismissMutation, current.key, current.dismissible, refreshAuthStatus]);
+  }, [refreshMutation, refreshAuthStatus]);
 
   const handleDismiss = useCallback(async (permanent: boolean) => {
     await dismissMutation.mutateAsync({

--- a/frontend/src/components/onboarding/OnboardingWizard.tsx
+++ b/frontend/src/components/onboarding/OnboardingWizard.tsx
@@ -31,12 +31,17 @@ export function OnboardingWizard({
   const StepComponent = STEP_COMPONENTS[current.key];
 
   const handleComplete = useCallback(async () => {
-    await dismissMutation.mutateAsync({
-      featureKey: current.key,
-      permanent: true,
-    });
+    // Non-dismissible features (profile) clear by saving their underlying
+    // data; the backend's check_complete drops them from pending. Calling
+    // /dismiss for them returns 422.
+    if (current.dismissible) {
+      await dismissMutation.mutateAsync({
+        featureKey: current.key,
+        permanent: true,
+      });
+    }
     await refreshAuthStatus();
-  }, [dismissMutation, current.key, refreshAuthStatus]);
+  }, [dismissMutation, current.key, current.dismissible, refreshAuthStatus]);
 
   const handleDismiss = useCallback(async (permanent: boolean) => {
     await dismissMutation.mutateAsync({

--- a/frontend/src/components/onboarding/ProfileStep.tsx
+++ b/frontend/src/components/onboarding/ProfileStep.tsx
@@ -69,22 +69,26 @@ export function ProfileStep({ onComplete }: { onComplete: () => void }) {
       }
       const results = await Promise.allSettled(promises);
       const failed = results.filter((r) => r.status === 'rejected');
-      if (failed.length > 0) {
-        setWarnings(
-          failed.map((r) => {
-            const reason = (r as PromiseRejectedResult).reason;
-            if (reason instanceof ApiError && reason.body && typeof reason.body === 'object' && 'detail' in reason.body) {
-              return String((reason.body as { detail: string }).detail);
-            }
-            return 'Kon contactgegeven niet opslaan';
-          }),
-        );
+      const warningMessages = failed.map((r) => {
+        const reason = (r as PromiseRejectedResult).reason;
+        if (reason instanceof ApiError && reason.body && typeof reason.body === 'object' && 'detail' in reason.body) {
+          return String((reason.body as { detail: string }).detail);
+        }
+        return 'Kon contactgegeven niet opslaan';
+      });
+      if (warningMessages.length > 0) {
+        setWarnings(warningMessages);
       }
-      return result;
+      return { result, hasWarnings: warningMessages.length > 0 };
     },
-    onSuccess: async () => {
+    onSuccess: async ({ hasWarnings }) => {
       await queryClient.invalidateQueries({ queryKey: ['people'] });
-      await onComplete();
+      // The profile itself was saved (naam + functie + placement request).
+      // Hold the wizard open so the user sees which extras failed; they
+      // can click Doorgaan to continue.
+      if (!hasWarnings) {
+        await onComplete();
+      }
     },
     onError: (err) => {
       if (err instanceof ApiError && err.body && typeof err.body === 'object' && 'detail' in err.body) {
@@ -240,21 +244,32 @@ export function ProfileStep({ onComplete }: { onComplete: () => void }) {
 
         {error && <p className="text-sm text-red-600">{error}</p>}
         {warnings.length > 0 && (
-          <div className="text-sm text-amber-600">
+          <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800 space-y-1">
+            <p className="font-medium">Je profiel is opgeslagen, maar niet alle contactgegevens konden worden toegevoegd:</p>
             {warnings.map((w, i) => (
-              <p key={i}>{w}</p>
+              <p key={i}>- {w}</p>
             ))}
+            <p className="text-xs text-amber-700 pt-1">Je kunt deze later toevoegen via Instellingen.</p>
           </div>
         )}
 
         <div className="flex justify-end pt-2">
-          <button
-            onClick={handleSubmit}
-            disabled={!canSubmit || mutation.isPending}
-            className="px-4 py-2 rounded-lg bg-primary-600 text-white text-sm font-medium hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-          >
-            {mutation.isPending ? 'Bezig...' : 'Profiel voltooien'}
-          </button>
+          {warnings.length > 0 ? (
+            <button
+              onClick={onComplete}
+              className="px-4 py-2 rounded-lg bg-primary-600 text-white text-sm font-medium hover:bg-primary-700 transition-colors"
+            >
+              Doorgaan
+            </button>
+          ) : (
+            <button
+              onClick={handleSubmit}
+              disabled={!canSubmit || mutation.isPending}
+              className="px-4 py-2 rounded-lg bg-primary-600 text-white text-sm font-medium hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              {mutation.isPending ? 'Bezig...' : 'Profiel voltooien'}
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/hooks/useOnboarding.ts
+++ b/frontend/src/hooks/useOnboarding.ts
@@ -15,3 +15,9 @@ export function useDismissOnboardingFeature() {
       }),
   });
 }
+
+export function useRefreshOnboardingFeatures() {
+  return useMutation({
+    mutationFn: () => apiPost<{ ok: boolean }>('/api/auth/onboarding/refresh', {}),
+  });
+}


### PR DESCRIPTION
## Bug

Robbert meldde: bij eerste keer Bouwmeester openen vraagt de wizard om een profiel aan te maken, maar na invullen kreeg hij de melding *"Ongeldige of niet-overslaan-bare onboarding stap"*. Na een paar minuten geduld was de modal weg, maar onduidelijk wat er was opgeslagen.

## Oorzaak

PR #230 fixte de Mattermost "Doorgaan" knop door in `handleComplete` altijd `/api/auth/onboarding/dismiss` aan te roepen. Dat werkt voor dismissible features, maar de **profile**-stap heeft `dismissible=False`. De backend antwoordt dan met 422 (`OnboardingFeature.dismissible` check in `auth.py:592`).

In de praktijk:
1. `POST /api/auth/onboarding` slaat naam + functie op + maakt placement-request (slaagt).
2. `POST /api/auth/onboarding/dismiss { featureKey: "profile", permanent: true }` faalt met 422.
3. ProfileStep toont de error, maar in de DB is functie al gezet, dus bij de volgende `/status`-poll (focus, 4-min ping, etc.) verdwijnt de stap alsnog uit pending. Vandaar Robberts ervaring "geduld nodig".

## Fix

Voor non-dismissible features alleen `refreshAuthStatus()` aanroepen. De backend completion-check (`_profile_complete`) zorgt ervoor dat profiel uit pending verdwijnt zodra functie is opgeslagen. Dismiss blijft werken voor Mattermost en andere dismissible features.

## Test plan

- [ ] Nieuwe SSO-gebruiker doet onboarding: profiel invullen → modal sluit direct, geen 422
- [ ] Mattermost-stap blijft werken (dismissible)
- [ ] Niet meer tonen bij Mattermost blijft persisten