### PR TITLE
Filter opdrachten op org-context en eis opdracht:read

### DIFF
--- a/backend/bouwmeester/api/routes/nodes.py
+++ b/backend/bouwmeester/api/routes/nodes.py
@@ -109,7 +109,9 @@ async def list_nodes(
     instrument_ids = [r.id for r in responses if r.node_type == "instrument"]
     if instrument_ids:
         opdracht_repo = OpdrachtRepository(db)
-        budget_map = await opdracht_repo.get_budget_summaries(instrument_ids)
+        budget_map = await opdracht_repo.get_budget_summaries(
+            instrument_ids, org_ctx=org_ctx
+        )
         for r in responses:
             if r.node_type == "instrument" and r.id in budget_map:
                 budget, gerealiseerd = budget_map[r.id]
@@ -705,12 +707,15 @@ async def get_node_financieel(
     id: UUID,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("opdracht:read")),
+    org_ctx: OrgContext = Depends(get_org_context),
 ) -> FinancieelOverzicht:
     """Get financial overview for a node (aggregated from opdrachten)."""
+    await check_resource_org_scope(db, "corpus_node", id, org_ctx)
     service = NodeService(db)
     require_found(await service.get(id), "Node")
     fin_service = FinancieelService(db)
-    return await fin_service.get_financieel_overzicht(id)
+    return await fin_service.get_financieel_overzicht(id, org_ctx=org_ctx)
 
 
 @router.get("/{id}/opdrachten", response_model=list[OpdrachtResponse])
@@ -718,12 +723,15 @@ async def get_node_opdrachten(
     id: UUID,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("opdracht:read")),
+    org_ctx: OrgContext = Depends(get_org_context),
 ) -> list[OpdrachtResponse]:
     """Get opdrachten linked to a node (via instrument_id or OpdrachtNode)."""
+    await check_resource_org_scope(db, "corpus_node", id, org_ctx)
     service = NodeService(db)
     require_found(await service.get(id), "Node")
     repo = OpdrachtRepository(db)
-    opdrachten = await repo.get_by_node(id)
+    opdrachten = await repo.get_by_node(id, org_ctx=org_ctx)
     return validate_list(OpdrachtResponse, opdrachten)
 
 

--- a/backend/bouwmeester/api/routes/opdrachten.py
+++ b/backend/bouwmeester/api/routes/opdrachten.py
@@ -56,6 +56,8 @@ async def list_opdrachten(
     skip: int = Query(0, ge=0),
     limit: int = Query(10_000, ge=1, le=10_000),
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("opdracht:read")),
+    org_ctx: OrgContext = Depends(get_org_context),
 ) -> list[OpdrachtResponse]:
     repo = OpdrachtRepository(db)
     items = await repo.get_all(
@@ -68,6 +70,7 @@ async def list_opdrachten(
         opdrachtnemer_id=opdrachtnemer_id,
         opdrachtgever_id=opdrachtgever_id,
         verantwoordelijke_id=verantwoordelijke_id,
+        org_ctx=org_ctx,
     )
     return validate_list(OpdrachtResponse, items)
 
@@ -83,6 +86,8 @@ async def get_opdrachten_summary(
     opdrachtgever_id: UUID | None = None,
     verantwoordelijke_id: UUID | None = None,
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("opdracht:read")),
+    org_ctx: OrgContext = Depends(get_org_context),
 ) -> OpdrachtenSummary:
     """Server-side aggregation of opdrachten totals (respects active filters)."""
     repo = OpdrachtRepository(db)
@@ -94,6 +99,7 @@ async def get_opdrachten_summary(
         opdrachtnemer_id=opdrachtnemer_id,
         opdrachtgever_id=opdrachtgever_id,
         verantwoordelijke_id=verantwoordelijke_id,
+        org_ctx=org_ctx,
     )
     totaal_budget = data["totaal_budget"]
     totaal_gerealiseerd = data["totaal_gerealiseerd"]
@@ -182,7 +188,10 @@ async def get_opdracht(
     id: UUID,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("opdracht:read")),
