### PR TITLE
Fix node-koppelen in lead-detail: aanmaken + persoon meekoppelen

### DIFF
--- a/frontend/src/components/leads/LeadDetailPanel.tsx
+++ b/frontend/src/components/leads/LeadDetailPanel.tsx
@@ -807,7 +807,6 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
     {showLinkNode && lead && (
       <LinkLeadNodeModal
         leadId={lead.id}
-        existingContactPersonIds={lead.contacts.map((c) => c.person_id)}
         onClose={() => setShowLinkNode(false)}
       />
     )}

--- a/frontend/src/components/leads/LeadDetailPanel.tsx
+++ b/frontend/src/components/leads/LeadDetailPanel.tsx
@@ -23,6 +23,7 @@ import { CreatableSelect } from '@/components/common/CreatableSelect';
 import { RichTextFormField } from '@/components/common/RichTextFormField';
 import { RichTextEditor } from '@/components/common/RichTextEditor';
 import { RichTextDisplay } from '@/components/common/RichTextDisplay';
+import { LinkLeadNodeModal } from './LinkLeadNodeModal';
 import { createPerson } from '@/api/people';
 import { Badge } from '@/components/common/Badge';
 import { DetailSection } from '@/components/common/DetailSection';
@@ -36,7 +37,6 @@ import {
   useCreateLeadActivity,
   useAddLeadContact,
   useRemoveLeadContact,
-  useLinkLeadNode,
   useUnlinkLeadNode,
   useUploadLeadAttachment,
   useDeleteLeadAttachment,
@@ -46,7 +46,6 @@ import {
 } from '@/hooks/useLeads';
 import { usePeople } from '@/hooks/usePeople';
 import { useInitiatieven, useCreateInitiatief } from '@/hooks/useInitiatieven';
-import { useNodes } from '@/hooks/useNodes';
 import { getLeadAttachmentDownloadUrl } from '@/api/leads';
 import { isOverdue, formatDateLong, timeAgo } from '@/utils/dates';
 import {
@@ -81,7 +80,6 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
   const { data: people } = usePeople();
   const { data: initiatieven } = useInitiatieven();
   const createInitiatief = useCreateInitiatief();
-  const { data: nodes } = useNodes();
 
   const contactPersonOptions = useMemo(
     () => (people ?? [])
@@ -96,7 +94,6 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
   const createActivity = useCreateLeadActivity();
   const addContact = useAddLeadContact();
   const removeContact = useRemoveLeadContact();
-  const linkNode = useLinkLeadNode();
   const unlinkNode = useUnlinkLeadNode();
   const uploadAttachment = useUploadLeadAttachment();
   const deleteAttachment = useDeleteLeadAttachment();
@@ -124,9 +121,8 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
   const [contactPersonId, setContactPersonId] = useState('');
   const [contactRol, setContactRol] = useState('contactpersoon');
 
-  // Node link form
+  // Node link modal
   const [showLinkNode, setShowLinkNode] = useState(false);
-  const [linkNodeId, setLinkNodeId] = useState('');
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [lightboxSrc, setLightboxSrc] = useState<{ src: string; alt: string } | null>(null);
@@ -250,19 +246,6 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
           setShowAddContact(false);
           setContactPersonId('');
           setContactRol('contactpersoon');
-        },
-      },
-    );
-  };
-
-  const handleLinkNode = () => {
-    if (!lead || !linkNodeId) return;
-    linkNode.mutate(
-      { leadId: lead.id, nodeId: linkNodeId },
-      {
-        onSuccess: () => {
-          setShowLinkNode(false);
-          setLinkNodeId('');
         },
       },
     );
@@ -722,29 +705,6 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
             ) : (
               <p className="text-sm text-text-secondary">Geen gelinkte nodes</p>
             )}
