### PR TITLE
Behoud lijststructuur bij paste in rich text editor

### DIFF
--- a/frontend/src/components/common/RichTextEditor.tsx
+++ b/frontend/src/components/common/RichTextEditor.tsx
@@ -4,11 +4,14 @@ import StarterKit from '@tiptap/starter-kit';
 import Mention from '@tiptap/extension-mention';
 import Placeholder from '@tiptap/extension-placeholder';
 import Link from '@tiptap/extension-link';
+import { DOMParser as ProseMirrorDOMParser } from '@tiptap/pm/model';
+import type { EditorView } from '@tiptap/pm/view';
 import { apiGet } from '@/api/client';
 import { formatFunctie, titleCase } from '@/types';
 import type { Person, OrganisatieEenheid, MentionSearchResult } from '@/types';
 import type { SuggestionProps, SuggestionKeyDownProps } from '@tiptap/suggestion';
 import { ReactRenderer } from '@tiptap/react';
+import { listyTextToHtml } from './richTextPaste';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -417,6 +420,34 @@ function parseContent(value: string): object | string {
   };
 }
 
+// ─── Paste handler: rescue list structure from plain text ──────────────────
+
+/**
+ * When the user pastes plain text that visually represents a list
+ * ("1. foo\n2. bar" or "- foo\n- bar"), convert it to real `ol`/`ul`
+ * nodes instead of a sequence of bare paragraphs.
+ *
+ * Returns true to signal the paste was handled.
+ */
+function insertListyTextOnPaste(view: EditorView, event: ClipboardEvent): boolean {
+  if (!event.clipboardData) return false;
+  // Honour rich content (HTML) — only step in for plain text pastes,
+  // and only when the user is doing a normal paste (not paste-as-plain).
+  if (event.clipboardData.types.includes('text/html')) return false;
+  const text = event.clipboardData.getData('text/plain');
+  if (!text) return false;
+
+  const html = listyTextToHtml(text);
+  if (!html) return false;
+
+  const container = document.createElement('div');
+  container.innerHTML = html;
+  const slice = ProseMirrorDOMParser.fromSchema(view.state.schema).parseSlice(container);
+  view.dispatch(view.state.tr.replaceSelection(slice).scrollIntoView());
+  event.preventDefault();
+  return true;
+}
+
 // ─── Main Component ─────────────────────────────────────────────────────────
 
 export function RichTextEditor({
@@ -450,6 +481,9 @@ export function RichTextEditor({
       PersonMention,
       HashtagMention,
     ],
+    editorProps: {
+      handlePaste: (view, event) => insertListyTextOnPaste(view, event),
+    },
     content: initialContent.current,
     editable: !readOnly,
     onUpdate: ({ editor }) => {

--- a/frontend/src/components/common/RichTextEditor.tsx
+++ b/frontend/src/components/common/RichTextEditor.tsx
@@ -4,7 +4,6 @@ import StarterKit from '@tiptap/starter-kit';
 import Mention from '@tiptap/extension-mention';
 import Placeholder from '@tiptap/extension-placeholder';
 import Link from '@tiptap/extension-link';
-import { DOMParser as ProseMirrorDOMParser } from '@tiptap/pm/model';
 import type { EditorView } from '@tiptap/pm/view';
 import { apiGet } from '@/api/client';
 import { formatFunctie, titleCase } from '@/types';
@@ -427,12 +426,12 @@ function parseContent(value: string): object | string {
  * ("1. foo\n2. bar" or "- foo\n- bar"), convert it to real `ol`/`ul`
  * nodes instead of a sequence of bare paragraphs.
  *
+ * If the clipboard already carries `text/html`, defer to ProseMirror's
+ * default rich-paste path, which already produces proper lists.
  * Returns true to signal the paste was handled.
  */
 function insertListyTextOnPaste(view: EditorView, event: ClipboardEvent): boolean {
   if (!event.clipboardData) return false;
-  // Honour rich content (HTML) — only step in for plain text pastes,
-  // and only when the user is doing a normal paste (not paste-as-plain).
   if (event.clipboardData.types.includes('text/html')) return false;
   const text = event.clipboardData.getData('text/plain');
   if (!text) return false;
@@ -440,12 +439,7 @@ function insertListyTextOnPaste(view: EditorView, event: ClipboardEvent): boolea
   const html = listyTextToHtml(text);
   if (!html) return false;
 
-  const container = document.createElement('div');
-  container.innerHTML = html;
-  const slice = ProseMirrorDOMParser.fromSchema(view.state.schema).parseSlice(container);
-  view.dispatch(view.state.tr.replaceSelection(slice).scrollIntoView());
-  event.preventDefault();
-  return true;
+  return view.pasteHTML(html, event);
 }
 
 // ─── Main Component ─────────────────────────────────────────────────────────

--- a/frontend/src/components/common/richTextPaste.test.ts
+++ b/frontend/src/components/common/richTextPaste.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { looksLikeListPaste, listyTextToHtml } from './richTextPaste';
+
+describe('looksLikeListPaste', () => {
+  it('detects numbered lists', () => {
+    expect(looksLikeListPaste('1. eerste\n2. tweede\n3. derde')).toBe(true);
+  });
+
+  it('detects bullet lists with -', () => {
+    expect(looksLikeListPaste('- alpha\n- bravo')).toBe(true);
+  });
+
+  it('detects bullet lists with •', () => {
+    expect(looksLikeListPaste('• alpha\n• bravo')).toBe(true);
+  });
+
+  it('detects 1) 2) style numbered lists', () => {
+    expect(looksLikeListPaste('1) eerste\n2) tweede')).toBe(true);
+  });
+
+  it('tolerates leading whitespace from indented mail clients', () => {
+    expect(looksLikeListPaste('   1. eerste\n   2. tweede')).toBe(true);
+  });
+
+  it('detects lists separated by blank lines', () => {
+    expect(looksLikeListPaste('1. eerste\n\n2. tweede\n\n3. derde')).toBe(true);
+  });
+
+  it('rejects plain prose', () => {
+    expect(looksLikeListPaste('Gewone tekst zonder lijst.\nMet meerdere regels.')).toBe(false);
+  });
+
+  it('rejects empty input', () => {
+    expect(looksLikeListPaste('')).toBe(false);
+  });
+
+  it('rejects a single isolated list-like line surrounded by prose', () => {
+    expect(
+      looksLikeListPaste('Hier staat veel tekst.\n1. een eenzaam ding\nEn nog meer tekst hier.\nOok een regel.'),
+    ).toBe(false);
+  });
+
+  it('accepts a list with surrounding prose', () => {
+    expect(
+      looksLikeListPaste('Inleiding.\n\n1. punt een\n2. punt twee\n3. punt drie\n\nAfsluiting.'),
+    ).toBe(true);
+  });
+});
+
+describe('listyTextToHtml', () => {
+  it('returns null for non-list text', () => {
+    expect(listyTextToHtml('Gewone tekst.')).toBeNull();
+  });
+
+  it('converts a numbered list to <ol>', () => {
+    const html = listyTextToHtml('1. eerste\n2. tweede\n3. derde');
+    expect(html).toContain('<ol>');
+    expect(html).toContain('<li>eerste</li>');
+    expect(html).toContain('<li>tweede</li>');
+    expect(html).toContain('<li>derde</li>');
+  });
+
+  it('converts a bullet list to <ul>', () => {
+    const html = listyTextToHtml('- alpha\n- bravo');
+    expect(html).toContain('<ul>');
+    expect(html).toContain('<li>alpha</li>');
+    expect(html).toContain('<li>bravo</li>');
+  });
+
+  it('converts • bullets', () => {
+    const html = listyTextToHtml('• alpha\n• bravo');
+    expect(html).toContain('<ul>');
+    expect(html).toContain('<li>alpha</li>');
+  });
+
+  it('converts 1) 2) numbered style', () => {
+    const html = listyTextToHtml('1) eerste\n2) tweede');
+    expect(html).toContain('<ol>');
+    expect(html).toContain('<li>eerste</li>');
+  });
+
+  it('handles indented list lines from mail clients', () => {
+    const html = listyTextToHtml('    1. eerste\n    2. tweede');
+    expect(html).toContain('<ol>');
+    expect(html).toContain('<li>eerste</li>');
+    expect(html).toContain('<li>tweede</li>');
+  });
+
+  it('preserves prose around the list', () => {
+    const html = listyTextToHtml(
+      'Inleiding.\n\n1. punt een\n2. punt twee\n\nAfsluiting.',
+    );
+    expect(html).toContain('<p>Inleiding.</p>');
+    expect(html).toContain('<ol>');
+    expect(html).toContain('<p>Afsluiting.</p>');
+  });
+
+  it('handles Windows line endings', () => {
+    const html = listyTextToHtml('1. eerste\r\n2. tweede');
+    expect(html).toContain('<ol>');
+    expect(html).toContain('<li>eerste</li>');
+    expect(html).toContain('<li>tweede</li>');
+  });
+
+  it('preserves the realistic Abram-style mail content', () => {
+    const input =
+      '1. Pilot van Abv met de SVB. (actie Abv)\n' +
+      '2. Pilot van Abv met DUO. (actie Abv)\n' +
+      '3. Een student doet onderzoek. (actie RR)';
+    const html = listyTextToHtml(input);
+    expect(html).toContain('<ol>');
+    expect(html).toContain('<li>Pilot van Abv met de SVB. (actie Abv)</li>');
+    expect(html).toContain('<li>Een student doet onderzoek. (actie RR)</li>');
+  });
+});

--- a/frontend/src/components/common/richTextPaste.ts
+++ b/frontend/src/components/common/richTextPaste.ts
@@ -1,0 +1,69 @@
+import { micromark } from 'micromark';
+
+const NUMBERED_LINE = /^\s*\d+[.)]\s+\S/;
+const BULLET_LINE = /^\s*[-*•]\s+\S/;
+
+/**
+ * Plain text from a mail-client paste often contains a list as visually
+ * numbered or bulleted lines (e.g. "1. foo\n2. bar" or "• foo\n• bar").
+ * Without help, ProseMirror lands those as bare paragraphs and the
+ * structure is lost. This detects whether such a list is present.
+ *
+ * Heuristic: at least two consecutive list-like lines, or a list-like
+ * line that makes up the majority of non-empty lines.
+ */
+export function looksLikeListPaste(text: string): boolean {
+  const lines = text.split('\n');
+  let listy = 0;
+  let nonEmpty = 0;
+  let consecutive = 0;
+  let maxConsecutive = 0;
+  for (const line of lines) {
+    if (!line.trim()) {
+      consecutive = 0;
+      continue;
+    }
+    nonEmpty += 1;
+    if (NUMBERED_LINE.test(line) || BULLET_LINE.test(line)) {
+      listy += 1;
+      consecutive += 1;
+      if (consecutive > maxConsecutive) maxConsecutive = consecutive;
+    } else {
+      consecutive = 0;
+    }
+  }
+  if (maxConsecutive >= 2) return true;
+  return nonEmpty > 0 && listy / nonEmpty > 0.5;
+}
+
+/**
+ * Normalise paste content so micromark recognises the list structure
+ * regardless of the source client's quirks.
+ *
+ * - Convert `•` and `1)` style bullets into markdown-friendly equivalents.
+ * - Strip leading whitespace on list lines (mail clients often indent).
+ * - Collapse Windows line endings.
+ */
+function normaliseForMarkdown(text: string): string {
+  return text
+    .replace(/\r\n?/g, '\n')
+    .split('\n')
+    .map((line) => {
+      const trimmed = line.replace(/^\s+/, '');
+      if (/^•\s+/.test(trimmed)) return trimmed.replace(/^•\s+/, '- ');
+      if (/^\d+\)\s+/.test(trimmed)) return trimmed.replace(/^(\d+)\)\s+/, '$1. ');
+      if (NUMBERED_LINE.test(trimmed) || BULLET_LINE.test(trimmed)) return trimmed;
+      return line;
+    })
+    .join('\n');
+}
+
+/**
+ * Convert plain text that contains list structure into HTML that
+ * ProseMirror can parse into proper `ol`/`ul` nodes. Returns `null`
+ * when the text shouldn't be treated as a list paste.
+ */
+export function listyTextToHtml(text: string): string | null {
+  if (!looksLikeListPaste(text)) return null;
+  return micromark(normaliseForMarkdown(text));
+}


### PR DESCRIPTION
## Probleem

Abram meldde dat hij in het veld **Beschrijving** bij een nieuwe lead tekst uit een mail plakt. De oorspronkelijke nummering ("1. ... 2. ... 3. ...") komt niet mee — alles landt als platte paragrafen, dus hij moet handmatig hernummeren.

Reproductie: kopieer plain text met genummerde of bullet-regels (uit Outlook, Mail.app, Slack thread, etc.) en plak in een `RichTextFormField`. TipTap krijgt plain text binnen, ziet geen lijststructuur en dropt het als losse paragrafen.

## Oplossing

Een paste-handler op de `RichTextEditor` die plain-text-pastes inspecteert. Als de tekst lijst-achtige regels bevat, wordt het via `micromark` (al een dependency) naar HTML geconverteerd en door ProseMirror's eigen DOMParser geparsed naar echte `ol`/`ul` nodes.

Detectie is conservatief: minstens twee opeenvolgende lijst-regels, of een meerderheid van de niet-lege regels moet lijstvorm hebben. Een enkele "1. ..." midden in proza wordt dus niet gepakt.

Ondersteunt `1.`, `1)`, `-`, `*`, en `•` als markers, en tolereert leading whitespace die mail-clients vaak toevoegen. Rich-text pastes (HTML) blijven het bestaande pad volgen — daar werkte het al.

## Reikwijdte

Werkt overal waar `RichTextFormField` of `RichTextEditor` direct wordt gebruikt: leads, nodes, taken, opdrachten, organisaties, personen, initiatieven.

## Test plan

- [ ] Kopieer Abram's voorbeeldtekst uit een mail (genummerd) en plak in het Beschrijving-veld bij een nieuwe lead → verwacht: een `<ol>` met de items
- [ ] Kopieer een bullet-lijst (`-` of `•`) uit Slack en plak → verwacht: `<ul>`
- [ ] Plak gewone proza zonder nummering → verwacht: paragrafen, ongewijzigd gedrag
- [ ] Plak rich HTML (uit een Word-document met opmaak) → verwacht: opmaak blijft behouden, paste-handler grijpt niet in
- [ ] Plak een mix (proza, dan een lijst, dan proza) → verwacht: paragrafen met lijst er tussenin