+    org_ctx: OrgContext = Depends(get_org_context),
 ) -> OpdrachtResponse:
+    await check_resource_org_scope(db, "opdracht", id, org_ctx)
     repo = OpdrachtRepository(db)
     opdracht = require_found(await repo.get(id), "Opdracht")
 

--- a/backend/bouwmeester/repositories/opdracht.py
+++ b/backend/bouwmeester/repositories/opdracht.py
@@ -6,6 +6,7 @@ from uuid import UUID
 from sqlalchemy import func, select
 from sqlalchemy.orm import selectinload
 
+from bouwmeester.core.org_context import OrgContext, apply_org_filter
 from bouwmeester.models.opdracht import Opdracht, OpdrachtNode
 from bouwmeester.models.resource_permission import ResourcePermission
 from bouwmeester.repositories.base import BaseRepository
@@ -89,13 +90,10 @@ class OpdrachtRepository(BaseRepository[Opdracht]):
         opdrachtnemer_id: UUID | None = None,
         opdrachtgever_id: UUID | None = None,
         verantwoordelijke_id: UUID | None = None,
+        org_ctx: OrgContext | None = None,
     ) -> list[Opdracht]:
-        stmt = (
-            select(Opdracht)
-            .options(selectinload(Opdracht.node_koppelingen))
-            .offset(skip)
-            .limit(limit)
-        )
+        stmt = select(Opdracht).options(selectinload(Opdracht.node_koppelingen))
+        stmt = apply_org_filter(stmt, Opdracht.opdrachtgever_id, org_ctx)
         if begrotingsjaar is not None:
             stmt = stmt.where(Opdracht.begrotingsjaar == begrotingsjaar)
         if type is not None:
@@ -110,7 +108,11 @@ class OpdrachtRepository(BaseRepository[Opdracht]):
             stmt = stmt.where(Opdracht.opdrachtgever_id == opdrachtgever_id)
         if verantwoordelijke_id is not None:
             stmt = stmt.where(Opdracht.verantwoordelijke_id == verantwoordelijke_id)
-        stmt = stmt.order_by(Opdracht.begrotingsjaar.desc(), Opdracht.titel)
+        stmt = (
+            stmt.order_by(Opdracht.begrotingsjaar.desc(), Opdracht.titel)
+            .offset(skip)
+            .limit(limit)
+        )
         result = await self.session.execute(stmt)
         return list(result.scalars().all())
 
@@ -181,6 +183,7 @@ class OpdrachtRepository(BaseRepository[Opdracht]):
         opdrachtnemer_id: UUID | None = None,
         opdrachtgever_id: UUID | None = None,
         verantwoordelijke_id: UUID | None = None,
+        org_ctx: OrgContext | None = None,
     ) -> dict:
         """Aggregate count, total budget, total gerealiseerd."""
         stmt = select(
@@ -190,6 +193,7 @@ class OpdrachtRepository(BaseRepository[Opdracht]):
                 "totaal_gerealiseerd"
             ),
         )
+        stmt = apply_org_filter(stmt, Opdracht.opdrachtgever_id, org_ctx)
         if begrotingsjaar is not None:
             stmt = stmt.where(Opdracht.begrotingsjaar == begrotingsjaar)
         if type is not None:

--- a/backend/bouwmeester/repositories/opdracht.py
+++ b/backend/bouwmeester/repositories/opdracht.py
@@ -120,19 +120,27 @@ class OpdrachtRepository(BaseRepository[Opdracht]):
         self,
         instrument_id: UUID,
         begrotingsjaar: int | None = None,
+        *,
+        org_ctx: OrgContext | None = None,
     ) -> list[Opdracht]:
         stmt = (
             select(Opdracht)
             .where(Opdracht.instrument_id == instrument_id)
             .options(selectinload(Opdracht.node_koppelingen))
         )
+        stmt = apply_org_filter(stmt, Opdracht.opdrachtgever_id, org_ctx)
         if begrotingsjaar is not None:
             stmt = stmt.where(Opdracht.begrotingsjaar == begrotingsjaar)
         stmt = stmt.order_by(Opdracht.begrotingsjaar.desc(), Opdracht.titel)
         result = await self.session.execute(stmt)
         return list(result.scalars().all())
 
