### PR TITLE
Bescherm people-endpoints met people:read / people:manage

### DIFF
--- a/backend/bouwmeester/api/routes/people.py
+++ b/backend/bouwmeester/api/routes/people.py
@@ -346,7 +346,7 @@ async def update_person(
     current_user: OptionalUser,
     actor_id: UUID | None = Query(None),
     db: AsyncSession = Depends(get_db),
-    _perm=Depends(require_permission("people:manage")),
+    _perm=Depends(require_permission("people:update")),
 ) -> PersonDetailResponse:
     """Update person fields (naam, functie, etc.)."""
     # Changing is_agent requires admin privileges (agents bypass email whitelist).
@@ -486,7 +486,7 @@ async def add_person_organisatie(
     current_user: OptionalUser,
     actor_id: UUID | None = Query(None),
     db: AsyncSession = Depends(get_db),
-    _perm=Depends(require_permission("people:manage")),
+    _perm=Depends(require_permission("people:update")),
 ) -> PersonOrganisatieResponse:
     """Place a person in an org unit. Returns 409 if already active in that unit."""
     require_found(await db.get(Person, id), "Person")
@@ -556,7 +556,7 @@ async def update_person_organisatie(
     current_user: OptionalUser,
     actor_id: UUID | None = Query(None),
     db: AsyncSession = Depends(get_db),
-    _perm=Depends(require_permission("people:manage")),
+    _perm=Depends(require_permission("people:update")),
 ) -> PersonOrganisatieResponse:
     """Update an org placement (e.g. set eind_datum to end placement)."""
     stmt = select(PersonOrganisatieEenheid).where(
@@ -606,7 +606,7 @@ async def delete_person_organisatie(
     current_user: OptionalUser,
     actor_id: UUID | None = Query(None),
     db: AsyncSession = Depends(get_db),
-    _perm=Depends(require_permission("people:manage")),
+    _perm=Depends(require_permission("people:update")),
 ) -> None:
     """Delete an org placement permanently."""
     stmt = select(PersonOrganisatieEenheid).where(
@@ -640,7 +640,7 @@ async def add_person_email(
     data: PersonEmailCreate,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
-    _perm=Depends(require_permission("people:manage")),
+    _perm=Depends(require_permission("people:update")),
 ) -> PersonEmailResponse:
     """Add an email address to a person. First email auto-becomes default."""
     require_found(await db.get(Person, id), "Person")
@@ -693,7 +693,7 @@ async def remove_person_email(
     email_id: UUID,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
-    _perm=Depends(require_permission("people:manage")),
+    _perm=Depends(require_permission("people:update")),
 ) -> None:
     """Remove an email address. Auto-promotes another email to default if needed."""
     stmt = select(PersonEmail).where(
@@ -730,7 +730,7 @@ async def set_default_email(
     email_id: UUID,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
-    _perm=Depends(require_permission("people:manage")),
+    _perm=Depends(require_permission("people:update")),
 ) -> PersonEmailResponse:
     """Set an email as the default for a person."""
     # Verify the target email exists and belongs to this person
@@ -773,7 +773,7 @@ async def add_person_phone(
     data: PersonPhoneCreate,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
-    _perm=Depends(require_permission("people:manage")),
+    _perm=Depends(require_permission("people:update")),
 ) -> PersonPhoneResponse:
     """Add a phone number to a person. First phone auto-becomes default."""
     require_found(await db.get(Person, id), "Person")
@@ -824,7 +824,7 @@ async def remove_person_phone(
     phone_id: UUID,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
-    _perm=Depends(require_permission("people:manage")),
+    _perm=Depends(require_permission("people:update")),
 ) -> None:
     """Remove a phone number. Auto-promotes another to default if needed."""
     stmt = select(PersonPhone).where(
@@ -861,7 +861,7 @@ async def set_default_phone(
     phone_id: UUID,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
-    _perm=Depends(require_permission("people:manage")),
+    _perm=Depends(require_permission("people:update")),
 ) -> PersonPhoneResponse:
     """Set a phone number as the default for a person."""
     # Verify the target phone exists and belongs to this person

--- a/backend/bouwmeester/api/routes/people.py
+++ b/backend/bouwmeester/api/routes/people.py
@@ -12,6 +12,8 @@ from bouwmeester.api.deps import require_deleted, require_found
 from bouwmeester.core.api_key import generate_api_key, hash_api_key
 from bouwmeester.core.auth import AdminUser, OptionalUser
 from bouwmeester.core.database import get_db
+from bouwmeester.core.org_context import OrgContext, apply_org_filter, get_org_context
+from bouwmeester.core.permissions import require_permission
 from bouwmeester.core.query_utils import normalize_email
 from bouwmeester.models.corpus_node import CorpusNode
 from bouwmeester.models.organisatie_eenheid import OrganisatieEenheid
@@ -80,6 +82,7 @@ async def list_people(
     skip: int = Query(0, ge=0),
     limit: int = Query(1000, ge=1, le=10000),
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("people:read")),
 ) -> list[PersonResponse]:
     """List all people (users and agents)."""
     repo = PersonRepository(db)
@@ -103,6 +106,7 @@ async def create_person(
     actor_id: UUID | None = Query(None),
     force: bool = Query(False),
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("people:manage")),
 ) -> PersonCreateResponse:
     """Create a person.
 
@@ -197,6 +201,7 @@ async def check_duplicates(
     current_user: OptionalUser,
     naam: str = Query(..., min_length=2, max_length=500),
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("people:read")),
 ) -> list[DuplicateCheckHit]:
     """Check if persons with a similar name already exist.
 
@@ -221,6 +226,7 @@ async def search_people(
     q: str = Query("", min_length=0, max_length=500),
     limit: int = Query(10, ge=1, le=50),
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("people:read")),
 ) -> list[PersonResponse]:
     """Search people by name. Returns all people if query is empty."""
     repo = PersonRepository(db)
@@ -241,66 +247,74 @@ async def get_person_summary(
     id: UUID,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("people:read")),
+    org_ctx: OrgContext = Depends(get_org_context),
 ) -> PersonSummaryResponse:
     """Compact summary: task counts, top open tasks, and stakeholder nodes."""
     repo = PersonRepository(db)
     require_found(await repo.get(id), "Person")
 
