### PR TITLE
Fix notitie toevoegen op lead + notificatie bij @-mention

### DIFF
--- a/backend/bouwmeester/api/routes/leads.py
+++ b/backend/bouwmeester/api/routes/leads.py
@@ -203,6 +203,7 @@ async def create_lead(
             type="lead_assigned",
             title=f"Je bent toegewezen aan lead: {lead.title}",
             message=f"Je bent toegewezen aan lead: {lead.title}",
+            related_lead_id=lead.id,
         )
         await notif_svc.send(notification_data)
 
@@ -394,6 +395,7 @@ async def update_lead(
                 type="lead_assigned",
                 title=f"Je bent toegewezen aan lead: {lead.title}",
                 message=f"Je bent toegewezen aan lead: {lead.title}",
+                related_lead_id=lead.id,
             )
             await notif_svc.send(notification_data)
 
@@ -406,6 +408,7 @@ async def update_lead(
                 type="lead_stage_changed",
                 title=f"Lead '{lead.title}' is verplaatst naar {lead.stage}",
                 message=f"Lead '{lead.title}' is verplaatst naar {lead.stage}",
+                related_lead_id=lead.id,
             )
             await notif_svc.send(notification_data)
 
@@ -485,6 +488,7 @@ async def move_lead(
             type="lead_stage_changed",
             title=f"Lead '{lead.title}' is verplaatst naar {lead.stage}",
             message=f"Lead '{lead.title}' is verplaatst naar {lead.stage}",
+            related_lead_id=lead.id,
         )
         await notif_svc.send(notification_data)
 
@@ -553,6 +557,7 @@ async def add_activity(
             type="lead_activity_added",
             title=f"Nieuwe notitie op lead '{lead.title}'",
             message=f"Nieuwe notitie op lead '{lead.title}'",
+            related_lead_id=lead.id,
         )
         await notif_svc.send(notification_data)
 
@@ -642,6 +647,7 @@ async def add_contact(
             type="lead_contact_added",
             title=f"Je bent toegevoegd als contactpersoon aan lead: {lead.title}",
             message=f"Je bent toegevoegd als contactpersoon aan lead: {lead.title}",
+            related_lead_id=lead_id,
         )
         await notif_svc.send(notification_data)
 

--- a/backend/bouwmeester/api/routes/leads.py
+++ b/backend/bouwmeester/api/routes/leads.py
@@ -556,7 +556,6 @@ async def add_activity(
         )
         await notif_svc.send(notification_data)
 
