### PR TITLE
Filter task-detail-endpoints en eenheid-overview op org-context

### DIFF
--- a/backend/bouwmeester/api/routes/tasks.py
+++ b/backend/bouwmeester/api/routes/tasks.py
@@ -149,7 +149,11 @@ async def get_my_tasks(
     limit: int = Query(100, ge=1, le=500),
     db: AsyncSession = Depends(get_db),
 ) -> list[TaskResponse]:
-    """Get tasks assigned to the current user (or person_id in dev mode)."""
+    """Get tasks assigned to the current user (or person_id in dev mode).
+
+    No org_ctx filter: a user is always entitled to see tasks assigned to
+    them, even in units they cannot otherwise browse.
+    """
     pid = effective_person_id(current_user, person_id)
     repo = TaskRepository(db)
     tasks = await repo.get_by_assignee(pid, skip=skip, limit=limit)
@@ -162,7 +166,10 @@ async def get_task_inbox(
     person_id: UUID | None = Query(None),
     db: AsyncSession = Depends(get_db),
 ) -> InboxResponse:
-    """Get aggregated inbox data for a person (tasks, notifications, deadlines)."""
+    """Get aggregated inbox data for a person (tasks, notifications, deadlines).
+
+    Inbox is always self-scoped (own tasks/notifications), so no org_ctx.
+    """
     pid = effective_person_id(current_user, person_id)
     service = InboxService(db)
     return await service.get_inbox(pid)
@@ -173,10 +180,14 @@ async def get_unassigned_tasks(
     current_user: OptionalUser,
     organisatie_eenheid_id: UUID | None = Query(None),
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("task:read")),
+    org_ctx: OrgContext = Depends(get_org_context),
 ) -> list[TaskResponse]:
     """List tasks that have no assignee, optionally filtered by org unit."""
+    if organisatie_eenheid_id is not None:
+        check_org_scope(organisatie_eenheid_id, org_ctx)
     repo = TaskRepository(db)
-    tasks = await repo.get_unassigned(organisatie_eenheid_id)
+    tasks = await repo.get_unassigned(organisatie_eenheid_id, org_ctx=org_ctx)
     return validate_list(TaskResponse, tasks)
 
 
@@ -184,10 +195,12 @@ async def get_unassigned_tasks(
 async def get_work_types(
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("task:read")),
+    org_ctx: OrgContext = Depends(get_org_context),
 ) -> list[str]:
     """Return distinct work_type values for autocomplete."""
     repo = TaskRepository(db)
-    return await repo.get_distinct_work_types()
+    return await repo.get_distinct_work_types(org_ctx=org_ctx)
 
 
 @router.get("/eenheid-overview", response_model=EenheidOverviewResponse)
@@ -195,8 +208,11 @@ async def get_eenheid_overview(
     current_user: OptionalUser,
     organisatie_eenheid_id: UUID = Query(...),
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("task:read")),
+    org_ctx: OrgContext = Depends(get_org_context),
 ) -> EenheidOverviewResponse:
     """Overview of tasks for an organisatie-eenheid."""
+    check_org_scope(organisatie_eenheid_id, org_ctx)
     service = EenheidOverviewService(db)
     return await service.get_overview(organisatie_eenheid_id)
 
@@ -206,8 +222,11 @@ async def get_task(
     id: UUID,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("task:read")),
+    org_ctx: OrgContext = Depends(get_org_context),
 ) -> TaskResponse:
     """Get a single task by ID, including assignee and node summaries."""
+    await check_resource_org_scope(db, "task", id, org_ctx)
     repo = TaskRepository(db)
     task = require_found(await repo.get(id), "Task")
     return TaskResponse.model_validate(task)
@@ -218,10 +237,13 @@ async def get_task_subtasks(
     id: UUID,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("task:read")),
+    org_ctx: OrgContext = Depends(get_org_context),
 ) -> list[TaskResponse]:
     """List subtasks of a parent task."""
+    await check_resource_org_scope(db, "task", id, org_ctx)
     repo = TaskRepository(db)
-    subtasks = await repo.get_subtasks(id)
+    subtasks = await repo.get_subtasks(id, org_ctx=org_ctx)
     return [TaskResponse.model_validate(t) for t in subtasks]
 
 

--- a/backend/bouwmeester/repositories/task.py
+++ b/backend/bouwmeester/repositories/task.py
@@ -159,6 +159,8 @@ class TaskRepository(BaseRepository[Task]):
     async def get_overdue(
         self,
         assignee_id: UUID | None = None,
+        *,
+        org_ctx: OrgContext | None = None,
     ) -> list[Task]:
         stmt = (
             select(Task)
@@ -170,6 +172,10 @@ class TaskRepository(BaseRepository[Task]):
         )
         if assignee_id is not None:
             stmt = stmt.where(Task.assignee_id == assignee_id)