-
-            {showLinkNode && (
-              <div className="flex items-center gap-2 mt-2">
-                <div className="flex-1">
-                  <CreatableSelect
-                    value={linkNodeId}
-                    onChange={setLinkNodeId}
-                    options={nodes?.map((n) => ({
-                      value: n.id,
-                      label: n.title,
-                      description: n.node_type?.replace(/_/g, ' ') ?? undefined,
-                    })) ?? []}
-                    placeholder="Zoek een node..."
-                  />
-                </div>
-                <Button size="sm" onClick={handleLinkNode} disabled={!linkNodeId}>
-                  Koppelen
-                </Button>
-                <Button variant="ghost" size="sm" onClick={() => setShowLinkNode(false)}>
-                  Annuleren
-                </Button>
-              </div>
-            )}
           </DetailSection>
 
           {/* Activiteiten */}
@@ -844,6 +804,13 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
     >
       Weet je zeker dat je deze lead wilt verwijderen?
     </ConfirmDialog>
+    {showLinkNode && lead && (
+      <LinkLeadNodeModal
+        leadId={lead.id}
+        existingContactPersonIds={lead.contacts.map((c) => c.person_id)}
+        onClose={() => setShowLinkNode(false)}
+      />
+    )}
     </>
   );
 }

--- a/frontend/src/components/leads/LinkLeadNodeModal.tsx
+++ b/frontend/src/components/leads/LinkLeadNodeModal.tsx
@@ -3,9 +3,10 @@ import { useState, useCallback, useMemo } from 'react';
 import { Modal } from '@/components/common/Modal';
 import { Button } from '@/components/common/Button';
 import { CreatableSelect, type SelectOption } from '@/components/common/CreatableSelect';
+import { useDebounce } from '@/hooks/useDebounce';
 import { useNodes, useCreateNode } from '@/hooks/useNodes';
 import { usePeople, useCreatePerson } from '@/hooks/usePeople';
-import { useLinkLeadNode, useAddLeadContact } from '@/hooks/useLeads';
+import { useLead, useLinkLeadNode, useAddLeadContact } from '@/hooks/useLeads';
 import { useToast } from '@/contexts/ToastContext';
 import { NodeType, NODE_TYPE_LABELS, LEAD_CONTACT_ROL_LABELS } from '@/types';
 
@@ -13,14 +14,29 @@ const CONTACT_ROLLEN: SelectOption[] = Object.entries(LEAD_CONTACT_ROL_LABELS).m
   ([value, label]) => ({ value, label }),
 );
 
+const NEW_NODE_TYPE_OPTIONS: SelectOption[] = [
+  NodeType.NOTITIE,
+  NodeType.DOSSIER,
+  NodeType.DOEL,
+  NodeType.PROBLEEM,
+  NodeType.INSTRUMENT,
+  NodeType.MAATREGEL,
+  NodeType.BELEIDSKADER,
+  NodeType.BELEIDSOPTIE,
+  NodeType.EFFECT,
+  NodeType.OVERIG,
+].map((value) => ({ value, label: NODE_TYPE_LABELS[value] }));
+
 interface Props {
   leadId: string | null;
-  existingContactPersonIds: string[];
   onClose: () => void;
 }
 