-    async def get_by_node(self, node_id: UUID) -> list[Opdracht]:
+    async def get_by_node(
+        self,
+        node_id: UUID,
+        *,
+        org_ctx: OrgContext | None = None,
+    ) -> list[Opdracht]:
         """Get opdrachten linked to a node via instrument_id or OpdrachtNode."""
         direct = select(Opdracht.id).where(Opdracht.instrument_id == node_id)
         via_junction = select(OpdrachtNode.opdracht_id).where(
@@ -145,6 +153,7 @@ class OpdrachtRepository(BaseRepository[Opdracht]):
             .options(selectinload(Opdracht.node_koppelingen))
             .order_by(Opdracht.begrotingsjaar.desc(), Opdracht.titel)
         )
+        stmt = apply_org_filter(stmt, Opdracht.opdrachtgever_id, org_ctx)
         result = await self.session.execute(stmt)
         return list(result.scalars().all())
 
@@ -215,6 +224,8 @@ class OpdrachtRepository(BaseRepository[Opdracht]):
     async def aggregate_by_instrument(
         self,
         instrument_id: UUID,
+        *,
+        org_ctx: OrgContext | None = None,
     ) -> list[dict]:
         """Aggregate budget/gerealiseerd per begrotingsjaar for an instrument."""
         stmt = (
@@ -234,11 +245,15 @@ class OpdrachtRepository(BaseRepository[Opdracht]):
             .group_by(Opdracht.begrotingsjaar)
             .order_by(Opdracht.begrotingsjaar)
         )
+        stmt = apply_org_filter(stmt, Opdracht.opdrachtgever_id, org_ctx)
         result = await self.session.execute(stmt)
         return [dict(row._mapping) for row in result.all()]
 
     async def get_budget_summaries(
-        self, instrument_ids: list[UUID]
+        self,
+        instrument_ids: list[UUID],
+        *,
+        org_ctx: OrgContext | None = None,
     ) -> dict[UUID, tuple[Decimal, Decimal]]:
         """Return {instrument_id: (total_budget, total_gerealiseerd)} for given IDs."""
         if not instrument_ids:
@@ -252,6 +267,7 @@ class OpdrachtRepository(BaseRepository[Opdracht]):
             .where(Opdracht.instrument_id.in_(instrument_ids))
             .group_by(Opdracht.instrument_id)
         )
