### PR TITLE
Bescherm parlementair-endpoints met dedicated permissions

### DIFF
--- a/backend/bouwmeester/api/routes/parlementair.py
+++ b/backend/bouwmeester/api/routes/parlementair.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from bouwmeester.api.deps import validate_list
 from bouwmeester.core.auth import OptionalUser
 from bouwmeester.core.database import get_db
+from bouwmeester.core.permissions import require_permission
 from bouwmeester.models.corpus_node import CorpusNode
 from bouwmeester.models.edge import Edge
 from bouwmeester.models.person import Person
@@ -59,6 +60,7 @@ async def list_imports(
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=500),
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("parlementair:read")),
 ) -> list[ParlementairItemResponse]:
     """List imported parliamentary items. Filter by status, bron, type, or search."""
     repo = ParlementairItemRepository(db)
@@ -78,6 +80,7 @@ async def get_import(
     import_id: UUID,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("parlementair:read")),
 ) -> ParlementairItemResponse:
     """Get a single parliamentary import item by ID."""
     repo = ParlementairItemRepository(db)
@@ -93,6 +96,7 @@ async def trigger_import(
     item_types: list[str] | None = Query(None, alias="types"),
     actor_id: UUID | None = Query(None),
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("parlementair:import")),
 ) -> dict:
     """Trigger a manual parliamentary item import poll."""
     from bouwmeester.services.parlementair_import_service import (
@@ -119,6 +123,7 @@ async def reprocess_imports(
     item_type: Literal["motie", "kamervraag", "toezegging"] = Query("toezegging"),
     actor_id: UUID | None = Query(None),
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("parlementair:import")),
 ) -> dict:
     """Re-process imported items that have no suggested edges.
 
@@ -148,6 +153,7 @@ async def get_review_queue(
     current_user: OptionalUser,
     type_filter: str | None = Query(None, alias="type"),
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("parlementair:read")),
 ) -> list[ParlementairItemResponse]:
     """Get parliamentary items pending review, optionally filtered by type."""
     repo = ParlementairItemRepository(db)
@@ -161,6 +167,7 @@ async def reject_import(
     current_user: OptionalUser,
     actor_id: UUID | None = Query(None),
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("parlementair:review")),
 ) -> ParlementairItemResponse:
     """Reject a parliamentary import item (sets status to rejected)."""
     repo = ParlementairItemRepository(db)
@@ -187,6 +194,7 @@ async def reopen_import(
     current_user: OptionalUser,
     actor_id: UUID | None = Query(None),
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("parlementair:review")),
 ) -> ParlementairItemResponse:
     """Reopen a rejected or out-of-scope item for review."""
     from bouwmeester.services.parlementair_import_service import (
@@ -237,6 +245,7 @@ async def complete_review(
     current_user: OptionalUser,
     actor_id: UUID | None = Query(None),
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("parlementair:review")),
 ) -> ParlementairItemResponse:
     """Complete review: assign eigenaar, create follow-up tasks, mark as reviewed."""
     repo = ParlementairItemRepository(db)
@@ -323,6 +332,7 @@ async def update_suggested_edge(
     body: UpdateSuggestedEdgeRequest,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("parlementair:review")),
 ) -> SuggestedEdgeResponse:
     """Update a suggested edge (e.g. change its edge type) before approval."""
     repo = SuggestedEdgeRepository(db)
@@ -343,6 +353,7 @@ async def approve_edge(
     current_user: OptionalUser,
     actor_id: UUID | None = Query(None),
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("parlementair:review")),
 ) -> SuggestedEdgeResponse:
     """Approve a suggested edge, creating the actual edge in the graph."""
     suggested_edge_repo = SuggestedEdgeRepository(db)
@@ -406,6 +417,7 @@ async def reject_edge(
     current_user: OptionalUser,
     actor_id: UUID | None = Query(None),
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("parlementair:review")),
 ) -> SuggestedEdgeResponse:
     """Reject a suggested edge (sets status to rejected)."""
     repo = SuggestedEdgeRepository(db)
@@ -434,6 +446,7 @@ async def reset_suggested_edge(
     current_user: OptionalUser,
     actor_id: UUID | None = Query(None),
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("parlementair:review")),
 ) -> SuggestedEdgeResponse:
     """Reset a suggested edge back to pending, undoing approve/reject."""
     repo = SuggestedEdgeRepository(db)

--- a/backend/bouwmeester/migrations/versions/d2e8f3a91c4b_add_parlementair_permissions.py
+++ b/backend/bouwmeester/migrations/versions/d2e8f3a91c4b_add_parlementair_permissions.py
@@ -35,7 +35,10 @@ _NEW_PERMISSIONS = [
 
 _ROLE_GRANTS = {
     "super_admin": [p[0] for p in _NEW_PERMISSIONS],
-    "platform_admin": ["parlementair:read", "parlementair:import"],
+    # platform_admin is infra-only (geen content-permissies in c44e4533e993)
+    # — bewust geen parlementair:read of :review.  :import zou analoog aan
+    # import_export:import zijn, maar ook dat overlaten aan ministry_admin
+    # houdt de rol consistent infra-only.
     "ministry_admin": [
         "parlementair:read",
         "parlementair:review",

--- a/backend/bouwmeester/migrations/versions/d2e8f3a91c4b_add_parlementair_permissions.py
+++ b/backend/bouwmeester/migrations/versions/d2e8f3a91c4b_add_parlementair_permissions.py
@@ -1,0 +1,88 @@
+"""add parlementair permissions
+
+Revision ID: d2e8f3a91c4b
+Revises: c1d4e7a3b9f2
+Create Date: 2026-05-04 14:00:00.000000
+
+Adds three new permissions for the parlementair module so the API routes
+can be gated:
+
+- ``parlementair:read``    — view imports, get details, view review queue
+- ``parlementair:review``  — reject/reopen/complete review, mutate edges
+- ``parlementair:import``  — trigger or reprocess imports (LLM-heavy)
+
+The permissions are granted to existing roles via the role_permission
+junction table.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d2e8f3a91c4b"
+down_revision: str | None = "c1d4e7a3b9f2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_NEW_PERMISSIONS = [
+    ("parlementair:read", "parlementair"),
+    ("parlementair:review", "parlementair"),
+    ("parlementair:import", "parlementair"),
+]
+
+
+_ROLE_GRANTS = {
+    "super_admin": [p[0] for p in _NEW_PERMISSIONS],
+    "platform_admin": ["parlementair:read", "parlementair:import"],
+    "ministry_admin": [
+        "parlementair:read",
+        "parlementair:review",
+        "parlementair:import",
+    ],
+    "unit_manager": [
+        "parlementair:read",
+        "parlementair:review",
+        "parlementair:import",
+    ],
+    "editor": ["parlementair:read", "parlementair:review"],
+    "viewer": ["parlementair:read"],
+}
+
+
+def upgrade() -> None:
+    permission_table = sa.table(
+        "permission",
+        sa.column("id", sa.String()),
+        sa.column("category", sa.String()),
+    )
+    op.bulk_insert(
+        permission_table,
+        [{"id": pid, "category": cat} for pid, cat in _NEW_PERMISSIONS],
+    )
+
+    role_permission_table = sa.table(
+        "role_permission",
+        sa.column("role_id", sa.String()),
+        sa.column("permission_id", sa.String()),
+    )
+    rows = [
+        {"role_id": role_id, "permission_id": perm_id}
+        for role_id, perms in _ROLE_GRANTS.items()
+        for perm_id in perms
+    ]
+    op.bulk_insert(role_permission_table, rows)
+
+
+def downgrade() -> None:
+    perm_ids = [p[0] for p in _NEW_PERMISSIONS]
+    bind = op.get_bind()
+    bind.execute(
+        sa.text("DELETE FROM role_permission WHERE permission_id = ANY(:ids)"),
+        {"ids": perm_ids},
+    )
+    bind.execute(
+        sa.text("DELETE FROM permission WHERE id = ANY(:ids)"),
+        {"ids": perm_ids},
+    )