+        # Skip org filter when listing the caller's own overdue tasks —
+        # users always see their own tasks regardless of org-scope.
+        if not (org_ctx is not None and org_ctx.person_id == assignee_id):
+            stmt = apply_org_filter(stmt, Task.organisatie_eenheid_id, org_ctx)
         stmt = stmt.order_by(Task.deadline.asc())
         result = await self.session.execute(stmt)
         return list(result.scalars().all())

--- a/backend/bouwmeester/repositories/task.py
+++ b/backend/bouwmeester/repositories/task.py
@@ -200,6 +200,8 @@ class TaskRepository(BaseRepository[Task]):
     async def get_unassigned(
         self,
         organisatie_eenheid_id: UUID | None = None,
+        *,
+        org_ctx: OrgContext | None = None,
     ) -> list[Task]:
         stmt = (
             select(Task)
@@ -209,19 +211,26 @@ class TaskRepository(BaseRepository[Task]):
             )
             .options(*_task_options())
         )
+        stmt = apply_org_filter(stmt, Task.organisatie_eenheid_id, org_ctx)
         if organisatie_eenheid_id is not None:
             stmt = stmt.where(Task.organisatie_eenheid_id == organisatie_eenheid_id)
         stmt = stmt.order_by(Task.created_at.desc())
         result = await self.session.execute(stmt)
         return list(result.scalars().all())
 
-    async def get_subtasks(self, parent_id: UUID) -> list[Task]:
+    async def get_subtasks(
+        self,
+        parent_id: UUID,
+        *,
+        org_ctx: OrgContext | None = None,
+    ) -> list[Task]:
         stmt = (
             select(Task)
             .where(Task.parent_id == parent_id)
             .options(*_task_options())
             .order_by(Task.order.asc().nulls_last(), Task.created_at.asc())
         )
+        stmt = apply_org_filter(stmt, Task.organisatie_eenheid_id, org_ctx)
         result = await self.session.execute(stmt)
         return list(result.scalars().all())
 
@@ -261,7 +270,11 @@ class TaskRepository(BaseRepository[Task]):
         await self.session.flush()
         return await self.get_subtasks(parent_id)
 
-    async def get_distinct_work_types(self) -> list[str]:
+    async def get_distinct_work_types(
+        self,
+        *,
+        org_ctx: OrgContext | None = None,
+    ) -> list[str]:
         """Return all distinct non-null work_type values, sorted alphabetically."""
         stmt = (
             select(distinct(Task.work_type))
@@ -269,6 +282,7 @@ class TaskRepository(BaseRepository[Task]):
             .where(Task.work_type != "")
             .order_by(Task.work_type)
         )
+        stmt = apply_org_filter(stmt, Task.organisatie_eenheid_id, org_ctx)
         result = await self.session.execute(stmt)
         return [row[0] for row in result.all()]
 