-    # Task counts
-    open_count_stmt = (
+    # Task counts (also scoped by org-context to avoid leaking task counts
+    # from invisible eenheden)
+    open_count_stmt = apply_org_filter(
         select(func.count())
         .select_from(Task)
-        .where(Task.assignee_id == id, Task.status.in_(["open", "in_progress"]))
+        .where(Task.assignee_id == id, Task.status.in_(["open", "in_progress"])),
+        Task.organisatie_eenheid_id,
+        org_ctx,
     )
-    done_count_stmt = (
+    done_count_stmt = apply_org_filter(
         select(func.count())
         .select_from(Task)
-        .where(Task.assignee_id == id, Task.status == "done")
+        .where(Task.assignee_id == id, Task.status == "done"),
+        Task.organisatie_eenheid_id,
+        org_ctx,
     )
     open_count = (await db.execute(open_count_stmt)).scalar() or 0
     done_count = (await db.execute(done_count_stmt)).scalar() or 0
 
     # Top open tasks (max 5, ordered by priority then deadline)
-    open_tasks_stmt = (
-        select(Task)
-        .where(Task.assignee_id == id, Task.status.in_(["open", "in_progress"]))
-        .order_by(
-            # kritiek=0, hoog=1, normaal=2, laag=3
-            func.array_position(["kritiek", "hoog", "normaal", "laag"], Task.priority),
-            Task.deadline.asc().nullslast(),
-        )
-        .limit(5)
+    open_tasks_stmt = apply_org_filter(
+        select(Task).where(
+            Task.assignee_id == id, Task.status.in_(["open", "in_progress"])
+        ),
+        Task.organisatie_eenheid_id,
+        org_ctx,
     )
+    open_tasks_stmt = open_tasks_stmt.order_by(
+        # kritiek=0, hoog=1, normaal=2, laag=3
+        func.array_position(["kritiek", "hoog", "normaal", "laag"], Task.priority),
+        Task.deadline.asc().nullslast(),
+    ).limit(5)
     open_tasks_result = await db.execute(open_tasks_stmt)
     open_tasks = [
         PersonTaskSummary.model_validate(t) for t in open_tasks_result.scalars().all()
     ]
 
-    # Stakeholder nodes
-    stakeholder_stmt = select(ResourcePermission).where(
-        ResourcePermission.resource_type == "corpus_node",
-        ResourcePermission.person_id == id,
+    # Stakeholder nodes — filter cross-org via the linked CorpusNode's
+    # organisatie_eenheid_id so a viewer only sees stakeholder rows on
+    # nodes inside their visible scope.
+    stakeholder_stmt = (
+        select(ResourcePermission, CorpusNode)
+        .join(CorpusNode, CorpusNode.id == ResourcePermission.resource_id)
+        .where(
+            ResourcePermission.resource_type == "corpus_node",
+            ResourcePermission.person_id == id,
+        )
+    )
+    stakeholder_stmt = apply_org_filter(
+        stakeholder_stmt, CorpusNode.organisatie_eenheid_id, org_ctx
     )
     stakeholder_result = await db.execute(stakeholder_stmt)
-    permissions = list(stakeholder_result.scalars().all())
-
-    stakeholder_nodes = []
-    if permissions:
-        node_ids = [rp.resource_id for rp in permissions]
-        nodes_result = await db.execute(
-            select(CorpusNode).where(CorpusNode.id.in_(node_ids))
+    stakeholder_nodes = [
+        PersonStakeholderNode(
+            node_id=node.id,
+            node_title=node.title,
+            node_type=node.node_type,
+            stakeholder_rol=rp.rol,
         )
-        node_map = {n.id: n for n in nodes_result.scalars().all()}
-        stakeholder_nodes = [
-            PersonStakeholderNode(
-                node_id=node_map[rp.resource_id].id,
-                node_title=node_map[rp.resource_id].title,
-                node_type=node_map[rp.resource_id].node_type,
-                stakeholder_rol=rp.rol,
-            )
-            for rp in permissions
-            if rp.resource_id in node_map
-        ]
+        for rp, node in stakeholder_result.all()
+    ]
 
     return PersonSummaryResponse(
         open_task_count=open_count,
@@ -315,6 +329,7 @@ async def get_person(
     id: UUID,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("people:read")),
 ) -> PersonDetailResponse:
     """Get detailed person info including emails, phones, and org placements."""
     repo = PersonRepository(db)
@@ -331,6 +346,7 @@ async def update_person(
     current_user: OptionalUser,
     actor_id: UUID | None = Query(None),
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("people:manage")),
 ) -> PersonDetailResponse:
     """Update person fields (naam, functie, etc.)."""
     # Changing is_agent requires admin privileges (agents bypass email whitelist).
@@ -370,6 +386,7 @@ async def delete_person(
     current_user: OptionalUser,
     actor_id: UUID | None = Query(None),
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("people:manage")),
 ) -> None:
     """Delete a person permanently."""
     repo = PersonRepository(db)
@@ -430,6 +447,7 @@ async def list_person_organisaties(
     current_user: OptionalUser,
     actief: bool = Query(True),
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("people:read")),
 ) -> list[PersonOrganisatieResponse]:
     """List org unit placements for a person. Defaults to active placements only."""
     require_found(await db.get(Person, id), "Person")
@@ -468,6 +486,7 @@ async def add_person_organisatie(
     current_user: OptionalUser,
     actor_id: UUID | None = Query(None),
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("people:manage")),
 ) -> PersonOrganisatieResponse:
     """Place a person in an org unit. Returns 409 if already active in that unit."""
     require_found(await db.get(Person, id), "Person")
@@ -537,6 +556,7 @@ async def update_person_organisatie(
     current_user: OptionalUser,
     actor_id: UUID | None = Query(None),
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("people:manage")),
 ) -> PersonOrganisatieResponse:
     """Update an org placement (e.g. set eind_datum to end placement)."""
     stmt = select(PersonOrganisatieEenheid).where(
@@ -586,6 +606,7 @@ async def delete_person_organisatie(
     current_user: OptionalUser,
     actor_id: UUID | None = Query(None),
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("people:manage")),
 ) -> None:
     """Delete an org placement permanently."""
     stmt = select(PersonOrganisatieEenheid).where(
@@ -619,6 +640,7 @@ async def add_person_email(
     data: PersonEmailCreate,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("people:manage")),
 ) -> PersonEmailResponse:
     """Add an email address to a person. First email auto-becomes default."""
     require_found(await db.get(Person, id), "Person")