-    # Notify @mentioned persons (skip assignee, already notified above)
     await sync_and_notify_mentions(
         db,
         "lead_activity",
@@ -564,6 +563,7 @@ async def add_activity(
         data.content,
         f"lead '{lead.title}'",
         sender_id=author_id,
+        source_lead_id=lead_id,
         exclude_person_id=lead.assignee_id,
     )
 

--- a/backend/bouwmeester/api/routes/leads.py
+++ b/backend/bouwmeester/api/routes/leads.py
@@ -54,6 +54,7 @@ from bouwmeester.schema.lead import (
 from bouwmeester.schema.notification import NotificationCreate
 from bouwmeester.schema.tag import LeadTagCreate, LeadTagResponse, TagCreate
 from bouwmeester.services.activity_service import log_activity
+from bouwmeester.services.mention_helper import sync_and_notify_mentions
 from bouwmeester.services.notification_service import NotificationService
 
 router = APIRouter(prefix="/leads", tags=["leads"])
@@ -555,6 +556,17 @@ async def add_activity(
         )
         await notif_svc.send(notification_data)
 
+    # Notify @mentioned persons (skip assignee, already notified above)
+    await sync_and_notify_mentions(
+        db,
+        "lead_activity",
+        activity.id,
+        data.content,
+        f"lead '{lead.title}'",
+        sender_id=author_id,
+        exclude_person_id=lead.assignee_id,
+    )
+
     await log_activity(
         db,
         current_user,
@@ -563,7 +575,7 @@ async def add_activity(
         details={
             "lead_id": str(lead_id),
             "lead_title": lead.title,
-            "activity_type": data.type,
+            "activity_type": data.activity_type.value,
         },
     )
 

--- a/backend/bouwmeester/migrations/versions/c1d4e7a3b9f2_add_related_lead_id_to_notification.py
+++ b/backend/bouwmeester/migrations/versions/c1d4e7a3b9f2_add_related_lead_id_to_notification.py
@@ -1,0 +1,46 @@
+"""add related_lead_id to notification
+
+Revision ID: c1d4e7a3b9f2
+Revises: aa5f2d126436
+Create Date: 2026-05-04 12:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c1d4e7a3b9f2"
+down_revision: str | None = "aa5f2d126436"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "notification",
+        sa.Column("related_lead_id", sa.UUID(), nullable=True),
+    )
+    op.create_foreign_key(
+        "notification_related_lead_id_fkey",
+        "notification",
+        "lead",
+        ["related_lead_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_index(
+        "ix_notification_related_lead_id",
+        "notification",
+        ["related_lead_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_notification_related_lead_id", table_name="notification")
+    op.drop_constraint(
+        "notification_related_lead_id_fkey", "notification", type_="foreignkey"
+    )
+    op.drop_column("notification", "related_lead_id")

--- a/backend/bouwmeester/models/notification.py
+++ b/backend/bouwmeester/models/notification.py
@@ -12,6 +12,7 @@ from bouwmeester.core.database import Base
 
 if TYPE_CHECKING:
     from bouwmeester.models.corpus_node import CorpusNode
+    from bouwmeester.models.lead import Lead
     from bouwmeester.models.person import Person
     from bouwmeester.models.task import Task
 
@@ -46,6 +47,11 @@ class Notification(Base):
         ForeignKey("task.id", ondelete="SET NULL"),
         nullable=True,
     )
+    related_lead_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("lead.id", ondelete="SET NULL"),
+        nullable=True,
+    )
     sender_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("person.id", ondelete="SET NULL"),
@@ -72,6 +78,7 @@ class Notification(Base):
     )
     related_node: Mapped[Optional["CorpusNode"]] = relationship("CorpusNode")
     related_task: Mapped[Optional["Task"]] = relationship("Task")
+    related_lead: Mapped[Optional["Lead"]] = relationship("Lead")
     replies: Mapped[list["Notification"]] = relationship(
         "Notification",
         foreign_keys=[parent_id],

--- a/backend/bouwmeester/schema/notification.py
+++ b/backend/bouwmeester/schema/notification.py
@@ -43,6 +43,7 @@ class NotificationBase(BaseModel):
     sender_id: UUID | None = None
     related_node_id: UUID | None = None
     related_task_id: UUID | None = None
+    related_lead_id: UUID | None = None
     parent_id: UUID | None = None
     thread_id: UUID | None = None
 

--- a/backend/bouwmeester/services/mention_helper.py
+++ b/backend/bouwmeester/services/mention_helper.py
@@ -21,6 +21,7 @@ async def sync_and_notify_mentions(
     sender_id: UUID | None = None,
     source_node_id: UUID | None = None,
     source_task_id: UUID | None = None,
+    source_lead_id: UUID | None = None,
     exclude_person_id: UUID | None = None,
 ) -> None:
     """Sync mentions from content and send notifications to mentioned persons.
@@ -60,6 +61,7 @@ async def sync_and_notify_mentions(
                         entity_title,
                         source_node_id=source_node_id,
                         source_task_id=source_task_id,
+                        source_lead_id=source_lead_id,
                         sender_id=sender_id,
                     )
     except Exception:

--- a/backend/bouwmeester/services/notification_service.py
+++ b/backend/bouwmeester/services/notification_service.py
@@ -513,6 +513,7 @@ class NotificationService:
         source_title: str,
         source_node_id: UUID | None = None,
         source_task_id: UUID | None = None,
+        source_lead_id: UUID | None = None,
         sender_id: UUID | None = None,
     ) -> Notification:
         """Notify a person they were @mentioned."""
@@ -524,6 +525,7 @@ class NotificationService:
             sender_id=sender_id,
             related_node_id=source_node_id,
             related_task_id=source_task_id,
+            related_lead_id=source_lead_id,
         )
         notification = await self.repo.create(data)
         self._send_to_mattermost(notification)

--- a/backend/tests/test_lead_activity.py
+++ b/backend/tests/test_lead_activity.py
@@ -138,6 +138,5 @@ async def test_mentioned_assignee_only_gets_one_notification(
         .all()
     )
 
-    # Only the lead_activity_added notification (no extra 'mention')
     assert len(notifs) == 1
     assert notifs[0].type == "lead_activity_added"

--- a/backend/tests/test_lead_activity.py
+++ b/backend/tests/test_lead_activity.py
@@ -1,0 +1,143 @@
+"""Tests for lead activity endpoints, including @-mention notifications."""
+
+import json
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from bouwmeester.models.lead import Lead
+from bouwmeester.models.notification import Notification
+
+
+@pytest.fixture
+async def sample_lead(db_session):
+    lead = Lead(
+        id=uuid.uuid4(),
+        title="Test lead",
+        stage="inbox",
+    )
+    db_session.add(lead)
+    await db_session.flush()
+    return lead
+
+
+@pytest.fixture
+async def assigned_lead(db_session, sample_person):
+    lead = Lead(
+        id=uuid.uuid4(),
+        title="Assigned lead",
+        stage="inbox",
+        assignee_id=sample_person.id,
+    )
+    db_session.add(lead)
+    await db_session.flush()
+    return lead
+
+
+async def test_add_activity_returns_201(client, sample_lead):
+    """Plain note creates activity and returns 201 (regression for data.type bug)."""
+    resp = await client.post(
+        f"/api/leads/{sample_lead.id}/activities",
+        json={"content": "Eerste notitie", "activity_type": "note"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["content"] == "Eerste notitie"
+    assert body["activity_type"] == "note"
+
+
+async def test_add_activity_with_mention_notifies_target(
+    client, db_session, sample_lead, second_person
+):
+    """An @-mention in a note creates a 'mention' notification with related_lead_id."""
+    tiptap_content = json.dumps(
+        {
+            "type": "doc",
+            "content": [
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {
+                            "type": "mention",
+                            "attrs": {
+                                "id": str(second_person.id),
+                                "label": second_person.naam,
+                                "mentionType": "person",
+                            },
+                        },
+                        {"type": "text", "text": " kun jij hierop reageren?"},
+                    ],
+                }
+            ],
+        }
+    )
+
+    resp = await client.post(
+        f"/api/leads/{sample_lead.id}/activities",
+        json={"content": tiptap_content, "activity_type": "note"},
+    )
+    assert resp.status_code == 201
+
+    notifs = (
+        (
+            await db_session.execute(
+                select(Notification).where(
+                    Notification.person_id == second_person.id,
+                    Notification.type == "mention",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    assert len(notifs) == 1
+    assert notifs[0].related_lead_id == sample_lead.id
+    assert "Test lead" in notifs[0].title
+
+
+async def test_mentioned_assignee_only_gets_one_notification(
+    client, db_session, assigned_lead, sample_person
+):
+    """Assignee gets only the lead_activity_added notification, not also a mention."""
+    tiptap_content = json.dumps(
+        {
+            "type": "doc",
+            "content": [
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {
+                            "type": "mention",
+                            "attrs": {
+                                "id": str(sample_person.id),
+                                "label": sample_person.naam,
+                                "mentionType": "person",
+                            },
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+
+    resp = await client.post(
+        f"/api/leads/{assigned_lead.id}/activities",
+        json={"content": tiptap_content, "activity_type": "note"},
+    )
+    assert resp.status_code == 201
+
+    notifs = (
+        (
+            await db_session.execute(
+                select(Notification).where(Notification.person_id == sample_person.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    # Only the lead_activity_added notification (no extra 'mention')
+    assert len(notifs) == 1
+    assert notifs[0].type == "lead_activity_added"

--- a/frontend/src/components/common/NotificationBell.tsx
+++ b/frontend/src/components/common/NotificationBell.tsx
@@ -5,6 +5,7 @@ import { useNotifications, useUnreadCount, useMarkNotificationRead, useMarkAllNo
 import { useCurrentPerson } from '@/contexts/CurrentPersonContext';
 import { useTaskDetail } from '@/contexts/TaskDetailContext';
 import { useNodeDetail } from '@/contexts/NodeDetailContext';
+import { useLeadDetail } from '@/contexts/LeadDetailContext';
 import { timeAgo } from '@/utils/dates';
 import type { Notification } from '@/types';
 import { richTextToPlain } from '@/utils/richtext';
@@ -132,6 +133,7 @@ export function NotificationBell() {
   const navigate = useNavigate();
   const { openTaskDetail } = useTaskDetail();
   const { openNodeDetail } = useNodeDetail();
+  const { openLeadDetail } = useLeadDetail();
   const { currentPerson } = useCurrentPerson();
 
   useBrowserNotifications();
@@ -215,6 +217,10 @@ export function NotificationBell() {
                       setOpen(false);
                     } else if (notification.related_node_id) {
                       openNodeDetail(notification.related_node_id);
+                      if (!notification.is_read) markRead.mutate(notification.id);
+                      setOpen(false);
+                    } else if (notification.related_lead_id) {
+                      openLeadDetail(notification.related_lead_id);
                       if (!notification.is_read) markRead.mutate(notification.id);
                       setOpen(false);
                     }

--- a/frontend/src/components/inbox/InboxItem.tsx
+++ b/frontend/src/components/inbox/InboxItem.tsx
@@ -4,6 +4,7 @@ import { Badge } from '@/components/common/Badge';
 import { RichTextDisplay } from '@/components/common/RichTextDisplay';
 import { useTaskDetail } from '@/contexts/TaskDetailContext';
 import { useNodeDetail } from '@/contexts/NodeDetailContext';
+import { useLeadDetail } from '@/contexts/LeadDetailContext';
 import { formatDateTimeShort } from '@/utils/dates';
 import { NOTIFICATION_TYPE_LABELS, INBOX_TYPE_COLORS } from '@/types';
 import type { InboxItem as InboxItemType } from '@/types';
@@ -25,6 +26,7 @@ const typeIcons: Record<string, React.ReactNode> = {
 export function InboxItemCard({ item, onOpenThread, onMarkRead }: InboxItemProps) {
   const { openTaskDetail } = useTaskDetail();
   const { openNodeDetail } = useNodeDetail();
+  const { openLeadDetail } = useLeadDetail();
 
   const handleClick = () => {
     if (!item.read && onMarkRead) {
@@ -36,10 +38,12 @@ export function InboxItemCard({ item, onOpenThread, onMarkRead }: InboxItemProps
       openTaskDetail(item.task_id);
     } else if (item.node_id) {
       openNodeDetail(item.node_id);
+    } else if (item.lead_id) {
+      openLeadDetail(item.lead_id);
     }
   };
 
-  const isClickable = item.type === 'message' || !!item.task_id || !!item.node_id;
+  const isClickable = item.type === 'message' || !!item.task_id || !!item.node_id || !!item.lead_id;
 
   return (
     <Card hoverable={isClickable} onClick={handleClick}>

--- a/frontend/src/pages/InboxPage.tsx
+++ b/frontend/src/pages/InboxPage.tsx
@@ -110,6 +110,7 @@ export function InboxPage() {
     description: n.message,
     node_id: n.related_node_id,
     task_id: n.related_task_id,
+    lead_id: n.related_lead_id,
     sender_name: n.sender_name,
     reply_count: n.reply_count,
     created_at: n.created_at,

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -809,6 +809,7 @@ export interface InboxItem {
   source?: string;
   node_id?: string;
   task_id?: string;
+  lead_id?: string;
   sender_name?: string;
   reply_count?: number;
   created_at: string;
@@ -1212,6 +1213,7 @@ export interface Notification {
   is_read: boolean;
   related_node_id?: string;
   related_task_id?: string;
+  related_lead_id?: string;
   parent_id?: string;
   thread_id?: string;
   reply_count: number;


### PR DESCRIPTION
## Wat
Twee bugs in het Activiteiten-blok van de lead-detail:

1. **Toevoegen geeft 500.** `add_activity` in `routes/leads.py` deed `log_activity(..., details={\"activity_type\": data.type})`, maar het schemaveld heet `activity_type`. Resultaat: `AttributeError`, transactie rollt terug, frontend toont \"Fout bij toevoegen activiteit\".

2. **@-mention in notitie stuurt geen melding.** De richtekst-editor in een lead-activiteit ondersteunt `@persoon`, maar `add_activity` riep `sync_and_notify_mentions` niet aan, dus mentions werden niet doorgegeven aan het notificatiesysteem.

## Hoe
- `data.type` -> `data.activity_type.value` (StrEnum, expliciet `.value` voor JSON-veld in `details`).
- `sync_and_notify_mentions` aangeroepen met `source_type=\"lead_activity\"`. Assignee uitgesloten via `exclude_person_id` om dubbele meldingen te voorkomen wanneer iemand zowel assignee als mentioned is (de bestaande `lead_activity_added`-melding gaat al naar de assignee).

## Test plan
- [ ] Open een lead, voeg een notitie toe -> verschijnt in de lijst, geen foutmelding.
- [ ] Type `@<naam>` in de notitie en submit -> de getagde persoon ziet een notificatie van type `mention`.
- [ ] Notitie zonder mention -> alleen de assignee krijgt `lead_activity_added`.
- [ ] Notitie met mention naar de assignee zelf -> alleen `lead_activity_added`, geen tweede `mention`.