--- a/backend/bouwmeester/services/chat_service.py
+++ b/backend/bouwmeester/services/chat_service.py
@@ -1130,7 +1130,10 @@ async def _execute_read_tool(
             from bouwmeester.repositories.task import TaskRepository
 
             repo = TaskRepository(db)
-            tasks = await repo.get_by_node(UUID(args["node_id"]), limit=20)
+            org_ctx = await _build_chat_org_context(db, person_id)
+            tasks = await repo.get_by_node(
+                UUID(args["node_id"]), limit=20, org_ctx=org_ctx
+            )
             items = [_task_to_dict(t) for t in tasks]
             return _safe_dumps({"tasks": items, "count": len(items)})
 
@@ -1138,7 +1141,10 @@ async def _execute_read_tool(
             from bouwmeester.repositories.task import TaskRepository
 
             repo = TaskRepository(db)
-            tasks = await repo.get_by_assignee(UUID(args["person_id"]), limit=20)
+            org_ctx = await _build_chat_org_context(db, person_id)
+            tasks = await repo.get_by_assignee(
+                UUID(args["person_id"]), limit=20, org_ctx=org_ctx
+            )
             items = [_task_to_dict(t) for t in tasks]
             return _safe_dumps({"tasks": items, "count": len(items)})
 
@@ -1146,8 +1152,9 @@ async def _execute_read_tool(
             from bouwmeester.repositories.task import TaskRepository
 
             repo = TaskRepository(db)
+            org_ctx = await _build_chat_org_context(db, person_id)
             assignee_id = UUID(args["assignee_id"]) if args.get("assignee_id") else None
-            tasks = await repo.get_overdue(assignee_id=assignee_id)
+            tasks = await repo.get_overdue(assignee_id=assignee_id, org_ctx=org_ctx)
             items = [_task_to_dict(t) for t in tasks[:20]]
             return _safe_dumps({"tasks": items, "count": len(items)})
 

--- a/backend/tests/test_org_visibility.py
+++ b/backend/tests/test_org_visibility.py
@@ -250,6 +250,30 @@ async def test_list_tasks_by_node_hides_invisible_org(org_visibility_setup):
     assert len(resp.json()) == 0
 
 
+async def test_get_task_forbidden_for_invisible(org_visibility_setup):
+    """GET /tasks/{id} returns 403 for a task in an invisible org."""
+    s = org_visibility_setup
+    resp = await s["client"].get(f"/api/tasks/{s['invisible_task'].id}")
+    assert resp.status_code == 403
+
+
+async def test_get_task_subtasks_forbidden_for_invisible(org_visibility_setup):
+    """GET /tasks/{id}/subtasks returns 403 for a parent in an invisible org."""
+    s = org_visibility_setup
+    resp = await s["client"].get(f"/api/tasks/{s['invisible_task'].id}/subtasks")
+    assert resp.status_code == 403
+
+
+async def test_eenheid_overview_forbids_invisible_eenheid(org_visibility_setup):
+    """GET /tasks/eenheid-overview rejects an invisible eenheid."""
+    s = org_visibility_setup
+    resp = await s["client"].get(
+        "/api/tasks/eenheid-overview",
+        params={"organisatie_eenheid_id": str(s["invisible_org"].id)},
+    )
+    assert resp.status_code == 403
+
+
 # ---------------------------------------------------------------------------
 # Edge visibility tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Probleem

\`/api/tasks\` (list) was al goed gefilterd, maar de detail- en aggregaat-endpoints lekten cross-org data:

- \`GET /api/tasks/{id}\` — geen scope check, elke task zichtbaar
- \`GET /api/tasks/{id}/subtasks\` — idem, plus subtasks zelf ongefilterd
- \`GET /api/tasks/unassigned\` — geen filter, geen permission, geen scope-check op de query-param \`organisatie_eenheid_id\`
- \`GET /api/tasks/work-types\` — distinct work_type values uit alle eenheden
- \`GET /api/tasks/eenheid-overview\` — geen scope-check, je kon van elke eenheid de overview ophalen

## Fix

- Detail endpoints: \`_perm=Depends(require_permission(\"task:read\"))\` + \`await check_resource_org_scope(db, \"task\", id, org_ctx)\`
- \`get_unassigned\` en \`work-types\`: \`task:read\` + repo-side \`apply_org_filter(stmt, Task.organisatie_eenheid_id, org_ctx)\`
- \`eenheid-overview\`: \`task:read\` + \`check_org_scope(organisatie_eenheid_id, org_ctx)\` op de query-param

\`get_my_tasks\` en \`get_task_inbox\` blijven bewust self-scoped (assignee = caller, via \`effective_person_id\`). Een gebruiker mag taken die aan hem zijn toegewezen altijd zien, ook in eenheden waar hij verder geen toegang toe heeft. Comment in de code toegevoegd om die keuze vast te leggen.

\`TaskRepository.get_unassigned\`, \`get_subtasks\`, \`get_distinct_work_types\` accepteren nu een optionele \`org_ctx\` (kwarg-only, default None voor interne callers).

## Tests

3 nieuwe tests in \`test_org_visibility.py\`:

- \`test_get_task_forbidden_for_invisible\` — 403 op task in vreemde org
- \`test_get_task_subtasks_forbidden_for_invisible\` — 403
- \`test_eenheid_overview_forbids_invisible_eenheid\` — 403

Bestaande tests (test_tasks.py + rest van test_org_visibility) blijven groen.

## Onderdeel van bredere autorisatie-fix

Volgt op #263 (opdrachten + nodes-callers), #264 (parlementair), #265 (people).

## Test plan

- [x] \`uv run pytest tests/test_tasks.py tests/test_org_visibility.py -q\` — 31 pass
- [x] \`ruff format\` + \`ruff check\` clean
- [ ] Staging: viewer-rol → \`/api/tasks/{vreemde-task-id}\` 403
- [ ] Staging: viewer probeert \`/api/tasks/eenheid-overview?organisatie_eenheid_id={andere}\` → 403