-export function LinkLeadNodeModal({ leadId, existingContactPersonIds, onClose }: Props) {
-  const { data: nodes = [] } = useNodes();
+export function LinkLeadNodeModal({ leadId, onClose }: Props) {
+  const { data: lead } = useLead(leadId);
+  const [nodeQuery, setNodeQuery] = useState('');
+  const debouncedNodeQuery = useDebounce(nodeQuery, 200);
+  const { data: nodes = [] } = useNodes(undefined, debouncedNodeQuery);
   const { data: people = [] } = usePeople();
   const createNode = useCreateNode();
   const createPerson = useCreatePerson();
@@ -29,8 +45,14 @@ export function LinkLeadNodeModal({ leadId, existingContactPersonIds, onClose }:
   const { showError } = useToast();
 
   const [nodeId, setNodeId] = useState('');
+  const [newNodeType, setNewNodeType] = useState<NodeType>(NodeType.NOTITIE);
   const [personId, setPersonId] = useState('');
   const [rol, setRol] = useState('contactpersoon');
+
+  const existingContactPersonIds = useMemo(
+    () => new Set((lead?.contacts ?? []).map((c) => c.person_id)),
+    [lead],
+  );
 
   const nodeOptions: SelectOption[] = useMemo(
     () =>
@@ -56,10 +78,10 @@ export function LinkLeadNodeModal({ leadId, existingContactPersonIds, onClose }:
 
   const handleCreateNode = useCallback(
     async (text: string): Promise<string | null> => {
-      const node = await createNode.mutateAsync({ title: text, node_type: NodeType.NOTITIE });
+      const node = await createNode.mutateAsync({ title: text, node_type: newNodeType });
       return node.id;
     },
-    [createNode],
+    [createNode, newNodeType],
   );
 
   const handleCreatePerson = useCallback(
@@ -72,8 +94,10 @@ export function LinkLeadNodeModal({ leadId, existingContactPersonIds, onClose }:
 
   const resetAndClose = useCallback(() => {
     setNodeId('');
+    setNewNodeType(NodeType.NOTITIE);
     setPersonId('');
     setRol('contactpersoon');
+    setNodeQuery('');
     onClose();
   }, [onClose]);
 
@@ -81,17 +105,20 @@ export function LinkLeadNodeModal({ leadId, existingContactPersonIds, onClose }:
     if (!leadId || !nodeId) return;
     try {
       await linkNode.mutateAsync({ leadId, nodeId });
-      if (personId && !existingContactPersonIds.includes(personId)) {
-        try {
-          await addContact.mutateAsync({ leadId, personId, rol });
-        } catch {
-          showError('Node gekoppeld, maar contactpersoon kon niet worden toegevoegd');
-        }
-      }
-      resetAndClose();
     } catch {
-      // useMutationWithError already shows a toast
+      // useMutationWithError already shows a toast; keep modal open for retry
+      return;
     }
+    if (personId && !existingContactPersonIds.has(personId)) {
+      try {
+        await addContact.mutateAsync({ leadId, personId, rol });
+      } catch {
+        showError('Node gekoppeld, maar contactpersoon kon niet worden toegevoegd');
+        // Keep modal open so the user sees the partial result and can retry the contact
+        return;
+      }
+    }
+    resetAndClose();
   }, [
     leadId,
     nodeId,
@@ -132,9 +159,21 @@ export function LinkLeadNodeModal({ leadId, existingContactPersonIds, onClose }:
           options={nodeOptions}
           placeholder="Zoek of maak een node..."
           onCreate={handleCreateNode}
-          createLabel="Nieuwe notitie aanmaken"
+          createLabel={`Nieuwe ${NODE_TYPE_LABELS[newNodeType].toLowerCase()} aanmaken`}
+          onQueryChange={setNodeQuery}
+          filterLocally={false}
           required
         />
+        {!nodeId && (
+          <CreatableSelect
+            label="Type bij nieuwe node"
+            value={newNodeType}
+            onChange={(v) => setNewNodeType(v as NodeType)}
+            options={NEW_NODE_TYPE_OPTIONS}
+            placeholder="Selecteer een type..."
+            searchable={false}
+          />
+        )}
         <div className="border-t border-border pt-4 space-y-3">
           <p className="text-xs text-text-secondary">
             Optioneel: voeg ook een contactpersoon toe aan deze lead.

--- a/frontend/src/components/leads/LinkLeadNodeModal.tsx
+++ b/frontend/src/components/leads/LinkLeadNodeModal.tsx
@@ -1,0 +1,166 @@
+import { useState, useCallback, useMemo } from 'react';
+
+import { Modal } from '@/components/common/Modal';
+import { Button } from '@/components/common/Button';
+import { CreatableSelect, type SelectOption } from '@/components/common/CreatableSelect';
+import { useNodes, useCreateNode } from '@/hooks/useNodes';
+import { usePeople, useCreatePerson } from '@/hooks/usePeople';
+import { useLinkLeadNode, useAddLeadContact } from '@/hooks/useLeads';
+import { useToast } from '@/contexts/ToastContext';
+import { NodeType, NODE_TYPE_LABELS, LEAD_CONTACT_ROL_LABELS } from '@/types';
+
+const CONTACT_ROLLEN: SelectOption[] = Object.entries(LEAD_CONTACT_ROL_LABELS).map(
+  ([value, label]) => ({ value, label }),
+);
+
+interface Props {
+  leadId: string | null;
+  existingContactPersonIds: string[];
+  onClose: () => void;
+}
+
+export function LinkLeadNodeModal({ leadId, existingContactPersonIds, onClose }: Props) {
+  const { data: nodes = [] } = useNodes();
+  const { data: people = [] } = usePeople();
+  const createNode = useCreateNode();
+  const createPerson = useCreatePerson();
+  const linkNode = useLinkLeadNode();
+  const addContact = useAddLeadContact();
+  const { showError } = useToast();
+
+  const [nodeId, setNodeId] = useState('');
+  const [personId, setPersonId] = useState('');
+  const [rol, setRol] = useState('contactpersoon');
+
+  const nodeOptions: SelectOption[] = useMemo(
+    () =>
+      nodes.map((n) => ({
+        value: n.id,
+        label: n.title,
+        description: NODE_TYPE_LABELS[n.node_type as NodeType] ?? n.node_type?.replace(/_/g, ' '),
+      })),
+    [nodes],
+  );
+
+  const personOptions: SelectOption[] = useMemo(
+    () =>
+      people
+        .filter((p) => p.is_active)
+        .map((p) => ({
+          value: p.id,
+          label: p.naam,
+          description: p.functie ?? undefined,
+        })),
+    [people],
+  );
+
+  const handleCreateNode = useCallback(
+    async (text: string): Promise<string | null> => {
+      const node = await createNode.mutateAsync({ title: text, node_type: NodeType.NOTITIE });
+      return node.id;
+    },
+    [createNode],
+  );
+
+  const handleCreatePerson = useCallback(
+    async (name: string): Promise<string | null> => {
+      const result = await createPerson.mutateAsync({ naam: name, force: true });
+      return result?.id ?? null;
+    },
+    [createPerson],
+  );
+
+  const resetAndClose = useCallback(() => {
+    setNodeId('');
+    setPersonId('');
+    setRol('contactpersoon');
+    onClose();
+  }, [onClose]);
+
+  const handleSubmit = useCallback(async () => {
+    if (!leadId || !nodeId) return;
+    try {
+      await linkNode.mutateAsync({ leadId, nodeId });
+      if (personId && !existingContactPersonIds.includes(personId)) {
+        try {
+          await addContact.mutateAsync({ leadId, personId, rol });
+        } catch {
+          showError('Node gekoppeld, maar contactpersoon kon niet worden toegevoegd');
+        }
+      }
+      resetAndClose();
+    } catch {
+      // useMutationWithError already shows a toast
+    }
+  }, [
+    leadId,
+    nodeId,
+    personId,
+    rol,
+    existingContactPersonIds,
+    linkNode,
+    addContact,
+    resetAndClose,
+    showError,
+  ]);
+
+  const submitting = linkNode.isPending || addContact.isPending;
+
+  return (
+    <Modal
+      open={!!leadId}
+      onClose={resetAndClose}
+      title="Node koppelen"
+      size="sm"
+      zIndex={60}
+      footer={
+        <>
+          <Button variant="secondary" onClick={resetAndClose}>
+            Annuleren
+          </Button>
+          <Button onClick={handleSubmit} loading={submitting} disabled={!nodeId}>
+            Koppelen
+          </Button>
+        </>
+      }
+    >
+      <div className="space-y-4">
+        <CreatableSelect
+          label="Node"
+          value={nodeId}
+          onChange={setNodeId}
+          options={nodeOptions}
+          placeholder="Zoek of maak een node..."
+          onCreate={handleCreateNode}
+          createLabel="Nieuwe notitie aanmaken"
+          required
+        />
+        <div className="border-t border-border pt-4 space-y-3">
+          <p className="text-xs text-text-secondary">
+            Optioneel: voeg ook een contactpersoon toe aan deze lead.
+          </p>
+          <CreatableSelect
+            label="Contactpersoon"
+            value={personId}
+            onChange={setPersonId}
+            options={personOptions}
+            placeholder="Zoek of maak een persoon..."
+            onCreate={handleCreatePerson}
+            createLabel="Nieuwe persoon aanmaken"
+            onClear={personId ? () => setPersonId('') : undefined}
+          />
+          {personId && (
+            <CreatableSelect
+              label="Rol"
+              value={rol}
+              onChange={setRol}
+              options={CONTACT_ROLLEN}
+              placeholder="Selecteer een rol..."
+              searchable={false}
+            />
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/components/leads/LinkLeadNodeModal.tsx
+++ b/frontend/src/components/leads/LinkLeadNodeModal.tsx
@@ -42,7 +42,7 @@ export function LinkLeadNodeModal({ leadId, onClose }: Props) {
   const createPerson = useCreatePerson();
   const linkNode = useLinkLeadNode();
   const addContact = useAddLeadContact();
-  const { showError } = useToast();
+  const { showError, showWarning } = useToast();
 
   const [nodeId, setNodeId] = useState('');
   const [newNodeType, setNewNodeType] = useState<NodeType>(NodeType.NOTITIE);
@@ -67,13 +67,13 @@ export function LinkLeadNodeModal({ leadId, onClose }: Props) {
   const personOptions: SelectOption[] = useMemo(
     () =>
       people
-        .filter((p) => p.is_active)
+        .filter((p) => p.is_active && !existingContactPersonIds.has(p.id))
         .map((p) => ({
           value: p.id,
           label: p.naam,
           description: p.functie ?? undefined,
         })),
-    [people],
+    [people, existingContactPersonIds],
   );
 
   const handleCreateNode = useCallback(
@@ -109,13 +109,17 @@ export function LinkLeadNodeModal({ leadId, onClose }: Props) {
       // useMutationWithError already shows a toast; keep modal open for retry
       return;
     }
-    if (personId && !existingContactPersonIds.has(personId)) {
-      try {
-        await addContact.mutateAsync({ leadId, personId, rol });
-      } catch {
-        showError('Node gekoppeld, maar contactpersoon kon niet worden toegevoegd');
-        // Keep modal open so the user sees the partial result and can retry the contact
-        return;
+    if (personId) {
+      if (existingContactPersonIds.has(personId)) {
+        showWarning('Persoon was al gekoppeld als contactpersoon');
+      } else {
+        try {
+          await addContact.mutateAsync({ leadId, personId, rol });
+        } catch {
+          showError('Node gekoppeld, maar contactpersoon kon niet worden toegevoegd');
+          // Keep modal open so the user sees the partial result and can retry the contact
+          return;
+        }
       }
     }
     resetAndClose();
@@ -129,6 +133,7 @@ export function LinkLeadNodeModal({ leadId, onClose }: Props) {
     addContact,
     resetAndClose,
     showError,
+    showWarning,
   ]);
 
   const submitting = linkNode.isPending || addContact.isPending;


### PR DESCRIPTION
## Probleem

In de lead-detail werkte de "Koppelen"-knop niet voor nodes die nog niet bestonden. De inline `CreatableSelect` had geen `onCreate`-handler, dus als je iets intypte zonder match bleef de Koppelen-knop disabled. Daarnaast was er geen manier om in dezelfde flow ook een nieuwe contactpersoon aan de lead te koppelen.

## Wijziging

Vervangt de inline node-link-form door `LinkLeadNodeModal`:

- Selecteer een bestaande node of maak een nieuwe Notitie-node aan (`NodeType.NOTITIE`).
- Optioneel: kies of maak een persoon aan, die wordt direct als contactpersoon aan de lead gekoppeld (alleen als de persoon nog niet als contact verbonden is).

De nieuwe node wordt aangemaakt via `useCreateNode`, gekoppeld via `useLinkLeadNode`, en de optionele persoon via `useAddLeadContact`. Patroon volgt `AddLeadContactModal`.

## Testplan

- [ ] Open lead-detail, klik op "+ Koppelen", typ een nieuwe titel, kies "Nieuwe notitie aanmaken" — node wordt aangemaakt en gekoppeld.
- [ ] Open lead-detail, klik op "+ Koppelen", selecteer een bestaande node — gekoppeld zonder persoon.
- [ ] Idem, kies daarnaast een bestaande persoon — persoon verschijnt in de Contactpersonen-sectie.
- [ ] Idem, maak een nieuwe persoon aan in dezelfde modal — verschijnt in zowel People als de Contactpersonen-sectie.
- [ ] Persoon die al als contact gekoppeld is wordt niet dubbel toegevoegd.