### PR TITLE
Toon git SHA en build-tijd in Beheer > Systeem

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -58,6 +58,12 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
 
+      - name: Compute build metadata
+        id: build_meta
+        run: |
+          echo "git_sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          echo "build_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         uses: docker/build-push-action@v7
         with:
@@ -67,6 +73,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_SHA=${{ steps.build_meta.outputs.git_sha }}
+            BUILD_TIME=${{ steps.build_meta.outputs.build_time }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -36,6 +36,11 @@ USER 1001
 # Activate venv via PATH — entrypoint uses python/alembic/uvicorn directly
 ENV PATH="/app/.venv/bin:$PATH"
 
+ARG GIT_SHA=""
+ARG BUILD_TIME=""
+ENV GIT_SHA=$GIT_SHA
+ENV BUILD_TIME=$BUILD_TIME
+
 EXPOSE 8080
 
 ENTRYPOINT ["sh", "/app/entrypoint.sh"]

--- a/backend/bouwmeester/api/routes/admin.py
+++ b/backend/bouwmeester/api/routes/admin.py
@@ -739,11 +739,19 @@ async def reset_database(
 # Build / deploy info
 # ---------------------------------------------------------------------------
 
+# Process-level constants — these env vars are injected at Docker build time
+# and never change during the container's lifetime, so we read them once.
+_VERSION_INFO = {
+    "git_sha": os.environ.get("GIT_SHA", ""),
+    "build_time": os.environ.get("BUILD_TIME", ""),
+    "repo_url": os.environ.get(
+        "REPO_URL",
+        "https://github.com/BureauArchitectuurDigitaleOverheid/bouwmeester",
+    ),
+}
+
 
 @router.get("/version")
 async def version_info(admin: AdminUser) -> dict[str, str]:
-    """Return git SHA and build time injected at Docker build."""
-    return {
-        "git_sha": os.environ.get("GIT_SHA", ""),
-        "build_time": os.environ.get("BUILD_TIME", ""),
-    }
+    """Return backend git SHA, build time, and repo URL (admin only)."""
+    return _VERSION_INFO

--- a/backend/bouwmeester/api/routes/admin.py
+++ b/backend/bouwmeester/api/routes/admin.py
@@ -733,3 +733,17 @@ async def reset_database(
         message=f"Database gereset: {len(tables_to_clear)} tabellen gewist, "
         f"{admin_created} admin-accounts aangemaakt.",
     )
+
+
+# ---------------------------------------------------------------------------
+# Build / deploy info
+# ---------------------------------------------------------------------------
+
+
+@router.get("/version")
+async def version_info(admin: AdminUser) -> dict[str, str]:
+    """Return git SHA and build time injected at Docker build."""
+    return {
+        "git_sha": os.environ.get("GIT_SHA", ""),
+        "build_time": os.environ.get("BUILD_TIME", ""),
+    }

--- a/backend/tests/test_version.py
+++ b/backend/tests/test_version.py
@@ -1,0 +1,41 @@
+"""Tests for the /api/admin/version endpoint constants."""
+
+import importlib
+import os
+
+
+def _reload_admin(env: dict[str, str]):
+    for key in ("GIT_SHA", "BUILD_TIME", "REPO_URL"):
+        os.environ.pop(key, None)
+    for key, value in env.items():
+        os.environ[key] = value
+    from bouwmeester.api.routes import admin as admin_module
+
+    return importlib.reload(admin_module)
+
+
+def test_version_info_reads_env_vars():
+    """_VERSION_INFO captures the env vars present at module load."""
+    try:
+        admin = _reload_admin(
+            {
+                "GIT_SHA": "abc1234",
+                "BUILD_TIME": "2026-05-04T10:00:00Z",
+                "REPO_URL": "https://github.com/example/repo",
+            }
+        )
+        assert admin._VERSION_INFO == {
+            "git_sha": "abc1234",
+            "build_time": "2026-05-04T10:00:00Z",
+            "repo_url": "https://github.com/example/repo",
+        }
+    finally:
+        _reload_admin({})
+
+
+def test_version_info_defaults_when_env_absent():
+    """Without build args set, sha and build_time are empty; repo_url has a default."""
+    admin = _reload_admin({})
+    assert admin._VERSION_INFO["git_sha"] == ""
+    assert admin._VERSION_INFO["build_time"] == ""
+    assert admin._VERSION_INFO["repo_url"].startswith("https://github.com/")

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,6 +8,13 @@ RUN npm install
 COPY . .
 # Copy docs for the in-app documentation page (CI places docs/ in the context)
 COPY doc[s] /docs/
+
+# VITE_* vars are baked into the bundle at build time. CI injects them; for
+# local builds they default to empty and the version panel shows a placeholder.
+ARG GIT_SHA=""
+ARG BUILD_TIME=""
+ENV VITE_GIT_SHA=$GIT_SHA
+ENV VITE_BUILD_TIME=$BUILD_TIME
 RUN npm run build
 
 

--- a/frontend/src/components/admin/SystemInfo.tsx
+++ b/frontend/src/components/admin/SystemInfo.tsx
@@ -1,7 +1,8 @@
-import { ExternalLink, Loader2 } from 'lucide-react';
+import { AlertTriangle, ExternalLink } from 'lucide-react';
 import { useVersionInfo } from '@/hooks/useAdmin';
 
-const REPO_URL = 'https://github.com/BureauArchitectuurDigitaleOverheid/bouwmeester';
+const FRONTEND_GIT_SHA = (import.meta.env.VITE_GIT_SHA ?? '') as string;
+const FRONTEND_BUILD_TIME = (import.meta.env.VITE_BUILD_TIME ?? '') as string;
 
 function formatBuildTime(iso: string): string {
   if (!iso) return '–';
@@ -14,29 +15,40 @@ function formatBuildTime(iso: string): string {
   });
 }
 
+function CommitLink({ sha, repoUrl }: { sha: string; repoUrl: string }) {
+  if (!sha) return <span className="text-text-secondary">–</span>;
+  if (!repoUrl) return <span className="font-mono">{sha}</span>;
+  return (
+    <a
+      href={`${repoUrl}/commit/${sha}`}
+      target="_blank"
+      rel="noreferrer"
+      className="inline-flex items-center gap-1 font-mono text-primary-700 hover:underline"
+    >
+      {sha}
+      <ExternalLink className="h-3.5 w-3.5" />
+    </a>
+  );
+}
+
 export function SystemInfo() {
   const { data, isLoading, error } = useVersionInfo();
 
-  if (isLoading) {
-    return (
-      <div className="flex items-center gap-2 text-text-secondary">
-        <Loader2 className="h-4 w-4 animate-spin" />
-        Laden…
-      </div>
-    );
-  }
+  if (isLoading) return <div className="text-sm text-text-secondary">Laden…</div>;
 
   if (error) {
     return (
-      <div className="text-red-700">
+      <div className="text-sm text-red-700">
         Kon versie-informatie niet ophalen.
       </div>
     );
   }
 
-  const sha = data?.git_sha || '';
-  const buildTime = data?.build_time || '';
-  const hasInfo = sha || buildTime;
+  const backendSha = data?.git_sha || '';
+  const backendBuildTime = data?.build_time || '';
+  const repoUrl = data?.repo_url || '';
+  const hasAny = backendSha || backendBuildTime || FRONTEND_GIT_SHA || FRONTEND_BUILD_TIME;
+  const drift = backendSha && FRONTEND_GIT_SHA && backendSha !== FRONTEND_GIT_SHA;
 
   return (
     <div className="space-y-6 max-w-2xl">
@@ -47,35 +59,37 @@ export function SystemInfo() {
         </p>
       </div>
 
-      {!hasInfo ? (
+      {!hasAny ? (
         <div className="rounded-md border border-border bg-gray-50 p-4 text-sm text-text-secondary">
-          Geen versie-informatie beschikbaar. In lokale dev-builds zijn
-          <code className="mx-1">GIT_SHA</code> en
-          <code className="mx-1">BUILD_TIME</code> niet ingesteld; ze worden
-          alleen door de CI-build gevuld.
+          Geen versie-informatie beschikbaar. In lokale dev-builds zijn de
+          build-args niet gezet; ze worden alleen door de CI-build gevuld.
         </div>
       ) : (
-        <dl className="grid grid-cols-[max-content_1fr] gap-x-6 gap-y-3 text-sm">
-          <dt className="font-medium text-text-secondary">Commit</dt>
-          <dd>
-            {sha ? (
-              <a
-                href={`${REPO_URL}/commit/${sha}`}
-                target="_blank"
-                rel="noreferrer"
-                className="inline-flex items-center gap-1 font-mono text-primary-700 hover:underline"
-              >
-                {sha}
-                <ExternalLink className="h-3.5 w-3.5" />
-              </a>
-            ) : (
-              <span className="text-text-secondary">–</span>
-            )}
-          </dd>
+        <>
+          {drift ? (
+            <div className="flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900">
+              <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0" />
+              <div>
+                Backend en frontend draaien op verschillende commits. Dit kan
+                tijdelijk voorkomen tijdens een deploy, maar mag niet blijvend zijn.
+              </div>
+            </div>
+          ) : null}
 
-          <dt className="font-medium text-text-secondary">Gebouwd op</dt>
-          <dd>{formatBuildTime(buildTime)}</dd>
-        </dl>
+          <dl className="grid grid-cols-[max-content_1fr] gap-x-6 gap-y-3 text-sm">
+            <dt className="font-medium text-text-secondary">Backend-commit</dt>
+            <dd><CommitLink sha={backendSha} repoUrl={repoUrl} /></dd>
+
+            <dt className="font-medium text-text-secondary">Backend gebouwd</dt>
+            <dd>{formatBuildTime(backendBuildTime)}</dd>
+
+            <dt className="font-medium text-text-secondary">Frontend-commit</dt>
+            <dd><CommitLink sha={FRONTEND_GIT_SHA} repoUrl={repoUrl} /></dd>
+
+            <dt className="font-medium text-text-secondary">Frontend gebouwd</dt>
+            <dd>{formatBuildTime(FRONTEND_BUILD_TIME)}</dd>
+          </dl>
+        </>
       )}
     </div>
   );

--- a/frontend/src/components/admin/SystemInfo.tsx
+++ b/frontend/src/components/admin/SystemInfo.tsx
@@ -1,0 +1,82 @@
+import { ExternalLink, Loader2 } from 'lucide-react';
+import { useVersionInfo } from '@/hooks/useAdmin';
+
+const REPO_URL = 'https://github.com/BureauArchitectuurDigitaleOverheid/bouwmeester';
+
+function formatBuildTime(iso: string): string {
+  if (!iso) return '–';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString('nl-NL', {
+    dateStyle: 'long',
+    timeStyle: 'short',
+    timeZone: 'Europe/Amsterdam',
+  });
+}
+
+export function SystemInfo() {
+  const { data, isLoading, error } = useVersionInfo();
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 text-text-secondary">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Laden…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="text-red-700">
+        Kon versie-informatie niet ophalen.
+      </div>
+    );
+  }
+
+  const sha = data?.git_sha || '';
+  const buildTime = data?.build_time || '';
+  const hasInfo = sha || buildTime;
+
+  return (
+    <div className="space-y-6 max-w-2xl">
+      <div>
+        <h2 className="text-lg font-semibold mb-1">Systeem</h2>
+        <p className="text-sm text-text-secondary">
+          Welke versie van Bouwmeester draait er nu in deze omgeving.
+        </p>
+      </div>
+
+      {!hasInfo ? (
+        <div className="rounded-md border border-border bg-gray-50 p-4 text-sm text-text-secondary">
+          Geen versie-informatie beschikbaar. In lokale dev-builds zijn
+          <code className="mx-1">GIT_SHA</code> en
+          <code className="mx-1">BUILD_TIME</code> niet ingesteld; ze worden
+          alleen door de CI-build gevuld.
+        </div>
+      ) : (
+        <dl className="grid grid-cols-[max-content_1fr] gap-x-6 gap-y-3 text-sm">
+          <dt className="font-medium text-text-secondary">Commit</dt>
+          <dd>
+            {sha ? (
+              <a
+                href={`${REPO_URL}/commit/${sha}`}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1 font-mono text-primary-700 hover:underline"
+              >
+                {sha}
+                <ExternalLink className="h-3.5 w-3.5" />
+              </a>
+            ) : (
+              <span className="text-text-secondary">–</span>
+            )}
+          </dd>
+
+          <dt className="font-medium text-text-secondary">Gebouwd op</dt>
+          <dd>{formatBuildTime(buildTime)}</dd>
+        </dl>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/hooks/queryKeys.ts
+++ b/frontend/src/hooks/queryKeys.ts
@@ -125,6 +125,7 @@ export const queryKeys = {
       ['admin', 'resource-permissions', personId] as const,
     eenheidRoleAssignments: (eenheidId: string | null) =>
       ['admin', 'eenheid-role-assignments', eenheidId] as const,
+    version: () => ['admin', 'version'] as const,
   },
 
   // --- Org Placements ---

--- a/frontend/src/hooks/useAdmin.ts
+++ b/frontend/src/hooks/useAdmin.ts
@@ -82,3 +82,20 @@ export function useUpdateAppConfig() {
     invalidateKeys: [queryKeys.admin.config()],
   });
 }
+
+// ---------------------------------------------------------------------------
+// Build / deploy info
+// ---------------------------------------------------------------------------
+
+export interface VersionInfo {
+  git_sha: string;
+  build_time: string;
+}
+
+export function useVersionInfo() {
+  return useQuery({
+    queryKey: queryKeys.admin.version(),
+    queryFn: () => apiGet<VersionInfo>('/api/admin/version'),
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/frontend/src/hooks/useAdmin.ts
+++ b/frontend/src/hooks/useAdmin.ts
@@ -90,6 +90,7 @@ export function useUpdateAppConfig() {
 export interface VersionInfo {
   git_sha: string;
   build_time: string;
+  repo_url: string;
 }
 
 export function useVersionInfo() {

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -11,6 +11,7 @@ import { EdgeSchemaManager } from '@/components/admin/EdgeSchemaManager';
 import { SharingManager } from '@/components/admin/SharingManager';
 import { RoleManager } from '@/components/admin/RoleManager';
 import { EenheidBeheerManager } from '@/components/admin/EenheidBeheerManager';
+import { SystemInfo } from '@/components/admin/SystemInfo';
 type Tab =
   | 'whitelist'
   | 'database'
@@ -20,7 +21,8 @@ type Tab =
   | 'schema'
   | 'users'
   | 'sharing'
-  | 'eenheden';
+  | 'eenheden'
+  | 'system';
 
 export function AdminPage() {
   const { person, oidcConfigured, loading, viewAsNonAdmin } = useAuth();
@@ -86,6 +88,9 @@ export function AdminPage() {
   if (hasPermission('database:backup')) {
     tabs.push({ id: 'database', label: 'Database' });
   }
+  if (hasPermission('config:manage')) {
+    tabs.push({ id: 'system', label: 'Systeem' });
+  }
 
   return (
     <div className="max-w-6xl">
@@ -118,6 +123,7 @@ export function AdminPage() {
           {activeTab === 'schema' && <EdgeSchemaManager />}
           {activeTab === 'sharing' && <SharingManager />}
           {activeTab === 'eenheden' && <EenheidBeheerManager />}
+          {activeTab === 'system' && <SystemInfo />}
         </>
       ) : null}
     </div>


### PR DESCRIPTION
## Samenvatting

- Build-args `GIT_SHA` en `BUILD_TIME` worden in de CI-build geïnjecteerd in zowel de backend (env vars) als de frontend (via `VITE_*` in de bundle).
- Nieuwe endpoint `GET /api/admin/version` geeft `git_sha`, `build_time` en `repo_url` terug (admin-only). `REPO_URL` is overridebaar via env var.
- Nieuwe tab **Beheer > Systeem** toont commit en build-tijd voor backend én frontend, met klikbare commit-links. Bij verschillende SHAs verschijnt een gele drift-waarschuwing.
- Lokale dev-builds tonen een uitleg dat de waarden alleen door CI worden ingevuld.
- Test toegevoegd voor `_VERSION_INFO` (env var lezen + defaults).

## Test plan

- [ ] Lokaal de Beheer > Systeem-tab openen — moet de "geen versie-informatie"-uitleg tonen.
- [ ] Na merge: na de eerste deploy de tab openen — moet vier velden tonen (backend + frontend, commit + tijd) met werkende commit-links.
- [ ] Niet-admin gebruiker krijgt 401/403 op `/api/admin/version`.