--- a/backend/tests/test_parlementair_authz.py
+++ b/backend/tests/test_parlementair_authz.py
@@ -1,0 +1,153 @@
+"""Authorization tests for the parlementair router.
+
+Verifies that an authenticated non-admin user without the
+``parlementair:read`` / ``parlementair:review`` / ``parlementair:import``
+permissions cannot access the corresponding endpoints.
+
+The dev-mode super-admin shortcut (no OIDC) is bypassed by overriding
+``get_optional_user`` and ``get_permission_context`` directly on the app.
+"""
+
+import uuid
+from datetime import date
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bouwmeester.core.auth import get_optional_user
+from bouwmeester.core.database import get_db
+from bouwmeester.core.permissions import PermissionContext, get_permission_context
+from bouwmeester.models.parlementair_item import ParlementairItem
+from bouwmeester.models.person import Person
+from bouwmeester.models.person_email import PersonEmail
+
+
+@pytest.fixture
+def _test_app():
+    from bouwmeester.core.app import create_app
+
+    return create_app()
+
+
+def _make_client(app, db_session, person, perms: set[str]):
+    """Build a client where the user has exactly *perms* (and nothing else)."""
+
+    async def _override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_optional_user] = lambda: person
+    app.dependency_overrides[get_permission_context] = lambda: PermissionContext(
+        person_id=person.id,
+        is_authenticated=True,
+        effective_permissions=set(perms),
+    )
+
+    transport = ASGITransport(app=app)
+    return AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={"Authorization": "Bearer test-parlementair-authz"},
+    )
+
+
+@pytest.fixture
+async def parlementair_authz_setup(db_session: AsyncSession, _test_app):
+    person = Person(
+        id=uuid.uuid4(),
+        naam="Parlementair Tester",
+        email=f"parl-{uuid.uuid4().hex[:8]}@example.com",
+        functie="tester",
+        is_active=True,
+    )
+    db_session.add(person)
+    await db_session.flush()
+    db_session.add(
+        PersonEmail(person_id=person.id, email=person.email, is_default=True)
+    )
+    await db_session.flush()
+
+    item = ParlementairItem(
+        id=uuid.uuid4(),
+        type="motie",
+        zaak_id=f"zaak-{uuid.uuid4().hex[:8]}",
+        zaak_nummer="36200-VII-99",
+        titel="Authz testmotie",
+        onderwerp="Authz",
+        bron="tweede_kamer",
+        datum=date(2024, 6, 15),
+        status="pending",
+    )
+    db_session.add(item)
+    await db_session.flush()
+
+    yield {"app": _test_app, "person": person, "item": item}
+
+    _test_app.dependency_overrides.clear()
+
+
+async def test_list_imports_requires_parlementair_read(
+    parlementair_authz_setup, db_session: AsyncSession
+):
+    """A user without parlementair:read gets 403 on GET /imports."""
+    s = parlementair_authz_setup
+    async with _make_client(s["app"], db_session, s["person"], set()) as ac:
+        resp = await ac.get("/api/parlementair/imports")
+    assert resp.status_code == 403
+
+
+async def test_list_imports_allows_parlementair_read(
+    parlementair_authz_setup, db_session: AsyncSession
+):
+    """A user with parlementair:read sees the imports list."""
+    s = parlementair_authz_setup
+
+    async def _override_get_db():
+        yield db_session
+
+    s["app"].dependency_overrides[get_db] = _override_get_db
+
+    async with _make_client(
+        s["app"], db_session, s["person"], {"parlementair:read"}
+    ) as ac:
+        resp = await ac.get("/api/parlementair/imports")
+    assert resp.status_code == 200
+    ids = {x["id"] for x in resp.json()}
+    assert str(s["item"].id) in ids
+
+
+async def test_trigger_import_requires_parlementair_import(
+    parlementair_authz_setup, db_session: AsyncSession
+):
+    """A user with only parlementair:read cannot trigger an import."""
+    s = parlementair_authz_setup
+
+    async def _override_get_db():
+        yield db_session
+
+    s["app"].dependency_overrides[get_db] = _override_get_db
+
+    async with _make_client(
+        s["app"], db_session, s["person"], {"parlementair:read"}
+    ) as ac:
+        resp = await ac.post("/api/parlementair/imports/trigger")
+    assert resp.status_code == 403
+
+
+async def test_reject_import_requires_parlementair_review(
+    parlementair_authz_setup, db_session: AsyncSession
+):
+    """A user with only parlementair:read cannot reject an import."""
+    s = parlementair_authz_setup
+
+    async def _override_get_db():
+        yield db_session
+
+    s["app"].dependency_overrides[get_db] = _override_get_db
+
+    async with _make_client(
+        s["app"], db_session, s["person"], {"parlementair:read"}
+    ) as ac:
+        resp = await ac.put(f"/api/parlementair/imports/{s['item'].id}/reject")
+    assert resp.status_code == 403