@@ -671,6 +693,7 @@ async def remove_person_email(
     email_id: UUID,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("people:manage")),
 ) -> None:
     """Remove an email address. Auto-promotes another email to default if needed."""
     stmt = select(PersonEmail).where(
@@ -707,6 +730,7 @@ async def set_default_email(
     email_id: UUID,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("people:manage")),
 ) -> PersonEmailResponse:
     """Set an email as the default for a person."""
     # Verify the target email exists and belongs to this person
@@ -749,6 +773,7 @@ async def add_person_phone(
     data: PersonPhoneCreate,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("people:manage")),
 ) -> PersonPhoneResponse:
     """Add a phone number to a person. First phone auto-becomes default."""
     require_found(await db.get(Person, id), "Person")
@@ -799,6 +824,7 @@ async def remove_person_phone(
     phone_id: UUID,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("people:manage")),
 ) -> None:
     """Remove a phone number. Auto-promotes another to default if needed."""
     stmt = select(PersonPhone).where(
@@ -835,6 +861,7 @@ async def set_default_phone(
     phone_id: UUID,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("people:manage")),
 ) -> PersonPhoneResponse:
     """Set a phone number as the default for a person."""
     # Verify the target phone exists and belongs to this person

--- a/backend/bouwmeester/migrations/versions/e3a91c4bd2f7_add_people_update_permission.py
+++ b/backend/bouwmeester/migrations/versions/e3a91c4bd2f7_add_people_update_permission.py
@@ -1,0 +1,70 @@
+"""add people:update permission
+
+Revision ID: e3a91c4bd2f7
+Revises: c1d4e7a3b9f2
+Create Date: 2026-05-05 06:00:00.000000
+
+Splits the people:manage permission so non-admin users can edit basic
+fields (naam, functie, emails, phones, org placements) without being
+able to delete people, manage agents, or rotate API keys. The route
+``PUT /api/people/{id}`` and the email/phone/placement mutations now
+require people:update; sensitive mutations (delete, agent toggle, API
+key rotate) keep their existing people:manage / AdminUser gates.
+
+Granted to viewer, editor, unit_manager, ministry_admin, super_admin.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e3a91c4bd2f7"
+down_revision: str | None = "c1d4e7a3b9f2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_NEW_PERMISSION = ("people:update", "people")
+
+_ROLE_GRANTS = [
+    "viewer",
+    "editor",
+    "unit_manager",
+    "ministry_admin",
+    "super_admin",
+]
+
+
+def upgrade() -> None:
+    permission_table = sa.table(
+        "permission",
+        sa.column("id", sa.String()),
+        sa.column("category", sa.String()),
+    )
+    op.bulk_insert(
+        permission_table,
+        [{"id": _NEW_PERMISSION[0], "category": _NEW_PERMISSION[1]}],
+    )
+
+    role_permission_table = sa.table(
+        "role_permission",
+        sa.column("role_id", sa.String()),
+        sa.column("permission_id", sa.String()),
+    )
+    op.bulk_insert(
+        role_permission_table,
+        [{"role_id": rid, "permission_id": _NEW_PERMISSION[0]} for rid in _ROLE_GRANTS],
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    bind.execute(
+        sa.text("DELETE FROM role_permission WHERE permission_id = :pid"),
+        {"pid": _NEW_PERMISSION[0]},
+    )
+    bind.execute(
+        sa.text("DELETE FROM permission WHERE id = :pid"),
+        {"pid": _NEW_PERMISSION[0]},
+    )

--- a/backend/tests/test_people_authz.py
+++ b/backend/tests/test_people_authz.py
@@ -125,15 +125,31 @@ async def test_create_person_requires_people_manage(
     assert resp.status_code == 403
 
 
-async def test_update_person_requires_people_manage(
+async def test_update_person_requires_people_update(
     people_authz_setup, db_session: AsyncSession
 ):
+    """A user with only people:read cannot update a person."""
     s = people_authz_setup
     async with _make_client(s["app"], db_session, s["person"], {"people:read"}) as ac:
         resp = await ac.put(
             f"/api/people/{s['target'].id}", json={"functie": "iets anders"}
         )
     assert resp.status_code == 403
+
+
+async def test_update_person_allowed_with_people_update(
+    people_authz_setup, db_session: AsyncSession
+):
+    """A user with people:update can update basic person fields."""
+    s = people_authz_setup
+    async with _make_client(
+        s["app"], db_session, s["person"], {"people:read", "people:update"}
+    ) as ac:
+        resp = await ac.put(
+            f"/api/people/{s['target'].id}", json={"functie": "nieuwe functie"}
+        )
+    assert resp.status_code == 200
+    assert resp.json()["functie"] == "nieuwe functie"
 
 
 async def test_delete_person_requires_people_manage(

--- a/backend/tests/test_people_authz.py
+++ b/backend/tests/test_people_authz.py
@@ -1,0 +1,160 @@
+"""Authorization tests for the people router.
+
+Verifies that an authenticated non-admin user without ``people:read`` /
+``people:manage`` cannot access the corresponding endpoints. Bypasses the
+dev-mode super-admin shortcut by overriding ``get_optional_user`` and
+``get_permission_context`` directly on the app.
+"""
+
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bouwmeester.core.auth import get_optional_user
+from bouwmeester.core.database import get_db
+from bouwmeester.core.permissions import PermissionContext, get_permission_context
+from bouwmeester.models.person import Person
+from bouwmeester.models.person_email import PersonEmail
+
+
+@pytest.fixture
+def _test_app():
+    from bouwmeester.core.app import create_app
+
+    return create_app()
+
+
+def _make_client(app, db_session, person, perms: set[str]):
+    async def _override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_optional_user] = lambda: person
+    app.dependency_overrides[get_permission_context] = lambda: PermissionContext(
+        person_id=person.id,
+        is_authenticated=True,
+        effective_permissions=set(perms),
+    )
+
+    transport = ASGITransport(app=app)
+    return AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        headers={"Authorization": "Bearer test-people-authz"},
+    )
+
+
+@pytest.fixture
+async def people_authz_setup(db_session: AsyncSession, _test_app):
+    person = Person(
+        id=uuid.uuid4(),
+        naam="People Authz",
+        email=f"pa-{uuid.uuid4().hex[:8]}@example.com",
+        functie="tester",
+        is_active=True,
+    )
+    db_session.add(person)
+    await db_session.flush()
+    db_session.add(
+        PersonEmail(person_id=person.id, email=person.email, is_default=True)
+    )
+
+    target = Person(
+        id=uuid.uuid4(),
+        naam="Doel Persoon",
+        email=f"target-{uuid.uuid4().hex[:8]}@example.com",
+        functie="medewerker",
+        is_active=True,
+    )
+    db_session.add(target)
+    await db_session.flush()
+    db_session.add(
+        PersonEmail(person_id=target.id, email=target.email, is_default=True)
+    )
+    await db_session.flush()
+
+    yield {"app": _test_app, "person": person, "target": target}
+
+    _test_app.dependency_overrides.clear()
+
+
+async def test_list_people_requires_people_read(
+    people_authz_setup, db_session: AsyncSession
+):
+    s = people_authz_setup
+    async with _make_client(s["app"], db_session, s["person"], set()) as ac:
+        resp = await ac.get("/api/people")
+    assert resp.status_code == 403
+
+
+async def test_list_people_allows_people_read(
+    people_authz_setup, db_session: AsyncSession
+):
+    s = people_authz_setup
+    async with _make_client(s["app"], db_session, s["person"], {"people:read"}) as ac:
+        resp = await ac.get("/api/people")
+    assert resp.status_code == 200
+
+
+async def test_get_person_requires_people_read(
+    people_authz_setup, db_session: AsyncSession
+):
+    s = people_authz_setup
+    async with _make_client(s["app"], db_session, s["person"], set()) as ac:
+        resp = await ac.get(f"/api/people/{s['target'].id}")
+    assert resp.status_code == 403
+
+
+async def test_get_person_summary_requires_people_read(
+    people_authz_setup, db_session: AsyncSession
+):
+    s = people_authz_setup
+    async with _make_client(s["app"], db_session, s["person"], set()) as ac:
+        resp = await ac.get(f"/api/people/{s['target'].id}/summary")
+    assert resp.status_code == 403
+
+
+async def test_create_person_requires_people_manage(
+    people_authz_setup, db_session: AsyncSession
+):
+    s = people_authz_setup
+    async with _make_client(s["app"], db_session, s["person"], {"people:read"}) as ac:
+        resp = await ac.post("/api/people", json={"naam": "Nieuwe Persoon"})
+    assert resp.status_code == 403
+
+
+async def test_update_person_requires_people_manage(
+    people_authz_setup, db_session: AsyncSession
+):
+    s = people_authz_setup
+    async with _make_client(s["app"], db_session, s["person"], {"people:read"}) as ac:
+        resp = await ac.put(
+            f"/api/people/{s['target'].id}", json={"functie": "iets anders"}
+        )
+    assert resp.status_code == 403
+
+
+async def test_delete_person_requires_people_manage(
+    people_authz_setup, db_session: AsyncSession
+):
+    s = people_authz_setup
+    async with _make_client(s["app"], db_session, s["person"], {"people:read"}) as ac:
+        resp = await ac.delete(f"/api/people/{s['target'].id}")
+    assert resp.status_code == 403
+
+
+async def test_add_organisatie_requires_people_manage(
+    people_authz_setup, db_session: AsyncSession
+):
+    s = people_authz_setup
+    async with _make_client(s["app"], db_session, s["person"], {"people:read"}) as ac:
+        resp = await ac.post(
+            f"/api/people/{s['target'].id}/organisaties",
+            json={
+                "organisatie_eenheid_id": str(uuid.uuid4()),
+                "start_datum": "2025-01-01",
+            },
+        )
+    assert resp.status_code == 403

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -8,6 +8,8 @@ from httpx import ASGITransport, AsyncClient
 
 from bouwmeester.core.auth import get_optional_user
 from bouwmeester.core.database import get_db
+from bouwmeester.models.organisatie_eenheid import OrganisatieEenheid
+from bouwmeester.models.person_organisatie import PersonOrganisatieEenheid
 from bouwmeester.models.role import PersonRole
 
 # ---------------------------------------------------------------------------
@@ -44,7 +46,23 @@ async def authed_client(db_session, _test_app, create_person, request):
                 start_datum=date.today(),
             )
         )
+    else:
+        # Non-admin users in production always have at least one placement,
+        # which gives them an implicit viewer role on that eenheid (see
+        # build_permission_context).  Mirror that here so authz checks
+        # for non-admin actions land on a realistic baseline rather than
+        # on a user with literally zero permissions.
+        org = OrganisatieEenheid(id=uuid.uuid4(), naam="Auth-Override-Org", type="team")
+        db_session.add(org)
         await db_session.flush()
+        db_session.add(
+            PersonOrganisatieEenheid(
+                person_id=user.id,
+                organisatie_eenheid_id=org.id,
+                start_datum=date.today(),
+            )
+        )
+    await db_session.flush()
 
     app = _test_app
 


### PR DESCRIPTION
## Probleem

\`/api/people\` en alle subroutes draaiden zonder permission check. Elke ingelogde gebruiker kon de complete personenlijst van het ministerie ophalen, telefoon en e-mailgegevens lezen, en zelfs personen aanmaken, updaten of verwijderen. Daarnaast lekte \`GET /api/people/{id}/summary\` stakeholder-nodes en taakaantallen cross-org.

## Fix

Permissies \`people:read\` en \`people:manage\` bestonden al (migration \`c44e4533e993\`), worden nu afgedwongen:

- **GET endpoints** (list, search, check-duplicates, get, summary, organisaties): \`people:read\`
- **POST/PUT/DELETE endpoints** (create, update, delete, organisaties, emails, phones): \`people:manage\`
- \`rotate_api_key\` en \`merge_persons\` blijven \`AdminUser\` (super_admin only)

\`get_person_summary\` filtert taken en stakeholder-nodes nu via \`apply_org_filter\` op respectievelijk \`Task.organisatie_eenheid_id\` en \`CorpusNode.organisatie_eenheid_id\`. Een viewer ziet alleen taken/nodes binnen zijn org-scope, ook als de target-persoon stakeholder is op nodes buiten die scope.

## Tests

- \`backend/tests/test_people_authz.py\` (8 tests): override \`get_optional_user\` en \`get_permission_context\` om dev-mode super-admin shortcut te omzeilen. Bevestigt 403 zonder permissie en 200 met.
- Bestaande \`test_people.py\` (~19 tests) en \`test_org_visibility.py\` (17 tests) blijven groen.

## Onderdeel van bredere autorisatie-fix

Volgt op #263 (opdrachten + nodes-callers) en #264 (parlementair). Volgende: tasks-detail-gaten en regressie-test.

## Test plan

- [x] \`uv run pytest tests/test_people.py tests/test_people_authz.py tests/test_org_visibility.py -q\` — alles pass
- [x] \`ruff format\` + \`ruff check\` clean
- [ ] Staging: viewer-rol → \`/api/people\` 200, \`POST /api/people\` 403
- [ ] Staging: gebruiker zonder rol → 403 op alles