+        stmt = apply_org_filter(stmt, Opdracht.opdrachtgever_id, org_ctx)
         result = await self.session.execute(stmt)
         return {
             row.instrument_id: (row.budget, row.gerealiseerd) for row in result.all()

--- a/backend/bouwmeester/services/chat_service.py
+++ b/backend/bouwmeester/services/chat_service.py
@@ -1313,11 +1313,13 @@ async def _execute_read_tool(
             from bouwmeester.repositories.opdracht import OpdrachtRepository
 
             repo = OpdrachtRepository(db)
+            org_ctx = await _build_chat_org_context(db, person_id)
             opdrachten = await repo.get_all(
                 limit=15,
                 begrotingsjaar=args.get("begrotingsjaar"),
                 status=args.get("status"),
                 type=args.get("type"),
+                org_ctx=org_ctx,
             )
             items = [
                 {
@@ -1337,9 +1339,18 @@ async def _execute_read_tool(
             from bouwmeester.repositories.opdracht import OpdrachtRepository
 
             repo = OpdrachtRepository(db)
-            o = await repo.get(UUID(args["opdracht_id"]))
+            org_ctx = await _build_chat_org_context(db, person_id)
+            opdracht_id = UUID(args["opdracht_id"])
+            o = await repo.get(opdracht_id)
             if not o:
                 return _safe_dumps({"error": "Opdracht niet gevonden"})
+            # Respect org-context: hide opdrachten from invisible eenheden.
+            if not org_ctx.is_admin and o.opdrachtgever_id is not None:
+                visible = set(org_ctx.visible_eenheid_ids) | set(
+                    org_ctx.shared_eenheid_ids
+                )
+                if o.opdrachtgever_id not in visible:
+                    return _safe_dumps({"error": "Geen toegang tot deze opdracht"})
             return _safe_dumps(
                 {
                     "id": str(o.id),

--- a/backend/bouwmeester/services/financieel_service.py
+++ b/backend/bouwmeester/services/financieel_service.py
@@ -9,6 +9,7 @@ from uuid import UUID
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from bouwmeester.core.org_context import OrgContext, apply_org_filter
 from bouwmeester.models.corpus_node import CorpusNode
 from bouwmeester.models.edge import Edge
 from bouwmeester.models.opdracht import Opdracht, OpdrachtNode
@@ -20,7 +21,12 @@ class FinancieelService:
     def __init__(self, session: AsyncSession) -> None:
         self.session = session
 
-    async def get_financieel_overzicht(self, node_id: UUID) -> FinancieelOverzicht:
+    async def get_financieel_overzicht(
+        self,
+        node_id: UUID,
+        *,
+        org_ctx: OrgContext | None = None,
+    ) -> FinancieelOverzicht:
         """Get financial overview for a node.
 
         For instrument nodes: aggregate directly linked opdrachten.
@@ -70,6 +76,7 @@ class FinancieelService:
             .group_by(Opdracht.begrotingsjaar)
             .order_by(Opdracht.begrotingsjaar)
         )
+        stmt = apply_org_filter(stmt, Opdracht.opdrachtgever_id, org_ctx)
 
         result = await self.session.execute(stmt)
         per_jaar = [

--- a/backend/tests/test_org_visibility.py
+++ b/backend/tests/test_org_visibility.py
@@ -6,6 +6,7 @@ organisatie-eenheden (or data without an org assignment).
 
 import uuid
 from datetime import date
+from decimal import Decimal
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -15,6 +16,7 @@ from bouwmeester.core.auth import get_optional_user
 from bouwmeester.core.database import get_db
 from bouwmeester.models.corpus_node import CorpusNode
 from bouwmeester.models.edge import Edge
+from bouwmeester.models.opdracht import Opdracht
 from bouwmeester.models.organisatie_eenheid import OrganisatieEenheid
 from bouwmeester.models.person import Person
 from bouwmeester.models.person_email import PersonEmail
@@ -127,6 +129,43 @@ async def org_visibility_setup(db_session: AsyncSession, _test_app):
     db_session.add_all([visible_task, invisible_task])
     await db_session.flush()
 
+    # Create opdrachten: one in each org, one without org
+    visible_opdracht = Opdracht(
+        id=uuid.uuid4(),
+        titel="Zichtbare opdracht",
+        type="opdracht",
+        status="actief",
+        begrotingsjaar=2025,
+        instrument_id=visible_node.id,
+        opdrachtgever_id=visible_org.id,
+        budget=Decimal("100000"),
+        gerealiseerd=Decimal("25000"),
+    )
+    invisible_opdracht = Opdracht(
+        id=uuid.uuid4(),
+        titel="Onzichtbare opdracht",
+        type="opdracht",
+        status="actief",
+        begrotingsjaar=2025,
+        instrument_id=invisible_node.id,
+        opdrachtgever_id=invisible_org.id,
+        budget=Decimal("200000"),
+        gerealiseerd=Decimal("50000"),
+    )
+    unassigned_opdracht = Opdracht(
+        id=uuid.uuid4(),
+        titel="Ongeplaatste opdracht",
+        type="opdracht",
+        status="actief",
+        begrotingsjaar=2025,
+        instrument_id=unassigned_node.id,
+        opdrachtgever_id=None,
+        budget=Decimal("50000"),
+        gerealiseerd=Decimal("0"),
+    )
+    db_session.add_all([visible_opdracht, invisible_opdracht, unassigned_opdracht])
+    await db_session.flush()
+
     # Create edge type
     from bouwmeester.models.edge_type import EdgeType
 
@@ -182,6 +221,9 @@ async def org_visibility_setup(db_session: AsyncSession, _test_app):
             "invisible_task": invisible_task,
             "edge_both_visible": edge_both_visible,
             "edge_one_invisible": edge_one_invisible,
+            "visible_opdracht": visible_opdracht,
+            "invisible_opdracht": invisible_opdracht,
+            "unassigned_opdracht": unassigned_opdracht,
         }
 
     app.dependency_overrides.clear()
@@ -278,3 +320,54 @@ async def test_get_edge_returns_404_for_invisible(org_visibility_setup):
     s = org_visibility_setup
     resp = await s["client"].get(f"/api/edges/{s['edge_one_invisible'].id}")
     assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Opdracht visibility tests
+# ---------------------------------------------------------------------------
+
+
+async def test_list_opdrachten_hides_invisible_org(org_visibility_setup):
+    """Non-admin should not see opdrachten from an invisible org."""
+    s = org_visibility_setup
+    resp = await s["client"].get("/api/opdrachten")
+    assert resp.status_code == 200
+    ids = {o["id"] for o in resp.json()}
+    assert str(s["visible_opdracht"].id) in ids
+    assert str(s["invisible_opdracht"].id) not in ids
+
+
+async def test_list_opdrachten_shows_null_org(org_visibility_setup):
+    """Non-admin should see opdrachten without opdrachtgever_id (NULL)."""
+    s = org_visibility_setup
+    resp = await s["client"].get("/api/opdrachten")
+    assert resp.status_code == 200
+    ids = {o["id"] for o in resp.json()}
+    assert str(s["unassigned_opdracht"].id) in ids
+
+
+async def test_summary_excludes_invisible_org(org_visibility_setup):
+    """Summary aggregates only over opdrachten the user can see."""
+    s = org_visibility_setup
+    resp = await s["client"].get("/api/opdrachten/summary")
+    assert resp.status_code == 200
+    data = resp.json()
+    # visible (100k + 50k null) but not invisible (200k)
+    assert int(data["count"]) == 2
+    assert Decimal(str(data["totaal_budget"])) == Decimal("150000")
+    assert Decimal(str(data["totaal_gerealiseerd"])) == Decimal("25000")
+
+
+async def test_get_opdracht_forbidden_for_invisible(org_visibility_setup):
+    """Non-admin should get 403 for an opdracht in an invisible org."""
+    s = org_visibility_setup
+    resp = await s["client"].get(f"/api/opdrachten/{s['invisible_opdracht'].id}")
+    assert resp.status_code == 403
+
+
+async def test_get_opdracht_allows_visible(org_visibility_setup):
+    """Non-admin should be able to read an opdracht in their org."""
+    s = org_visibility_setup
+    resp = await s["client"].get(f"/api/opdrachten/{s['visible_opdracht'].id}")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == str(s["visible_opdracht"].id)

--- a/backend/tests/test_org_visibility.py
+++ b/backend/tests/test_org_visibility.py
@@ -371,3 +371,31 @@ async def test_get_opdracht_allows_visible(org_visibility_setup):
     resp = await s["client"].get(f"/api/opdrachten/{s['visible_opdracht'].id}")
     assert resp.status_code == 200
     assert resp.json()["id"] == str(s["visible_opdracht"].id)
+
+
+# ---------------------------------------------------------------------------
+# Node-driven opdracht endpoints (instrument-detail leakage)
+# ---------------------------------------------------------------------------
+
+
+async def test_get_node_opdrachten_filters_invisible(org_visibility_setup):
+    """GET /nodes/{instrument}/opdrachten only shows opdrachten in scope."""
+    s = org_visibility_setup
+    resp = await s["client"].get(f"/api/nodes/{s['visible_node'].id}/opdrachten")
+    assert resp.status_code == 200
+    ids = {o["id"] for o in resp.json()}
+    assert str(s["invisible_opdracht"].id) not in ids
+
+
+async def test_get_node_opdrachten_forbids_invisible_node(org_visibility_setup):
+    """An invisible node returns 403 via check_resource_org_scope."""
+    s = org_visibility_setup
+    resp = await s["client"].get(f"/api/nodes/{s['invisible_node'].id}/opdrachten")
+    assert resp.status_code == 403
+
+
+async def test_get_node_financieel_forbids_invisible_node(org_visibility_setup):
+    """Financial overview on an invisible node is forbidden."""
+    s = org_visibility_setup
+    resp = await s["client"].get(f"/api/nodes/{s['invisible_node'].id}/financieel")
+    assert resp.status_code == 403


### PR DESCRIPTION
## Probleem

Een gebruiker die niet de juiste rechten zou moeten hebben kreeg via een directe link toegang tot \`/opdrachten\` en zag daar **alle** opdrachten van het ministerie. De drie GET-endpoints op \`/api/opdrachten\` (list, summary, detail) hadden geen permission check en geen org-scope filter.

Schrijf-endpoints (POST/PUT/DELETE) waren wel correct beveiligd met \`require_permission(\"opdracht:create|update|delete\")\` en \`check_resource_org_scope\`. De lees-kant was over het hoofd gezien.

## Fix

- \`OpdrachtRepository.get_all\` en \`.get_summary\` accepteren nu een optionele \`org_ctx: OrgContext | None\`. Wanneer meegegeven wordt \`apply_org_filter(stmt, Opdracht.opdrachtgever_id, org_ctx)\` toegepast — zelfde patroon als \`CorpusNodeRepository\` en \`TaskRepository\`. Default \`None\` houdt interne callers (background services, dashboards) ongewijzigd.
- \`list_opdrachten\` en \`get_opdrachten_summary\` krijgen \`_perm=Depends(require_permission(\"opdracht:read\"))\` en \`org_ctx=Depends(get_org_context)\`. \`get_opdracht\` doet bovendien \`check_resource_org_scope(db, \"opdracht\", id, org_ctx)\` voor de detail-lookup.
- \`opdracht:read\` was al geseed in migration \`c44e4533e993\` en gegrant aan \`viewer\` en hoger. Geen nieuwe migratie nodig.

## Tests

5 nieuwe tests in \`backend/tests/test_org_visibility.py\` (hergebruik bestaande \`org_visibility_setup\` fixture):

- \`test_list_opdrachten_hides_invisible_org\`
- \`test_list_opdrachten_shows_null_org\`
- \`test_summary_excludes_invisible_org\`
- \`test_get_opdracht_forbidden_for_invisible\`
- \`test_get_opdracht_allows_visible\`

Bestaande \`tests/test_opdrachten.py\` (21 tests) blijft groen — die draaien zonder OIDC en raken het admin-shortcut-pad in \`get_org_context\`.

## Sanity-query staging vóór deploy

\`\`\`sql
SELECT count(*) FROM opdracht WHERE opdrachtgever_id IS NULL;
\`\`\`

Opdrachten met NULL \`opdrachtgever_id\` blijven voor iedereen zichtbaar (consistent met andere modules — \`apply_org_filter\` doet \`column IS NULL OR column IN (...)\`). Als dat aantal hoog is moet later een data-cleanup of NOT NULL migratie volgen.

## Vervolg

Dit is fase 1 van een breder probleem: meerdere andere route-bestanden (parlementair.py, people.py, sommige tasks.py endpoints) hebben hetzelfde patroon en zijn ook onbeschermd. Volgt in aparte PR's.

## Test plan

- [x] \`uv run pytest tests/test_org_visibility.py -v\` — 14 tests pass (waarvan 5 nieuw)
- [x] \`uv run pytest tests/test_opdrachten.py -v\` — 21 tests pass (regressie-check)
- [x] \`ruff format\` + \`ruff check\` clean
- [ ] Staging: gebruiker zonder placement → \`/api/opdrachten\` returnt \`[]\`
- [ ] Staging: gebruiker met placement in eenheid X → ziet alleen opdrachten met \`opdrachtgever_id=X\` of NULL
- [ ] Staging: \`GET /api/opdrachten/{id-andere-eenheid}\` → 403