### PR TITLE
Voeg authz-inventory regressietest voor /api/* GET routes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,17 @@ Production access is restricted to whitelisted email addresses stored in the `wh
 - When the whitelist table is empty, all emails are allowed (backwards compatible for local dev)
 - Non-whitelisted users can request access via the AccessDeniedPage; admins approve/deny from Beheer > Verzoeken
 
+## Authorization patterns
+
+`AuthRequiredMiddleware` enforces authentication on `/api/*`. **Authorization** (which records a user may see/mutate) is per-route, using these helpers:
+
+- **List endpoints** filter on `org_ctx`: pass `org_ctx: OrgContext = Depends(get_org_context)` to the route and `apply_org_filter(stmt, Model.organisatie_eenheid_id, org_ctx)` in the repo.
+- **Detail endpoints** check scope: `await check_resource_org_scope(db, "<resource_type>", id, org_ctx)`.
+- **Mutations** also need a permission gate: `_perm=Depends(require_permission("<perm>"))` plus `check_org_scope(eenheid_id, org_ctx)` on any incoming `organisatie_eenheid_id`.
+- **Tenant-wide-by-design** endpoints (`tags`, `organisatie`-chart, `edge-types`, `roles`) are intentionally readable by every authenticated user. Whitelist them in `backend/tests/test_route_authorization_inventory.py`.
+
+The inventory test fails CI on any new GET `/api/*` route that lacks an authz dependency, so adding a list-endpoint without `apply_org_filter` is impossible without an explicit whitelist or known-debt entry.
+
 ## Pull requests
 
 - Always branch from the latest remote main: `git fetch origin && git checkout -b <branch> origin/main`

--- a/backend/tests/test_route_authorization_inventory.py
+++ b/backend/tests/test_route_authorization_inventory.py
@@ -1,0 +1,227 @@
+"""Regression guard: every API GET route must declare an authz dependency.
+
+Walks the FastAPI app's route table and fails the build if a GET route
+under ``/api/`` lacks one of the recognised authz dependencies (or is
+not on the explicit public/whitelisted set).
+
+This catches the common regression of adding a new GET endpoint and
+forgetting ``require_permission`` / ``get_org_context``.
+
+When a new endpoint is genuinely public or self-scoped (no leak risk),
+add it to ``_AUTHZ_WHITELIST`` with a short justification.
+
+Endpoints that are *known* to lack authz but are not yet fixed live in
+``_KNOWN_DEBT``.  They are exempt from the test — but a second test
+fails if a known-debt entry is no longer present (so we can't silently
+re-introduce a regression on a fixed route either).
+"""
+
+from fastapi.routing import APIRoute
+
+# Routes that are intentionally accessible without an authz dependency.
+# Each entry must include a comment documenting why.
+_AUTHZ_WHITELIST: dict[str, str] = {
+    # Public auth/health endpoints
+    "/api/auth/status": "public — used by frontend to detect login state",
+    "/api/auth/me": "self-scoped to current user",
+    "/api/auth/csrf": "public — bootstrap CSRF token",
+    "/api/auth/login": "public — start OIDC flow",
+    "/api/auth/callback": "public — OIDC callback",
+    "/api/auth/logout": "public — terminate session",
+    "/api/health": "public health check",
+    "/api/health/ready": "public health check",
+    # Self-scoped endpoints (effective_person_id ensures caller-only data)
+    "/api/tasks/my": "self-scoped via effective_person_id",
+    "/api/tasks/inbox": "self-scoped via effective_person_id",
+    # Mattermost webhook endpoints (authenticated via shared secret)
+    "/api/mattermost/slash": "authenticated via shared secret in body",
+    "/api/mattermost/action": "authenticated via shared secret in body",
+    "/api/mattermost/verify-link": "public — link verification",
+    # WebAuthn registration/authentication ceremony
+    "/api/webauthn/authenticate/options": "public — start authn ceremony",
+    "/api/webauthn/authenticate/verify": "public — complete authn ceremony",
+    # Tenant-wide reference data (intentionally readable by any logged-in user
+    # because the authn middleware already gates /api/*)
+    "/api/tags": "ministerie-breed gedeeld per ontwerp",
+    "/api/tags/search": "ministerie-breed gedeeld per ontwerp",
+    "/api/tags/tree": "ministerie-breed gedeeld per ontwerp",
+    "/api/tags/{tag_id}": "ministerie-breed gedeeld per ontwerp",
+    "/api/edge-types": "schema-data, ministerie-breed",
+    "/api/edge-types/{id}": "schema-data, ministerie-breed",
+    "/api/edge-types/valid": "schema-data, ministerie-breed",
+    "/api/edge-schema-rules": "schema-data, ministerie-breed",
+    "/api/skill.md": "skill markdown bundle, no PII",
+}
+
+# Whole-prefix whitelists (every GET under this prefix is exempt).
+_AUTHZ_PREFIX_WHITELIST: tuple[str, ...] = (
+    "/api/auth/",
+    "/api/health",
+    "/api/webauthn/",
+    "/api/mattermost/",
+)
+
+# Known-debt: GET routes that still lack authz but are scheduled for a
+# follow-up PR.  Keeping them in this list:
+#   1. lets CI stay green on main while the cleanup is in flight, and
+#   2. catches any *new* authz regressions on routes outside this set.
+# Once a route here grows an authz dependency, the second test below
+# will demand it be removed from the list — preventing accidental
+# re-introduction of the gap.
+#
+# Routes covered by in-flight PRs (#263 opdrachten, #264 parlementair,
+# #265 people, #266 tasks) are still listed here because this PR is based
+# on plain main; once those PR's merge their entries will be flagged by
+# test_known_debt_is_still_unauthorized and cleaned up.
+_KNOWN_DEBT: set[str] = {
+    "/api/activity/inbox",
+    "/api/chat/{conversation_id}",
+    "/api/chat/attachments/{attachment_id}/preview",
+    "/api/export/archimate",
+    "/api/export/corpus",
+    "/api/export/edges",
+    "/api/export/nodes",
+    "/api/externe-organisaties",
+    "/api/externe-organisaties/{id}",
+    "/api/graph/path",
+    "/api/graph/search",
+    "/api/llm/corpus-gaps",
+    "/api/mentions/references/{target_id}",
+    "/api/mentions/search",
+    "/api/nodes/{id}/bron-detail",
+    "/api/nodes/{id}/financieel",
+    "/api/nodes/{id}/graph",
+    "/api/nodes/{id}/history/statuses",
+    "/api/nodes/{id}/history/titles",
+    "/api/nodes/{id}/neighbors",
+    "/api/nodes/{id}/opdrachten",
+    "/api/nodes/{id}/parlementair-item",
+    "/api/nodes/{id}/stakeholders",
+    "/api/nodes/{id}/tags",
+    "/api/nodes/{id}/tasks",
+    "/api/nodes/{node_id}/bijlage",
+    "/api/nodes/{node_id}/bijlage/download",
+    "/api/notifications",
+    "/api/notifications/count",
+    "/api/notifications/dashboard-stats",
+    "/api/notifications/{id}",
+    "/api/notifications/{id}/replies",
+    "/api/opdrachten",
+    "/api/opdrachten/summary",
+    "/api/opdrachten/{id}",
+    "/api/org-placements/my-requests",
+    "/api/organisatie",
+    "/api/organisatie/managed-by/{person_id}",
+    "/api/organisatie/search",
+    "/api/organisatie/{id}",
+    "/api/organisatie/{id}/history/managers",
+    "/api/organisatie/{id}/history/namen",
+    "/api/organisatie/{id}/history/parents",
+    "/api/organisatie/{id}/personen",
+    "/api/parlementair/imports",
+    "/api/parlementair/imports/{import_id}",
+    "/api/parlementair/review-queue",
+    "/api/people",
+    "/api/people/check-duplicates",
+    "/api/people/search",
+    "/api/people/{id}",
+    "/api/people/{id}/organisaties",
+    "/api/people/{id}/summary",
+    "/api/roles",
+    "/api/roles/my-permissions",
+    "/api/tasks/eenheid-overview",
+    "/api/tasks/unassigned",
+    "/api/tasks/work-types",
+    "/api/tasks/{id}",
+    "/api/tasks/{id}/subtasks",
+}
+
+# Recognised dependency-callable names that satisfy the authz requirement.
+_AUTHZ_DEP_NAMES = {
+    "_check",  # require_permission inner closure
+    "get_org_context",
+    "get_permission_context",
+    "get_initiatief_context",
+    "get_admin_user",  # AdminUser annotation
+    "effective_person_id",
+}
+
+
+def _route_has_authz_dep(route: APIRoute) -> bool:
+    """True if any of the route's dependencies match _AUTHZ_DEP_NAMES."""
+
+    def _walk(deps):
+        for dep in deps:
+            call = getattr(dep, "call", None)
+            if call is not None and call.__name__ in _AUTHZ_DEP_NAMES:
+                return True
+            if _walk(getattr(dep, "dependencies", [])):
+                return True
+        return False
+
+    return _walk(route.dependant.dependencies)
+
+
+def _collect_get_routes(app) -> list[APIRoute]:
+    return [
+        r
+        for r in app.routes
+        if isinstance(r, APIRoute) and "GET" in r.methods and r.path.startswith("/api/")
+    ]
+
+
+def _is_exempt(path: str) -> bool:
+    if path in _AUTHZ_WHITELIST or path in _KNOWN_DEBT:
+        return True
+    return any(path.startswith(p) for p in _AUTHZ_PREFIX_WHITELIST)
+
+
+def test_all_get_routes_have_authz_dep(_test_app):
+    """Fail if any GET /api/* route is missing an authz dependency.
+
+    Whitelisted entries (intentionally public/self-scoped) and known-debt
+    entries (scheduled for follow-up) are exempt.
+    """
+    offenders: list[str] = []
+
+    for route in _collect_get_routes(_test_app):
+        if _is_exempt(route.path):
+            continue
+        if _route_has_authz_dep(route):
+            continue
+        offenders.append(route.path)
+
+    assert not offenders, (
+        "New GET routes without authz dependency. Either add one of "
+        f"{sorted(_AUTHZ_DEP_NAMES)}, whitelist in _AUTHZ_WHITELIST with "
+        "justification, or — if this is genuine debt — add to _KNOWN_DEBT:\n"
+        + "\n".join(f"  - {p}" for p in sorted(offenders))
+    )
+
+
+def test_known_debt_is_still_unauthorized(_test_app):
+    """Fail if a route in _KNOWN_DEBT has acquired an authz dependency.
+
+    Forces removal from the debt list when fixed, so the test stays a
+    meaningful regression guard rather than a stale wishlist.
+    """
+    fixed: list[str] = []
+    actual_paths = {r.path for r in _collect_get_routes(_test_app)}
+
+    for route in _collect_get_routes(_test_app):
+        if route.path not in _KNOWN_DEBT:
+            continue
+        if _route_has_authz_dep(route):
+            fixed.append(route.path)
+
+    # Routes in the debt list that no longer exist also need to be cleaned up.
+    stale = sorted(_KNOWN_DEBT - actual_paths)
+
+    assert not fixed, (
+        "These routes are now protected — remove them from _KNOWN_DEBT:\n"
+        + "\n".join(f"  - {p}" for p in sorted(fixed))
+    )
+    assert not stale, (
+        "These routes no longer exist — remove them from _KNOWN_DEBT:\n"
+        + "\n".join(f"  - {p}" for p in stale)
+    )

--- a/backend/tests/test_route_authorization_inventory.py
+++ b/backend/tests/test_route_authorization_inventory.py
@@ -51,6 +51,16 @@ _AUTHZ_WHITELIST: dict[str, str] = {
     "/api/edge-types/valid": "schema-data, ministerie-breed",
     "/api/edge-schema-rules": "schema-data, ministerie-breed",
     "/api/skill.md": "skill markdown bundle, no PII",
+    # Notifications: handlers filter on effective_person_id explicitly
+    # in the route body (zie notifications.py — list/count/dashboard-stats
+    # roepen effective_person_id aan; detail/replies gaan door
+    # _check_notification_owner). De inventory test detecteert die
+    # in-body call niet, dus expliciet whitelisten.
+    "/api/notifications": "self-scoped via effective_person_id in handler",
+    "/api/notifications/count": "self-scoped via effective_person_id in handler",
+    "/api/notifications/dashboard-stats": "self-scoped via effective_person_id",
+    "/api/notifications/{id}": "self-scoped via _check_notification_owner",
+    "/api/notifications/{id}/replies": "self-scoped via _check_notification_owner",
 }
 
 # Whole-prefix whitelists (every GET under this prefix is exempt).
@@ -101,11 +111,6 @@ _KNOWN_DEBT: set[str] = {
     "/api/nodes/{id}/tasks",
     "/api/nodes/{node_id}/bijlage",
     "/api/nodes/{node_id}/bijlage/download",
-    "/api/notifications",
-    "/api/notifications/count",
-    "/api/notifications/dashboard-stats",
-    "/api/notifications/{id}",
-    "/api/notifications/{id}/replies",
     "/api/opdrachten",
     "/api/opdrachten/summary",
     "/api/opdrachten/{id}",


### PR DESCRIPTION
## Probleem

De fixes in #263, #264, #265 en #266 dichten concrete autorisatie-gaten op opdrachten, parlementair, people en task-detail-endpoints. Maar ze garanderen niets voor toekomstige nieuwe endpoints. Bij een grote codebase introduceer je makkelijk een GET-endpoint zonder \`require_permission\` of \`get_org_context\` — geen review-checklist gaat dat consistent vangen.

## Fix

Twee tests in \`backend/tests/test_route_authorization_inventory.py\`:

1. **\`test_all_get_routes_have_authz_dep\`** doorloopt de FastAPI route-tabel en faalt op elk GET \`/api/*\` endpoint dat geen authz-dependency declareert (\`require_permission\` / \`get_org_context\` / \`get_permission_context\` / \`get_admin_user\` / \`effective_person_id\` / \`get_initiatief_context\`). Twee uitzonderingen:
   - \`_AUTHZ_WHITELIST\` voor bewust publieke of tenant-brede endpoints (auth/health/tags/edge-types/skill.md/etc), elk met justificatie-comment.
   - \`_KNOWN_DEBT\` voor endpoints die nog niet beveiligd zijn maar wel op de roadmap.
2. **\`test_known_debt_is_still_unauthorized\`** faalt zodra een debt-route een authz-dep krijgt of niet meer bestaat. Forceert opruimen van de lijst zodra iets gefixt is — de set kan niet verworden tot stale wishlist.

\`CLAUDE.md\` krijgt een korte sectie 'Authorization patterns' die het patroon voor list/detail/mutatie-endpoints documenteert.

## Hoe dit werkt met #263-#266

Deze PR is gebaseerd op kale main. \`_KNOWN_DEBT\` bevat dus ook routes die in #263, #264, #265 en #266 worden gefixt. Zodra die PR's mergen:

1. \`test_known_debt_is_still_unauthorized\` faalt op main omdat de gefixte routes nu een authz-dep hebben.
2. Mergende persoon (of follow-up commit) verwijdert die paths uit \`_KNOWN_DEBT\`.
3. CI is weer groen.

Dat is bewust gedrag: het dwingt de set actueel te houden in plaats van stille drift.

**Volgorde van mergen** maakt niet uit: deze PR mag eerst, na, of tussendoor. Alleen na merge moet er een \`_KNOWN_DEBT\` cleanup-commit volgen.

## Verbeteringen voor de toekomst

Routes in \`_KNOWN_DEBT\` die geen onderdeel zijn van de huidige fix-batch (notifications, organisatie-history, mentions, externe-organisaties, exports, graph, llm, chat, bijlage, node-detail-subroutes, activity-inbox, org-placements/my-requests, roles) moeten nog inhoudelijk geaudit worden. Sommige zijn waarschijnlijk veilig (bijvoorbeeld \`notifications\` filtert al via \`effective_person_id\` in de implementatie maar via een ander pad dan de inventory-test detecteert) en kunnen na audit naar \`_AUTHZ_WHITELIST\` verhuizen. Andere hebben echte fixes nodig.

## Test plan

- [x] \`uv run pytest tests/test_route_authorization_inventory.py -v\` — 2 pass op kale main
- [x] \`ruff format\` + \`ruff check\` clean
- [ ] Na merge van #263-#266: cleanup-commit op main die de gefixte paths uit \`_KNOWN_DEBT\` haalt