### PR DESCRIPTION
## Probleem

Alle endpoints onder \`/api/parlementair\` waren ongeprotegeerd: \`list_imports\`, \`get_import\`, \`review-queue\`, \`reject\`, \`reopen\`, \`complete\`, \`patch /edges/{id}\`, \`approve_edge\`, \`reject_edge\`, \`reset_suggested_edge\`, en zelfs de duurzame LLM-calls \`trigger_import\` en \`reprocess_imports\`. Elke ingelogde gebruiker kon imports zien én ad-hoc een ronde tag-extractie + matching starten.

## Fix

Drie nieuwe permissions via alembic-migratie \`d2e8f3a91c4b\`:

- \`parlementair:read\` — lezen van imports/review-queue (viewer, editor, unit_manager, ministry_admin, super_admin, platform_admin)
- \`parlementair:review\` — reject/reopen/complete review en edge-mutaties (editor, unit_manager, ministry_admin, super_admin)
- \`parlementair:import\` — trigger en reprocess (unit_manager, ministry_admin, platform_admin, super_admin)

Routes krijgen \`_perm=Depends(require_permission(\"parlementair:...\"))\` per endpoint. Geen organisatie-eenheid filter — parlementaire items zijn ministerie-breed bedoeld.

## Tests

Nieuwe \`backend/tests/test_parlementair_authz.py\` (4 tests) override \`get_optional_user\` en \`get_permission_context\` om de dev-mode super-admin shortcut te omzeilen. Verifieert 403 bij ontbreken van \`parlementair:read\`/\`parlementair:review\`/\`parlementair:import\` en 200 bij aanwezigheid.

Bestaande \`test_parlementair.py\` (37 tests) en \`test_parlementair_reprocess.py\` (14 tests) blijven groen — die draaien zonder OIDC en raken het admin-shortcut-pad.

## Migratie

\`d2e8f3a91c4b_add_parlementair_permissions.py\` voegt rijen toe aan \`permission\` en \`role_permission\`. Idempotent niet expliciet gemaakt (\`bulk_insert\`); rerun-veilig op productie omdat alembic-revisies single-application zijn.

\`\`\`sql
SELECT id FROM permission WHERE id LIKE 'parlementair:%';
-- Verwacht: 3 rijen na deploy.
\`\`\`

## Onderdeel van bredere autorisatie-fix

Volgt op #263 (opdrachten). Volgende PR's: tasks (gaten op detail/subtasks), people, regressie-test.

## Test plan

- [x] \`uv run pytest tests/test_parlementair_authz.py\` — 4 pass
- [x] \`uv run pytest tests/test_parlementair.py tests/test_parlementair_reprocess.py\` — 51 pass
- [x] \`alembic upgrade head\` lokaal — migratie schoon
- [x] \`ruff format\` + \`ruff check\` clean
- [ ] Staging: viewer-rol → \`/api/parlementair/imports\` 200, \`POST /api/parlementair/imports/trigger\` 403
- [ ] Staging: super_admin → alles 200