### PR TITLE
Funnel-velden, stakeholder-assessment, publieke initiatief-pagina + updates

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"043667b0-d85e-4c3f-85e4-702cb172e34a","pid":11650,"procStart":"Mon May  4 14:28:13 2026","acquiredAt":1777959128883}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"043667b0-d85e-4c3f-85e4-702cb172e34a","pid":11650,"procStart":"Mon May  4 14:28:13 2026","acquiredAt":1777959128883}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,35 @@ ParlementairItem (tracks imported parliamentary items: moties, kamervragen, toez
 ├── SuggestedEdge (proposed edges to corpus nodes, pending review)
 ├── CorpusNode (corpus_node_id, the created politieke_input node)
 └── type discriminator (motie, kamervraag, toezegging, amendement, ...)
+
+Initiatief
+├── Lead (initiatief_id) — funnel-stage tracking
+├── ResourcePermission (eigenaar/contributor/viewer per persoon of eenheid)
+├── InitiatiefUpdatePost (publication posts; published_at IS NULL = concept)
+└── slug (unique URL-segment, eenmalig instelbaar via /settings)
+
+StakeholderAssessment (belang/houding/invloed per persoon op een scope)
+├── scope_type=corpus_node OR initiatief
+├── scope_id (polymorphic FK; access-check in route, geen DB-FK)
+└── unique (person_id, scope_type, scope_id)
 ```
+
+## Initiatief settings & publieke pagina
+
+Per-initiatief feature-toggles (eigenaar-only via `PUT /api/initiatieven/{id}/settings`):
+
+- `funnel_enabled` — toont engagement_type + drie 1-5 scores op leads van dit initiatief
+- `public_page_enabled` — opt-in publieke pagina op `/c/:slug`
+- `score_strategisch_label` / `score_politiek_label` / `score_positie_label` — eigen labels die de defaults overschrijven
+
+Slug-rules in `backend/bouwmeester/core/slug.py`: lowercase, `[a-z0-9-]`, niet leeg, niet in `RESERVED_SLUGS`. Eenmalig instelbaar via UI (immutable na save in v1).
+
+Publieke endpoint `GET /api/public/initiatieven/by-slug/{slug}`:
+- Zit in `_PUBLIC_PREFIXES` van `auth_required.py` — geen auth nodig
+- Returnt 404 als slug niet bestaat OF `public_page_enabled=false` (geen 403 om bestaan niet te lekken)
+- Two-step query (lookup zonder relations, daarna eager-load) om timing-side-channel te beperken
+- Toont alleen naam/beschrijving/kleur + gepubliceerde `InitiatiefUpdatePost` records (`published_at IS NOT NULL`)
+- Frontend route `/c/:slug` in `App.tsx` zit buiten `AuthGate`; `<meta name="robots" content="noindex">` op de pagina, plus blanket `Disallow: /` in `frontend/public/robots.txt`
 
 ## Seed data and PII
 

--- a/backend/bouwmeester/api/routes/__init__.py
+++ b/backend/bouwmeester/api/routes/__init__.py
@@ -18,6 +18,9 @@ from bouwmeester.api.routes.fcc import router as fcc_router
 from bouwmeester.api.routes.graph import router as graph_router
 from bouwmeester.api.routes.import_export import router as import_export_router
 from bouwmeester.api.routes.initiatief import router as initiatieven_router
+from bouwmeester.api.routes.initiatief_update import (
+    router as initiatief_updates_router,
+)
 from bouwmeester.api.routes.leads import router as leads_router
 from bouwmeester.api.routes.llm import router as llm_router
 from bouwmeester.api.routes.mattermost import router as mattermost_router
@@ -29,6 +32,9 @@ from bouwmeester.api.routes.org_placements import router as org_placements_route
 from bouwmeester.api.routes.organisatie import router as organisatie_router
 from bouwmeester.api.routes.parlementair import router as parlementair_router
 from bouwmeester.api.routes.people import router as people_router
+from bouwmeester.api.routes.public_initiatief import (
+    router as public_initiatief_router,
+)
 from bouwmeester.api.routes.resource_permissions import (
     router as resource_permissions_router,
 )
@@ -36,6 +42,9 @@ from bouwmeester.api.routes.roles import router as roles_router
 from bouwmeester.api.routes.search import router as search_router
 from bouwmeester.api.routes.sharing import router as sharing_router
 from bouwmeester.api.routes.skill import router as skill_router
+from bouwmeester.api.routes.stakeholder_assessments import (
+    router as stakeholder_assessments_router,
+)
 from bouwmeester.api.routes.tags import router as tags_router
 from bouwmeester.api.routes.tasks import router as tasks_router
 from bouwmeester.api.routes.webauthn import router as webauthn_router
@@ -55,6 +64,7 @@ api_router.include_router(fcc_router)
 api_router.include_router(externe_organisaties_router)
 api_router.include_router(graph_router)
 api_router.include_router(initiatieven_router)
+api_router.include_router(initiatief_updates_router)
 api_router.include_router(import_export_router)
 api_router.include_router(leads_router)
 api_router.include_router(llm_router)
@@ -67,11 +77,13 @@ api_router.include_router(org_placements_router)
 api_router.include_router(organisatie_router)
 api_router.include_router(parlementair_router)
 api_router.include_router(people_router)
+api_router.include_router(public_initiatief_router)
 api_router.include_router(resource_permissions_router)
 api_router.include_router(roles_router)
 api_router.include_router(search_router)
 api_router.include_router(sharing_router)
 api_router.include_router(skill_router)
+api_router.include_router(stakeholder_assessments_router)
 api_router.include_router(tags_router)
 api_router.include_router(tasks_router)
 api_router.include_router(webauthn_router)

--- a/backend/bouwmeester/api/routes/initiatief.py
+++ b/backend/bouwmeester/api/routes/initiatief.py
@@ -30,6 +30,7 @@ from bouwmeester.schema.initiatief import (
     InitiatiefMemberCreate,
     InitiatiefMemberResponse,
     InitiatiefResponse,
+    InitiatiefSettingsUpdate,
     InitiatiefUpdate,
 )
 from bouwmeester.services.activity_service import log_activity
@@ -213,6 +214,33 @@ async def update_initiatief(
         None,
         "initiatief.updated",
         details={"initiatief_id": str(initiatief.id), "naam": initiatief.naam},
+    )
+
+    return InitiatiefResponse.model_validate(initiatief)
+
+
+@router.put("/{id}/settings", response_model=InitiatiefResponse)
+async def update_initiatief_settings(
+    id: UUID,
+    data: InitiatiefSettingsUpdate,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    perm_ctx: PermissionContext = Depends(get_permission_context),
+) -> InitiatiefResponse:
+    """Update settings (slug, toggles, score-labels). Eigenaar only."""
+    repo = InitiatiefRepository(db)
+    await _require_access(repo, id, current_user, perm_ctx, "eigenaar")
+    initiatief = require_found(await repo.update_settings(id, data), "Initiatief")
+
+    await log_activity(
+        db,
+        current_user,
+        None,
+        "initiatief.settings_updated",
+        details={
+            "initiatief_id": str(initiatief.id),
+            "fields": list(data.model_dump(exclude_unset=True).keys()),
+        },
     )
 
     return InitiatiefResponse.model_validate(initiatief)

--- a/backend/bouwmeester/api/routes/initiatief_update.py
+++ b/backend/bouwmeester/api/routes/initiatief_update.py
@@ -1,0 +1,199 @@
+"""API routes for InitiatiefUpdatePost (publication posts on an initiatief)."""
+
+from datetime import UTC, datetime
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from bouwmeester.api.deps import require_found
+from bouwmeester.api.routes.initiatief import _require_access
+from bouwmeester.core.auth import OptionalUser
+from bouwmeester.core.database import get_db
+from bouwmeester.core.permissions import (
+    PermissionContext,
+    get_permission_context,
+)
+from bouwmeester.models.initiatief_update import InitiatiefUpdatePost
+from bouwmeester.repositories.initiatief import InitiatiefRepository
+from bouwmeester.schema.initiatief_update import (
+    InitiatiefUpdatePostCreate,
+    InitiatiefUpdatePostEdit,
+    InitiatiefUpdatePostResponse,
+)
+
+router = APIRouter(prefix="/initiatieven", tags=["initiatief-updates"])
+
+
+def _to_response(post: InitiatiefUpdatePost) -> InitiatiefUpdatePostResponse:
+    return InitiatiefUpdatePostResponse(
+        id=post.id,
+        initiatief_id=post.initiatief_id,
+        titel=post.titel,
+        body=post.body,
+        published_at=post.published_at,
+        published_by_id=post.published_by_id,
+        published_by_naam=(post.published_by.naam if post.published_by else None),
+        created_at=post.created_at,
+        updated_at=post.updated_at,
+    )
+
+
+async def _load_post(
+    db: AsyncSession, initiatief_id: UUID, post_id: UUID
+) -> InitiatiefUpdatePost | None:
+    stmt = (
+        select(InitiatiefUpdatePost)
+        .where(
+            InitiatiefUpdatePost.id == post_id,
+            InitiatiefUpdatePost.initiatief_id == initiatief_id,
+        )
+        .options(selectinload(InitiatiefUpdatePost.published_by))
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+@router.get(
+    "/{initiatief_id}/updates",
+    response_model=list[InitiatiefUpdatePostResponse],
+)
+async def list_updates(
+    initiatief_id: UUID,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    perm_ctx: PermissionContext = Depends(get_permission_context),
+) -> list[InitiatiefUpdatePostResponse]:
+    """All updates (drafts + published) for members; viewers see same."""
+    repo = InitiatiefRepository(db)
+    require_found(await repo.get_by_id(initiatief_id), "Initiatief")
+    await _require_access(repo, initiatief_id, current_user, perm_ctx, "viewer")
+
+    stmt = (
+        select(InitiatiefUpdatePost)
+        .where(InitiatiefUpdatePost.initiatief_id == initiatief_id)
+        .options(selectinload(InitiatiefUpdatePost.published_by))
+        .order_by(InitiatiefUpdatePost.created_at.desc())
+    )
+    result = await db.execute(stmt)
+    return [_to_response(p) for p in result.scalars().all()]
+
+
+@router.post(
+    "/{initiatief_id}/updates",
+    response_model=InitiatiefUpdatePostResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_update(
+    initiatief_id: UUID,
+    data: InitiatiefUpdatePostCreate,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    perm_ctx: PermissionContext = Depends(get_permission_context),
+) -> InitiatiefUpdatePostResponse:
+    repo = InitiatiefRepository(db)
+    require_found(await repo.get_by_id(initiatief_id), "Initiatief")
+    await _require_access(repo, initiatief_id, current_user, perm_ctx, "contributor")
+
+    post = InitiatiefUpdatePost(
+        initiatief_id=initiatief_id,
+        titel=data.titel,
+        body=data.body,
+    )
+    if data.publish:
+        post.published_at = datetime.now(UTC)
+        post.published_by_id = current_user.id if current_user else None
+
+    db.add(post)
+    await db.flush()
+    await db.refresh(post, attribute_names=["published_by"])
+    return _to_response(post)
+
+
+@router.put(
+    "/{initiatief_id}/updates/{post_id}",
+    response_model=InitiatiefUpdatePostResponse,
+)
+async def edit_update(
+    initiatief_id: UUID,
+    post_id: UUID,
+    data: InitiatiefUpdatePostEdit,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    perm_ctx: PermissionContext = Depends(get_permission_context),
+) -> InitiatiefUpdatePostResponse:
+    repo = InitiatiefRepository(db)
+    await _require_access(repo, initiatief_id, current_user, perm_ctx, "contributor")
+    post = require_found(await _load_post(db, initiatief_id, post_id), "Update")
+    payload = data.model_dump(exclude_unset=True)
+    for key, value in payload.items():
+        setattr(post, key, value)
+    await db.flush()
+    await db.refresh(post, attribute_names=["published_by"])
+    return _to_response(post)
+
+
+@router.post(
+    "/{initiatief_id}/updates/{post_id}/publish",
+    response_model=InitiatiefUpdatePostResponse,
+)
+async def publish_update(
+    initiatief_id: UUID,
+    post_id: UUID,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    perm_ctx: PermissionContext = Depends(get_permission_context),
+) -> InitiatiefUpdatePostResponse:
+    repo = InitiatiefRepository(db)
+    await _require_access(repo, initiatief_id, current_user, perm_ctx, "contributor")
+    post = require_found(await _load_post(db, initiatief_id, post_id), "Update")
+    post.published_at = datetime.now(UTC)
+    post.published_by_id = current_user.id if current_user else None
+    await db.flush()
+    await db.refresh(post, attribute_names=["published_by"])
+    return _to_response(post)
+
+
+@router.post(
+    "/{initiatief_id}/updates/{post_id}/unpublish",
+    response_model=InitiatiefUpdatePostResponse,
+)
+async def unpublish_update(
+    initiatief_id: UUID,
+    post_id: UUID,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    perm_ctx: PermissionContext = Depends(get_permission_context),
+) -> InitiatiefUpdatePostResponse:
+    repo = InitiatiefRepository(db)
+    await _require_access(repo, initiatief_id, current_user, perm_ctx, "contributor")
+    post = require_found(await _load_post(db, initiatief_id, post_id), "Update")
+    post.published_at = None
+    post.published_by_id = None
+    await db.flush()
+    await db.refresh(post, attribute_names=["published_by"])
+    return _to_response(post)
+
+
+@router.delete(
+    "/{initiatief_id}/updates/{post_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_update(
+    initiatief_id: UUID,
+    post_id: UUID,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    perm_ctx: PermissionContext = Depends(get_permission_context),
+) -> None:
+    repo = InitiatiefRepository(db)
+    await _require_access(repo, initiatief_id, current_user, perm_ctx, "contributor")
+    post = await _load_post(db, initiatief_id, post_id)
+    if post is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Update niet gevonden"
+        )
+    await db.delete(post)
+    await db.flush()

--- a/backend/bouwmeester/api/routes/initiatief_update.py
+++ b/backend/bouwmeester/api/routes/initiatief_update.py
@@ -108,6 +108,7 @@ async def create_update(
 
     db.add(post)
     await db.flush()
+    await db.refresh(post)
     await db.refresh(post, attribute_names=["published_by"])
     return _to_response(post)
 
@@ -131,6 +132,7 @@ async def edit_update(
     for key, value in payload.items():
         setattr(post, key, value)
     await db.flush()
+    await db.refresh(post)
     await db.refresh(post, attribute_names=["published_by"])
     return _to_response(post)
 
@@ -152,6 +154,7 @@ async def publish_update(
     post.published_at = datetime.now(UTC)
     post.published_by_id = current_user.id if current_user else None
     await db.flush()
+    await db.refresh(post)
     await db.refresh(post, attribute_names=["published_by"])
     return _to_response(post)
 
@@ -170,9 +173,11 @@ async def unpublish_update(
     repo = InitiatiefRepository(db)
     await _require_access(repo, initiatief_id, current_user, perm_ctx, "contributor")
     post = require_found(await _load_post(db, initiatief_id, post_id), "Update")
+    # Keep published_by_id as audit trail of last publisher; republishing
+    # overwrites it again.
     post.published_at = None
-    post.published_by_id = None
     await db.flush()
+    await db.refresh(post)
     await db.refresh(post, attribute_names=["published_by"])
     return _to_response(post)
 

--- a/backend/bouwmeester/api/routes/public_initiatief.py
+++ b/backend/bouwmeester/api/routes/public_initiatief.py
@@ -1,0 +1,74 @@
+"""Public (unauthenticated) endpoints for an initiatief community page."""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from bouwmeester.core.database import get_db
+from bouwmeester.models.initiatief import Initiatief
+from bouwmeester.models.initiatief_update import InitiatiefUpdatePost
+from bouwmeester.schema.initiatief_update import InitiatiefUpdatePostPublicResponse
+
+router = APIRouter(prefix="/public/initiatieven", tags=["public-initiatief"])
+
+
+class PublicInitiatiefResponse(BaseModel):
+    naam: str
+    slug: str
+    beschrijving: str | None = None
+    kleur: str | None = None
+    updates: list[InitiatiefUpdatePostPublicResponse] = []
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+@router.get("/by-slug/{slug}", response_model=PublicInitiatiefResponse)
+async def get_public_initiatief(
+    slug: str,
+    db: AsyncSession = Depends(get_db),
+) -> PublicInitiatiefResponse:
+    """Return naam/beschrijving/kleur + published updates only.
+
+    Returns 404 (not 403) when slug is unknown OR public_page_enabled is
+    false. Hiding existence on disabled pages is intentional — leaks no
+    information about which initiatieven exist internally.
+    """
+    stmt = (
+        select(Initiatief)
+        .where(Initiatief.slug == slug)
+        .options(
+            selectinload(Initiatief.updates).selectinload(
+                InitiatiefUpdatePost.published_by
+            )
+        )
+    )
+    result = await db.execute(stmt)
+    initiatief = result.scalar_one_or_none()
+    if initiatief is None or not initiatief.public_page_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Pagina niet gevonden"
+        )
+
+    published_updates = sorted(
+        (u for u in initiatief.updates if u.published_at is not None),
+        key=lambda u: u.published_at,
+        reverse=True,
+    )
+
+    return PublicInitiatiefResponse(
+        naam=initiatief.naam,
+        slug=initiatief.slug or "",
+        beschrijving=initiatief.beschrijving,
+        kleur=initiatief.kleur,
+        updates=[
+            InitiatiefUpdatePostPublicResponse(
+                titel=u.titel,
+                body=u.body,
+                published_at=u.published_at,
+                published_by_naam=(u.published_by.naam if u.published_by else None),
+            )
+            for u in published_updates
+        ],
+    )

--- a/backend/bouwmeester/api/routes/public_initiatief.py
+++ b/backend/bouwmeester/api/routes/public_initiatief.py
@@ -9,9 +9,27 @@ from sqlalchemy.orm import selectinload
 from bouwmeester.core.database import get_db
 from bouwmeester.models.initiatief import Initiatief
 from bouwmeester.models.initiatief_update import InitiatiefUpdatePost
+from bouwmeester.models.lead import Lead
 from bouwmeester.schema.initiatief_update import InitiatiefUpdatePostPublicResponse
 
 router = APIRouter(prefix="/public/initiatieven", tags=["public-initiatief"])
+
+# Stages where a lead is considered actively in progress; others (inbox /
+# verkennen / koelkast) are intentionally hidden from the public surface
+# even when public_visible is true.
+_PUBLIC_VISIBLE_STAGES = (
+    "eerste_gesprek",
+    "interne_check",
+    "follow_up",
+    "in_the_pocket",
+)
+
+
+class PublicCasus(BaseModel):
+    """Lead-derived public summary; only fields the eigenaar wrote for outside."""
+
+    titel: str
+    samenvatting: str | None = None
 
 
 class PublicInitiatiefResponse(BaseModel):
@@ -20,6 +38,7 @@ class PublicInitiatiefResponse(BaseModel):
     beschrijving: str | None = None
     kleur: str | None = None
     updates: list[InitiatiefUpdatePostPublicResponse] = []
+    casussen: list[PublicCasus] = []
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -62,6 +81,23 @@ async def get_public_initiatief(
         reverse=True,
     )
 
+    # Lopende casussen: leads waar de eigenaar/contributor expliciet een
+    # publieks-titel heeft geschreven én de toggle aan zette én de lead in
+    # een actieve stage zit.
+    casussen_result = await db.execute(
+        select(Lead.public_title, Lead.public_summary)
+        .where(
+            Lead.initiatief_id == initiatief.id,
+            Lead.public_visible.is_(True),
+            Lead.public_title.is_not(None),
+            Lead.stage.in_(_PUBLIC_VISIBLE_STAGES),
+        )
+        .order_by(Lead.created_at.desc())
+    )
+    casussen = [
+        PublicCasus(titel=row[0], samenvatting=row[1]) for row in casussen_result.all()
+    ]
+
     return PublicInitiatiefResponse(
         naam=initiatief.naam,
         slug=initiatief.slug or "",
@@ -76,4 +112,5 @@ async def get_public_initiatief(
             )
             for u in published_updates
         ],
+        casussen=casussen,
     )

--- a/backend/bouwmeester/api/routes/public_initiatief.py
+++ b/backend/bouwmeester/api/routes/public_initiatief.py
@@ -34,22 +34,27 @@ async def get_public_initiatief(
     Returns 404 (not 403) when slug is unknown OR public_page_enabled is
     false. Hiding existence on disabled pages is intentional — leaks no
     information about which initiatieven exist internally.
+
+    Two-step query keeps timing roughly constant between "slug doesn't
+    exist" and "exists but private": both bail before any relation loads.
     """
-    stmt = (
+    lookup = await db.execute(select(Initiatief).where(Initiatief.slug == slug))
+    initiatief = lookup.scalar_one_or_none()
+    if initiatief is None or not initiatief.public_page_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Pagina niet gevonden"
+        )
+
+    detail = await db.execute(
         select(Initiatief)
-        .where(Initiatief.slug == slug)
+        .where(Initiatief.id == initiatief.id)
         .options(
             selectinload(Initiatief.updates).selectinload(
                 InitiatiefUpdatePost.published_by
             )
         )
     )
-    result = await db.execute(stmt)
-    initiatief = result.scalar_one_or_none()
-    if initiatief is None or not initiatief.public_page_enabled:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Pagina niet gevonden"
-        )
+    initiatief = detail.scalar_one()
 
     published_updates = sorted(
         (u for u in initiatief.updates if u.published_at is not None),

--- a/backend/bouwmeester/api/routes/stakeholder_assessments.py
+++ b/backend/bouwmeester/api/routes/stakeholder_assessments.py
@@ -7,8 +7,14 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from bouwmeester.api.deps import require_found
+from bouwmeester.api.routes.initiatief import _require_access
 from bouwmeester.core.auth import OptionalUser
 from bouwmeester.core.database import get_db
+from bouwmeester.core.permissions import (
+    PermissionContext,
+    get_permission_context,
+)
+from bouwmeester.repositories.initiatief import InitiatiefRepository
 from bouwmeester.repositories.stakeholder_assessment import (
     StakeholderAssessmentRepository,
 )
@@ -41,12 +47,63 @@ def _to_response(obj) -> StakeholderAssessmentResponse:
     )
 
 
+async def _check_scope_access(
+    db: AsyncSession,
+    scope_type: str,
+    scope_id: UUID,
+    current_user: OptionalUser,
+    perm_ctx: PermissionContext,
+    *,
+    write: bool,
+) -> None:
+    """Verify the caller may read (or write) assessments on the given scope.
+
+    Raises 403/404 on denial. ``write=True`` requires contributor-level on
+    initiatief or `node:update` on corpus_node; ``write=False`` requires
+    viewer-level / `node:read`.
+    """
+    if scope_type == "initiatief":
+        repo = InitiatiefRepository(db)
+        require_found(await repo.get_by_id(scope_id), "Initiatief")
+        await _require_access(
+            repo,
+            scope_id,
+            current_user,
+            perm_ctx,
+            "contributor" if write else "viewer",
+        )
+        return
+    if scope_type == "corpus_node":
+        # Nodes have no per-record ACL today: tenant-wide reads gated by the
+        # authn-middleware, mutations gated by node:update.
+        if write and not perm_ctx.has_permission("node:update"):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Geen rechten om stakeholder-assessment te wijzigen",
+            )
+        if not write and not perm_ctx.has_permission("node:read"):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Geen rechten om stakeholder-assessments te lezen",
+            )
+        return
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail=f"Onbekend scope_type: {scope_type}",
+    )
+
+
 @router.get("", response_model=list[StakeholderAssessmentResponse])
 async def list_assessments(
     scope_type: StakeholderScopeType,
     scope_id: UUID,
+    current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    perm_ctx: PermissionContext = Depends(get_permission_context),
 ) -> list[StakeholderAssessmentResponse]:
+    await _check_scope_access(
+        db, scope_type.value, scope_id, current_user, perm_ctx, write=False
+    )
     repo = StakeholderAssessmentRepository(db)
     items = await repo.list_for_scope(scope_type.value, scope_id)
     return [_to_response(item) for item in items]
@@ -61,7 +118,16 @@ async def create_assessment(
     data: StakeholderAssessmentCreate,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    perm_ctx: PermissionContext = Depends(get_permission_context),
 ) -> StakeholderAssessmentResponse:
+    await _check_scope_access(
+        db,
+        data.scope_type.value,
+        data.scope_id,
+        current_user,
+        perm_ctx,
+        write=True,
+    )
     repo = StakeholderAssessmentRepository(db)
     assessed_by_id = current_user.id if current_user else None
     try:
@@ -80,8 +146,18 @@ async def update_assessment(
     data: StakeholderAssessmentUpdate,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    perm_ctx: PermissionContext = Depends(get_permission_context),
 ) -> StakeholderAssessmentResponse:
     repo = StakeholderAssessmentRepository(db)
+    existing = require_found(await repo.get_by_id(id), "Assessment")
+    await _check_scope_access(
+        db,
+        existing.scope_type,
+        existing.scope_id,
+        current_user,
+        perm_ctx,
+        write=True,
+    )
     assessed_by_id = current_user.id if current_user else None
     assessment = require_found(
         await repo.update(id, data, assessed_by_id=assessed_by_id),
@@ -93,9 +169,20 @@ async def update_assessment(
 @router.delete("/{id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_assessment(
     id: UUID,
+    current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    perm_ctx: PermissionContext = Depends(get_permission_context),
 ) -> None:
     repo = StakeholderAssessmentRepository(db)
+    existing = require_found(await repo.get_by_id(id), "Assessment")
+    await _check_scope_access(
+        db,
+        existing.scope_type,
+        existing.scope_id,
+        current_user,
+        perm_ctx,
+        write=True,
+    )
     if not await repo.delete(id):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Assessment niet gevonden"

--- a/backend/bouwmeester/api/routes/stakeholder_assessments.py
+++ b/backend/bouwmeester/api/routes/stakeholder_assessments.py
@@ -1,0 +1,102 @@
+"""API routes for StakeholderAssessment."""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bouwmeester.api.deps import require_found
+from bouwmeester.core.auth import OptionalUser
+from bouwmeester.core.database import get_db
+from bouwmeester.repositories.stakeholder_assessment import (
+    StakeholderAssessmentRepository,
+)
+from bouwmeester.schema.stakeholder_assessment import (
+    StakeholderAssessmentCreate,
+    StakeholderAssessmentResponse,
+    StakeholderAssessmentUpdate,
+    StakeholderScopeType,
+)
+
+router = APIRouter(prefix="/stakeholder-assessments", tags=["stakeholder-assessments"])
+
+
+def _to_response(obj) -> StakeholderAssessmentResponse:
+    return StakeholderAssessmentResponse(
+        id=obj.id,
+        person_id=obj.person_id,
+        person_naam=obj.person.naam if obj.person else "",
+        scope_type=obj.scope_type,
+        scope_id=obj.scope_id,
+        belang=obj.belang,
+        houding=obj.houding,
+        invloed=obj.invloed,
+        notitie=obj.notitie,
+        assessed_by_id=obj.assessed_by_id,
+        assessed_by_naam=obj.assessed_by.naam if obj.assessed_by else None,
+        assessed_at=obj.assessed_at,
+        created_at=obj.created_at,
+        updated_at=obj.updated_at,
+    )
+
+
+@router.get("", response_model=list[StakeholderAssessmentResponse])
+async def list_assessments(
+    scope_type: StakeholderScopeType,
+    scope_id: UUID,
+    db: AsyncSession = Depends(get_db),
+) -> list[StakeholderAssessmentResponse]:
+    repo = StakeholderAssessmentRepository(db)
+    items = await repo.list_for_scope(scope_type.value, scope_id)
+    return [_to_response(item) for item in items]
+
+
+@router.post(
+    "",
+    response_model=StakeholderAssessmentResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_assessment(
+    data: StakeholderAssessmentCreate,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+) -> StakeholderAssessmentResponse:
+    repo = StakeholderAssessmentRepository(db)
+    assessed_by_id = current_user.id if current_user else None
+    try:
+        assessment = await repo.create(data, assessed_by_id=assessed_by_id)
+    except IntegrityError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Assessment voor deze persoon en scope bestaat al",
+        )
+    return _to_response(assessment)
+
+
+@router.put("/{id}", response_model=StakeholderAssessmentResponse)
+async def update_assessment(
+    id: UUID,
+    data: StakeholderAssessmentUpdate,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+) -> StakeholderAssessmentResponse:
+    repo = StakeholderAssessmentRepository(db)
+    assessed_by_id = current_user.id if current_user else None
+    assessment = require_found(
+        await repo.update(id, data, assessed_by_id=assessed_by_id),
+        "Assessment",
+    )
+    return _to_response(assessment)
+
+
+@router.delete("/{id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_assessment(
+    id: UUID,
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    repo = StakeholderAssessmentRepository(db)
+    if not await repo.delete(id):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Assessment niet gevonden"
+        )

--- a/backend/bouwmeester/core/slug.py
+++ b/backend/bouwmeester/core/slug.py
@@ -1,0 +1,51 @@
+"""Slug generation and validation."""
+
+import re
+import unicodedata
+
+# Reserved words that cannot be used as slugs (collide with routes / system).
+RESERVED_SLUGS: frozenset[str] = frozenset(
+    {
+        "api",
+        "auth",
+        "admin",
+        "c",
+        "i",
+        "public",
+        "health",
+        "static",
+        "assets",
+        "login",
+        "logout",
+        "callback",
+        "webauthn",
+        "mattermost",
+        "new",
+        "edit",
+    }
+)
+
+_SLUG_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+_NON_ALNUM = re.compile(r"[^a-z0-9]+")
+
+
+def slugify(value: str) -> str:
+    """Turn an arbitrary string into a slug.
+
+    Lowercases, strips diacritics, replaces non-alphanumerics with hyphens,
+    and collapses repeats. Returns an empty string if nothing remains.
+    """
+    normalized = unicodedata.normalize("NFKD", value)
+    ascii_only = normalized.encode("ascii", "ignore").decode("ascii")
+    lowered = ascii_only.lower()
+    hyphenated = _NON_ALNUM.sub("-", lowered)
+    return hyphenated.strip("-")
+
+
+def is_valid_slug(slug: str) -> bool:
+    """A slug is valid if it matches the pattern and isn't reserved."""
+    if not slug:
+        return False
+    if slug in RESERVED_SLUGS:
+        return False
+    return bool(_SLUG_PATTERN.match(slug))

--- a/backend/bouwmeester/middleware/auth_required.py
+++ b/backend/bouwmeester/middleware/auth_required.py
@@ -43,6 +43,7 @@ _api_key_failures: dict[str, list[float]] = defaultdict(list)
 _PUBLIC_PREFIXES = (
     "/api/auth/",
     "/api/health/",
+    "/api/public/",
     "/api/webauthn/authenticate/",
     "/api/mattermost/slash",
     "/api/mattermost/action",

--- a/backend/bouwmeester/migrations/versions/7f9793c38f23_merge_funnel_and_parlementair_.py
+++ b/backend/bouwmeester/migrations/versions/7f9793c38f23_merge_funnel_and_parlementair_.py
@@ -1,0 +1,23 @@
+"""merge funnel and parlementair-permissions heads
+
+Revision ID: 7f9793c38f23
+Revises: 27276a028617, b6d7e8f90135
+Create Date: 2026-05-05 07:35:07.769970
+
+"""
+
+from collections.abc import Sequence
+
+# revision identifiers, used by Alembic.
+revision: str = "7f9793c38f23"
+down_revision: str | None = ("27276a028617", "b6d7e8f90135")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/backend/bouwmeester/migrations/versions/a5c6d7e8f024_add_stakeholder_assessment.py
+++ b/backend/bouwmeester/migrations/versions/a5c6d7e8f024_add_stakeholder_assessment.py
@@ -1,0 +1,88 @@
+"""add stakeholder_assessment table
+
+Revision ID: a5c6d7e8f024
+Revises: f4b5c6d7e913
+Create Date: 2026-05-05
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a5c6d7e8f024"
+down_revision: str | None = "f4b5c6d7e913"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "stakeholder_assessment",
+        sa.Column(
+            "id",
+            sa.UUID(),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("person_id", sa.UUID(), nullable=False),
+        sa.Column(
+            "scope_type",
+            sa.String(),
+            nullable=False,
+            comment="corpus_node|initiatief",
+        ),
+        sa.Column("scope_id", sa.UUID(), nullable=False),
+        sa.Column("belang", sa.Integer(), nullable=True),
+        sa.Column(
+            "houding",
+            sa.String(),
+            nullable=True,
+            comment="tegen|kritisch|neutraal|welwillend|voorstander",
+        ),
+        sa.Column("invloed", sa.Integer(), nullable=True),
+        sa.Column("notitie", sa.Text(), nullable=True),
+        sa.Column("assessed_by_id", sa.UUID(), nullable=True),
+        sa.Column("assessed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["person_id"], ["person.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["assessed_by_id"], ["person.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "person_id",
+            "scope_type",
+            "scope_id",
+            name="uq_stakeholder_assessment_person_scope",
+        ),
+    )
+    op.create_index(
+        op.f("ix_stakeholder_assessment_person_id"),
+        "stakeholder_assessment",
+        ["person_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_stakeholder_assessment_scope_id"),
+        "stakeholder_assessment",
+        ["scope_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_stakeholder_assessment_scope_id"),
+        table_name="stakeholder_assessment",
+    )
+    op.drop_index(
+        op.f("ix_stakeholder_assessment_person_id"),
+        table_name="stakeholder_assessment",
+    )
+    op.drop_table("stakeholder_assessment")

--- a/backend/bouwmeester/migrations/versions/b6d7e8f90135_add_initiatief_update_post.py
+++ b/backend/bouwmeester/migrations/versions/b6d7e8f90135_add_initiatief_update_post.py
@@ -1,0 +1,72 @@
+"""add initiatief_update table for publication posts
+
+Revision ID: b6d7e8f90135
+Revises: a5c6d7e8f024
+Create Date: 2026-05-05
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "b6d7e8f90135"
+down_revision: str | None = "a5c6d7e8f024"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "initiatief_update",
+        sa.Column(
+            "id",
+            sa.UUID(),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("initiatief_id", sa.UUID(), nullable=False),
+        sa.Column("titel", sa.String(), nullable=False),
+        sa.Column("body", sa.Text(), nullable=True),
+        sa.Column("published_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("published_by_id", sa.UUID(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["initiatief_id"], ["initiatief.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["published_by_id"], ["person.id"], ondelete="SET NULL"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_initiatief_update_initiatief_id"),
+        "initiatief_update",
+        ["initiatief_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_initiatief_update_published_at"),
+        "initiatief_update",
+        ["published_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_initiatief_update_published_at"),
+        table_name="initiatief_update",
+    )
+    op.drop_index(
+        op.f("ix_initiatief_update_initiatief_id"),
+        table_name="initiatief_update",
+    )
+    op.drop_table("initiatief_update")

--- a/backend/bouwmeester/migrations/versions/c8e9f01a2b34_score_check_constraints.py
+++ b/backend/bouwmeester/migrations/versions/c8e9f01a2b34_score_check_constraints.py
@@ -1,0 +1,44 @@
+"""add CHECK constraints on funnel + assessment scores
+
+Revision ID: c8e9f01a2b34
+Revises: 7f9793c38f23
+Create Date: 2026-05-05
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "c8e9f01a2b34"
+down_revision: str | None = "7f9793c38f23"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Lead funnel scores
+    for col in ("score_strategisch", "score_politiek", "score_positie"):
+        op.create_check_constraint(
+            f"ck_lead_{col}_range",
+            "lead",
+            f"{col} IS NULL OR ({col} BETWEEN 1 AND 5)",
+        )
+    # Stakeholder assessment scores
+    for col in ("belang", "invloed"):
+        op.create_check_constraint(
+            f"ck_stakeholder_assessment_{col}_range",
+            "stakeholder_assessment",
+            f"{col} IS NULL OR ({col} BETWEEN 1 AND 5)",
+        )
+
+
+def downgrade() -> None:
+    for col in ("belang", "invloed"):
+        op.drop_constraint(
+            f"ck_stakeholder_assessment_{col}_range",
+            "stakeholder_assessment",
+            type_="check",
+        )
+    for col in ("score_strategisch", "score_politiek", "score_positie"):
+        op.drop_constraint(f"ck_lead_{col}_range", "lead", type_="check")

--- a/backend/bouwmeester/migrations/versions/d2f5a1b8c947_add_initiatief_settings_and_slug.py
+++ b/backend/bouwmeester/migrations/versions/d2f5a1b8c947_add_initiatief_settings_and_slug.py
@@ -1,0 +1,94 @@
+"""add initiatief settings and slug
+
+Revision ID: d2f5a1b8c947
+Revises: c1d4e7a3b9f2
+Create Date: 2026-05-05
+
+"""
+
+import re
+import unicodedata
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d2f5a1b8c947"
+down_revision: str | None = "c1d4e7a3b9f2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_NON_ALNUM = re.compile(r"[^a-z0-9]+")
+_RESERVED = frozenset(
+    {"api", "auth", "admin", "c", "i", "public", "health", "static", "assets"}
+)
+
+
+def _slugify(value: str) -> str:
+    normalized = unicodedata.normalize("NFKD", value)
+    ascii_only = normalized.encode("ascii", "ignore").decode("ascii")
+    hyphenated = _NON_ALNUM.sub("-", ascii_only.lower())
+    return hyphenated.strip("-")
+
+
+def upgrade() -> None:
+    op.add_column("initiatief", sa.Column("slug", sa.String(), nullable=True))
+    op.add_column(
+        "initiatief",
+        sa.Column(
+            "funnel_enabled",
+            sa.Boolean(),
+            server_default="false",
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        "initiatief",
+        sa.Column(
+            "public_page_enabled",
+            sa.Boolean(),
+            server_default="false",
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        "initiatief", sa.Column("score_strategisch_label", sa.String(), nullable=True)
+    )
+    op.add_column(
+        "initiatief", sa.Column("score_politiek_label", sa.String(), nullable=True)
+    )
+    op.add_column(
+        "initiatief", sa.Column("score_positie_label", sa.String(), nullable=True)
+    )
+
+    # Backfill slugs from existing naam values, ensuring uniqueness.
+    bind = op.get_bind()
+    rows = bind.execute(sa.text("SELECT id, naam FROM initiatief")).fetchall()
+    used: set[str] = set()
+    for row_id, naam in rows:
+        base = _slugify(naam or "")
+        if not base or base in _RESERVED:
+            continue
+        candidate = base
+        suffix = 2
+        while candidate in used:
+            candidate = f"{base}-{suffix}"
+            suffix += 1
+        used.add(candidate)
+        bind.execute(
+            sa.text("UPDATE initiatief SET slug = :slug WHERE id = :id"),
+            {"slug": candidate, "id": row_id},
+        )
+
+    op.create_unique_constraint("uq_initiatief_slug", "initiatief", ["slug"])
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_initiatief_slug", "initiatief", type_="unique")
+    op.drop_column("initiatief", "score_positie_label")
+    op.drop_column("initiatief", "score_politiek_label")
+    op.drop_column("initiatief", "score_strategisch_label")
+    op.drop_column("initiatief", "public_page_enabled")
+    op.drop_column("initiatief", "funnel_enabled")
+    op.drop_column("initiatief", "slug")

--- a/backend/bouwmeester/migrations/versions/d9f0a1b2c345_add_lead_public_fields.py
+++ b/backend/bouwmeester/migrations/versions/d9f0a1b2c345_add_lead_public_fields.py
@@ -1,0 +1,37 @@
+"""add public-publication fields to lead
+
+Revision ID: d9f0a1b2c345
+Revises: c8e9f01a2b34
+Create Date: 2026-05-05
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d9f0a1b2c345"
+down_revision: str | None = "c8e9f01a2b34"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "lead",
+        sa.Column(
+            "public_visible",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+    )
+    op.add_column("lead", sa.Column("public_title", sa.String(), nullable=True))
+    op.add_column("lead", sa.Column("public_summary", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("lead", "public_summary")
+    op.drop_column("lead", "public_title")
+    op.drop_column("lead", "public_visible")

--- a/backend/bouwmeester/migrations/versions/e3a4b5c6d802_add_lead_funnel_fields.py
+++ b/backend/bouwmeester/migrations/versions/e3a4b5c6d802_add_lead_funnel_fields.py
@@ -1,0 +1,42 @@
+"""add lead funnel fields
+
+Revision ID: e3a4b5c6d802
+Revises: d2f5a1b8c947
+Create Date: 2026-05-05
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e3a4b5c6d802"
+down_revision: str | None = "d2f5a1b8c947"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "lead",
+        sa.Column(
+            "engagement_type",
+            sa.String(),
+            nullable=True,
+            comment=(
+                "intern_oppakken|voorbereiden_eigen_team|betrokken_houden|"
+                "verkenning|nog_te_bepalen"
+            ),
+        ),
+    )
+    op.add_column("lead", sa.Column("score_strategisch", sa.Integer(), nullable=True))
+    op.add_column("lead", sa.Column("score_politiek", sa.Integer(), nullable=True))
+    op.add_column("lead", sa.Column("score_positie", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("lead", "score_positie")
+    op.drop_column("lead", "score_politiek")
+    op.drop_column("lead", "score_strategisch")
+    op.drop_column("lead", "engagement_type")

--- a/backend/bouwmeester/migrations/versions/f4b5c6d7e913_add_evaluatie_activity_fields.py
+++ b/backend/bouwmeester/migrations/versions/f4b5c6d7e913_add_evaluatie_activity_fields.py
@@ -1,0 +1,27 @@
+"""add evaluatie activity fields to lead_activity
+
+Revision ID: f4b5c6d7e913
+Revises: e3a4b5c6d802
+Create Date: 2026-05-05
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f4b5c6d7e913"
+down_revision: str | None = "e3a4b5c6d802"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("lead_activity", sa.Column("uitkomst", sa.Text(), nullable=True))
+    op.add_column("lead_activity", sa.Column("vervolgacties", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("lead_activity", "vervolgacties")
+    op.drop_column("lead_activity", "uitkomst")

--- a/backend/bouwmeester/models/__init__.py
+++ b/backend/bouwmeester/models/__init__.py
@@ -23,6 +23,7 @@ from bouwmeester.models.externe_organisatie import ExterneOrganisatie  # noqa: F
 from bouwmeester.models.fcc_sync_log import FccSyncLog  # noqa: F401
 from bouwmeester.models.http_session import HttpSession  # noqa: F401
 from bouwmeester.models.initiatief import Initiatief  # noqa: F401
+from bouwmeester.models.initiatief_update import InitiatiefUpdatePost  # noqa: F401
 from bouwmeester.models.instrument import Instrument  # noqa: F401
 from bouwmeester.models.lead import Lead  # noqa: F401
 from bouwmeester.models.lead_activity import LeadActivity  # noqa: F401
@@ -61,6 +62,9 @@ from bouwmeester.models.role import (  # noqa: F401
     RolePermission,
 )
 from bouwmeester.models.shared_access import SharedAccess  # noqa: F401
+from bouwmeester.models.stakeholder_assessment import (
+    StakeholderAssessment,  # noqa: F401
+)
 from bouwmeester.models.tag import LeadTag, NodeTag, Tag  # noqa: F401
 from bouwmeester.models.task import Task  # noqa: F401
 from bouwmeester.models.webauthn_credential import WebAuthnCredential  # noqa: F401
@@ -91,6 +95,7 @@ __all__ = [
     "FccSyncLog",
     "HttpSession",
     "Initiatief",
+    "InitiatiefUpdatePost",
     "Instrument",
     "Lead",
     "LeadActivity",
@@ -123,6 +128,7 @@ __all__ = [
     "Role",
     "RolePermission",
     "SharedAccess",
+    "StakeholderAssessment",
     "SuggestedEdge",
     "Tag",
     "Task",

--- a/backend/bouwmeester/models/initiatief.py
+++ b/backend/bouwmeester/models/initiatief.py
@@ -3,7 +3,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, Text, UniqueConstraint, func, text
+from sqlalchemy import Boolean, DateTime, ForeignKey, Text, UniqueConstraint, func, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -12,7 +12,10 @@ from bouwmeester.core.database import Base
 
 class Initiatief(Base):
     __tablename__ = "initiatief"
-    __table_args__ = (UniqueConstraint("naam", name="uq_initiatief_naam"),)
+    __table_args__ = (
+        UniqueConstraint("naam", name="uq_initiatief_naam"),
+        UniqueConstraint("slug", name="uq_initiatief_slug"),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
@@ -20,8 +23,18 @@ class Initiatief(Base):
         server_default=text("gen_random_uuid()"),
     )
     naam: Mapped[str] = mapped_column(nullable=False)
+    slug: Mapped[str | None] = mapped_column(nullable=True)
     beschrijving: Mapped[str | None] = mapped_column(Text, nullable=True)
     kleur: Mapped[str | None] = mapped_column(nullable=True)
+    funnel_enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
+    public_page_enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
+    score_strategisch_label: Mapped[str | None] = mapped_column(nullable=True)
+    score_politiek_label: Mapped[str | None] = mapped_column(nullable=True)
+    score_positie_label: Mapped[str | None] = mapped_column(nullable=True)
     created_by_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("person.id", ondelete="SET NULL"),
@@ -39,4 +52,10 @@ class Initiatief(Base):
     leads: Mapped[list["Lead"]] = relationship(  # noqa: F821
         "Lead",
         back_populates="initiatief",
+    )
+    updates: Mapped[list["InitiatiefUpdatePost"]] = relationship(  # noqa: F821
+        "InitiatiefUpdatePost",
+        back_populates="initiatief",
+        cascade="all, delete-orphan",
+        order_by="InitiatiefUpdatePost.created_at.desc()",
     )

--- a/backend/bouwmeester/models/initiatief_update.py
+++ b/backend/bouwmeester/models/initiatief_update.py
@@ -1,0 +1,60 @@
+"""InitiatiefUpdate model — explicit publication post on an initiatief."""
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional
+
+from sqlalchemy import DateTime, ForeignKey, Text, func, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from bouwmeester.core.database import Base
+
+if TYPE_CHECKING:
+    from bouwmeester.models.initiatief import Initiatief
+    from bouwmeester.models.person import Person
+
+
+class InitiatiefUpdatePost(Base):
+    """Author-driven publication on an initiatief.
+
+    Distinct from internal Lead activity: this is what shows on the public
+    /c/:slug page when published. `published_at` IS NULL means draft.
+    """
+
+    __tablename__ = "initiatief_update"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    initiatief_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("initiatief.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    titel: Mapped[str] = mapped_column(nullable=False)
+    body: Mapped[str | None] = mapped_column(Text, nullable=True)
+    published_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, index=True
+    )
+    published_by_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("person.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), onupdate=func.now(), nullable=True
+    )
+
+    initiatief: Mapped["Initiatief"] = relationship(
+        "Initiatief", back_populates="updates"
+    )
+    published_by: Mapped[Optional["Person"]] = relationship(
+        "Person", foreign_keys=[published_by_id]
+    )

--- a/backend/bouwmeester/models/lead.py
+++ b/backend/bouwmeester/models/lead.py
@@ -57,6 +57,16 @@ class Lead(Base):
     next_action_date: Mapped[date | None] = mapped_column(nullable=True)
     sort_order: Mapped[int] = mapped_column(default=0, server_default="0")
     raw_intake_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    engagement_type: Mapped[str | None] = mapped_column(
+        nullable=True,
+        comment=(
+            "intern_oppakken|voorbereiden_eigen_team|betrokken_houden|"
+            "verkenning|nog_te_bepalen"
+        ),
+    )
+    score_strategisch: Mapped[int | None] = mapped_column(nullable=True)
+    score_politiek: Mapped[int | None] = mapped_column(nullable=True)
+    score_positie: Mapped[int | None] = mapped_column(nullable=True)
     initiatief_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("initiatief.id", ondelete="CASCADE"),

--- a/backend/bouwmeester/models/lead.py
+++ b/backend/bouwmeester/models/lead.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import date, datetime
 from typing import TYPE_CHECKING, Optional
 
-from sqlalchemy import DateTime, ForeignKey, Text, func, text
+from sqlalchemy import Boolean, DateTime, ForeignKey, Text, func, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -67,6 +67,11 @@ class Lead(Base):
     score_strategisch: Mapped[int | None] = mapped_column(nullable=True)
     score_politiek: Mapped[int | None] = mapped_column(nullable=True)
     score_positie: Mapped[int | None] = mapped_column(nullable=True)
+    public_visible: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
+    public_title: Mapped[str | None] = mapped_column(nullable=True)
+    public_summary: Mapped[str | None] = mapped_column(Text, nullable=True)
     initiatief_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("initiatief.id", ondelete="CASCADE"),

--- a/backend/bouwmeester/models/lead_activity.py
+++ b/backend/bouwmeester/models/lead_activity.py
@@ -38,11 +38,13 @@ class LeadActivity(Base):
     activity_type: Mapped[str] = mapped_column(
         default="note",
         server_default="note",
-        comment="note|stage_change|meeting|call|email",
+        comment="note|stage_change|meeting|call|email|evaluatie",
     )
     metadata_: Mapped[dict] = mapped_column(
         "metadata", JSON, default=dict, server_default="{}"
     )
+    uitkomst: Mapped[str | None] = mapped_column(Text, nullable=True)
+    vervolgacties: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/backend/bouwmeester/models/stakeholder_assessment.py
+++ b/backend/bouwmeester/models/stakeholder_assessment.py
@@ -1,0 +1,80 @@
+"""StakeholderAssessment model — belang/houding/invloed of a person on a scope."""
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional
+
+from sqlalchemy import DateTime, ForeignKey, Text, UniqueConstraint, func, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from bouwmeester.core.database import Base
+
+if TYPE_CHECKING:
+    from bouwmeester.models.person import Person
+
+
+class StakeholderAssessment(Base):
+    """Per-person assessment scoped to a corpus node or initiatief.
+
+    Tracks how important a topic is to a stakeholder (belang), how they
+    feel about it (houding), and how much influence they have (invloed).
+    Distinct from `resource_permission` which tracks role/access.
+    """
+
+    __tablename__ = "stakeholder_assessment"
+    __table_args__ = (
+        UniqueConstraint(
+            "person_id",
+            "scope_type",
+            "scope_id",
+            name="uq_stakeholder_assessment_person_scope",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    person_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("person.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    scope_type: Mapped[str] = mapped_column(
+        nullable=False,
+        comment="corpus_node|initiatief",
+    )
+    scope_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        nullable=False,
+        index=True,
+    )
+    belang: Mapped[int | None] = mapped_column(nullable=True)
+    houding: Mapped[str | None] = mapped_column(
+        nullable=True,
+        comment="tegen|kritisch|neutraal|welwillend|voorstander",
+    )
+    invloed: Mapped[int | None] = mapped_column(nullable=True)
+    notitie: Mapped[str | None] = mapped_column(Text, nullable=True)
+    assessed_by_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("person.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    assessed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), onupdate=func.now(), nullable=True
+    )
+
+    person: Mapped["Person"] = relationship("Person", foreign_keys=[person_id])
+    assessed_by: Mapped[Optional["Person"]] = relationship(
+        "Person", foreign_keys=[assessed_by_id]
+    )

--- a/backend/bouwmeester/repositories/initiatief.py
+++ b/backend/bouwmeester/repositories/initiatief.py
@@ -7,12 +7,14 @@ from sqlalchemy.orm import selectinload
 
 from bouwmeester.core.initiatief_context import InitiatiefContext
 from bouwmeester.core.query_utils import escape_like
+from bouwmeester.core.slug import is_valid_slug, slugify
 from bouwmeester.models.initiatief import Initiatief
 from bouwmeester.models.resource_permission import ResourcePermission
 from bouwmeester.repositories.base import BaseRepository
 from bouwmeester.schema.initiatief import (
     EENHEID_ROL_RANK,
     InitiatiefCreate,
+    InitiatiefSettingsUpdate,
     InitiatiefUpdate,
 )
 
@@ -47,11 +49,37 @@ class InitiatiefRepository(BaseRepository[Initiatief]):
         result = await self.session.execute(stmt)
         return result.scalar_one_or_none()
 
+    async def get_by_slug(self, slug: str) -> Initiatief | None:
+        stmt = select(Initiatief).where(Initiatief.slug == slug)
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def _slug_exists(self, slug: str, exclude_id: UUID | None = None) -> bool:
+        stmt = select(Initiatief.id).where(Initiatief.slug == slug)
+        if exclude_id is not None:
+            stmt = stmt.where(Initiatief.id != exclude_id)
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none() is not None
+
+    async def _generate_unique_slug(
+        self, naam: str, exclude_id: UUID | None = None
+    ) -> str | None:
+        base = slugify(naam)
+        if not is_valid_slug(base):
+            return None
+        candidate = base
+        suffix = 2
+        while await self._slug_exists(candidate, exclude_id=exclude_id):
+            candidate = f"{base}-{suffix}"
+            suffix += 1
+        return candidate
+
     async def create(
         self, data: InitiatiefCreate, created_by_id: UUID | None = None
     ) -> Initiatief:
         dump = data.model_dump()
         dump["created_by_id"] = created_by_id
+        dump["slug"] = await self._generate_unique_slug(data.naam)
         initiatief = Initiatief(**dump)
         self.session.add(initiatief)
         await self.session.flush()
@@ -74,6 +102,39 @@ class InitiatiefRepository(BaseRepository[Initiatief]):
         if initiatief is None:
             return None
         for key, value in data.model_dump(exclude_unset=True).items():
+            setattr(initiatief, key, value)
+        await self.session.flush()
+        await self.session.refresh(initiatief)
+        return initiatief
+
+    async def update_settings(
+        self, id: UUID, data: InitiatiefSettingsUpdate
+    ) -> Initiatief | None:
+        initiatief = await self.session.get(Initiatief, id)
+        if initiatief is None:
+            return None
+        payload = data.model_dump(exclude_unset=True)
+        # If a slug is being assigned/changed, validate uniqueness.
+        if "slug" in payload and payload["slug"] is not None:
+            new_slug = payload["slug"]
+            if not is_valid_slug(new_slug):
+                from fastapi import HTTPException, status
+
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=(
+                        "Ongeldige slug. Gebruik alleen kleine letters, cijfers "
+                        "en streepjes. Reservewoorden zijn niet toegestaan."
+                    ),
+                )
+            if await self._slug_exists(new_slug, exclude_id=id):
+                from fastapi import HTTPException, status
+
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="Deze slug is al in gebruik",
+                )
+        for key, value in payload.items():
             setattr(initiatief, key, value)
         await self.session.flush()
         await self.session.refresh(initiatief)

--- a/backend/bouwmeester/repositories/lead_activity.py
+++ b/backend/bouwmeester/repositories/lead_activity.py
@@ -24,6 +24,8 @@ class LeadActivityRepository(BaseRepository[LeadActivity]):
             author_id=author_id,
             content=data.content,
             activity_type=data.activity_type,
+            uitkomst=data.uitkomst,
+            vervolgacties=data.vervolgacties,
         )
         self.session.add(activity)
         await self.session.flush()

--- a/backend/bouwmeester/repositories/stakeholder_assessment.py
+++ b/backend/bouwmeester/repositories/stakeholder_assessment.py
@@ -1,0 +1,101 @@
+"""Repository for StakeholderAssessment CRUD."""
+
+from datetime import UTC
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from bouwmeester.models.stakeholder_assessment import StakeholderAssessment
+from bouwmeester.repositories.base import BaseRepository
+from bouwmeester.schema.stakeholder_assessment import (
+    StakeholderAssessmentCreate,
+    StakeholderAssessmentUpdate,
+)
+
+
+class StakeholderAssessmentRepository(BaseRepository[StakeholderAssessment]):
+    model = StakeholderAssessment
+
+    async def list_for_scope(
+        self, scope_type: str, scope_id: UUID
+    ) -> list[StakeholderAssessment]:
+        stmt = (
+            select(StakeholderAssessment)
+            .where(
+                StakeholderAssessment.scope_type == scope_type,
+                StakeholderAssessment.scope_id == scope_id,
+            )
+            .options(
+                selectinload(StakeholderAssessment.person),
+                selectinload(StakeholderAssessment.assessed_by),
+            )
+            .order_by(StakeholderAssessment.created_at)
+        )
+        result = await self.session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def get_by_id(self, assessment_id: UUID) -> StakeholderAssessment | None:
+        stmt = (
+            select(StakeholderAssessment)
+            .where(StakeholderAssessment.id == assessment_id)
+            .options(
+                selectinload(StakeholderAssessment.person),
+                selectinload(StakeholderAssessment.assessed_by),
+            )
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def create(
+        self, data: StakeholderAssessmentCreate, assessed_by_id: UUID | None = None
+    ) -> StakeholderAssessment:
+        from datetime import datetime
+
+        assessment = StakeholderAssessment(
+            person_id=data.person_id,
+            scope_type=data.scope_type,
+            scope_id=data.scope_id,
+            belang=data.belang,
+            houding=data.houding,
+            invloed=data.invloed,
+            notitie=data.notitie,
+            assessed_by_id=assessed_by_id,
+            assessed_at=datetime.now(UTC),
+        )
+        self.session.add(assessment)
+        await self.session.flush()
+        await self.session.refresh(
+            assessment, attribute_names=["person", "assessed_by"]
+        )
+        return assessment
+
+    async def update(
+        self,
+        assessment_id: UUID,
+        data: StakeholderAssessmentUpdate,
+        assessed_by_id: UUID | None = None,
+    ) -> StakeholderAssessment | None:
+        from datetime import datetime
+
+        assessment = await self.get_by_id(assessment_id)
+        if assessment is None:
+            return None
+        for key, value in data.model_dump(exclude_unset=True).items():
+            setattr(assessment, key, value)
+        assessment.assessed_at = datetime.now(UTC)
+        if assessed_by_id is not None:
+            assessment.assessed_by_id = assessed_by_id
+        await self.session.flush()
+        await self.session.refresh(
+            assessment, attribute_names=["person", "assessed_by"]
+        )
+        return assessment
+
+    async def delete(self, assessment_id: UUID) -> bool:
+        assessment = await self.session.get(StakeholderAssessment, assessment_id)
+        if assessment is None:
+            return False
+        await self.session.delete(assessment)
+        await self.session.flush()
+        return True

--- a/backend/bouwmeester/repositories/stakeholder_assessment.py
+++ b/backend/bouwmeester/repositories/stakeholder_assessment.py
@@ -65,6 +65,8 @@ class StakeholderAssessmentRepository(BaseRepository[StakeholderAssessment]):
         )
         self.session.add(assessment)
         await self.session.flush()
+        # Refresh column attrs (server_default/onupdate) and relations together.
+        await self.session.refresh(assessment)
         await self.session.refresh(
             assessment, attribute_names=["person", "assessed_by"]
         )
@@ -87,6 +89,8 @@ class StakeholderAssessmentRepository(BaseRepository[StakeholderAssessment]):
         if assessed_by_id is not None:
             assessment.assessed_by_id = assessed_by_id
         await self.session.flush()
+        # Refresh column attrs (server_default/onupdate) and relations together.
+        await self.session.refresh(assessment)
         await self.session.refresh(
             assessment, attribute_names=["person", "assessed_by"]
         )

--- a/backend/bouwmeester/schema/__init__.py
+++ b/backend/bouwmeester/schema/__init__.py
@@ -98,6 +98,12 @@ from bouwmeester.schema.initiatief import (
     InitiatiefResponse,
     InitiatiefUpdate,
 )
+from bouwmeester.schema.initiatief_update import (
+    InitiatiefUpdatePostCreate,
+    InitiatiefUpdatePostEdit,
+    InitiatiefUpdatePostPublicResponse,
+    InitiatiefUpdatePostResponse,
+)
 from bouwmeester.schema.lead import (
     LeadActivityCreate,
     LeadActivityResponse,
@@ -216,6 +222,13 @@ from bouwmeester.schema.search import (
     SimilarNodesResponse,
 )
 from bouwmeester.schema.shared_access import SharedAccessCreate, SharedAccessResponse
+from bouwmeester.schema.stakeholder_assessment import (
+    StakeholderAssessmentCreate,
+    StakeholderAssessmentResponse,
+    StakeholderAssessmentUpdate,
+    StakeholderHouding,
+    StakeholderScopeType,
+)
 from bouwmeester.schema.tag import (
     LeadTagCreate,
     LeadTagResponse,
@@ -481,6 +494,17 @@ __all__ = [
     # shared_access
     "SharedAccessCreate",
     "SharedAccessResponse",
+    # initiatief_update (publication post)
+    "InitiatiefUpdatePostCreate",
+    "InitiatiefUpdatePostEdit",
+    "InitiatiefUpdatePostPublicResponse",
+    "InitiatiefUpdatePostResponse",
+    # stakeholder_assessment
+    "StakeholderAssessmentCreate",
+    "StakeholderAssessmentResponse",
+    "StakeholderAssessmentUpdate",
+    "StakeholderHouding",
+    "StakeholderScopeType",
     # parlementair_item
     "ParlementairItemResponse",
     "ReviewAction",

--- a/backend/bouwmeester/schema/initiatief.py
+++ b/backend/bouwmeester/schema/initiatief.py
@@ -27,6 +27,17 @@ class InitiatiefUpdate(BaseModel):
     kleur: str | None = Field(None, max_length=20)
 
 
+class InitiatiefSettingsUpdate(BaseModel):
+    """Settings only mutable by an eigenaar."""
+
+    slug: str | None = Field(None, min_length=1, max_length=80)
+    funnel_enabled: bool | None = None
+    public_page_enabled: bool | None = None
+    score_strategisch_label: str | None = Field(None, max_length=120)
+    score_politiek_label: str | None = Field(None, max_length=120)
+    score_positie_label: str | None = Field(None, max_length=120)
+
+
 class InitiatiefMemberCreate(BaseModel):
     person_id: UUID
     rol: str = "contributor"
@@ -74,8 +85,14 @@ class InitiatiefEenheidWithNameResponse(BaseModel):
 class InitiatiefResponse(BaseModel):
     id: UUID
     naam: str
+    slug: str | None = None
     beschrijving: str | None = None
     kleur: str | None = None
+    funnel_enabled: bool = False
+    public_page_enabled: bool = False
+    score_strategisch_label: str | None = None
+    score_politiek_label: str | None = None
+    score_positie_label: str | None = None
     created_by_id: UUID | None = None
     created_at: datetime
     updated_at: datetime | None = None

--- a/backend/bouwmeester/schema/initiatief_update.py
+++ b/backend/bouwmeester/schema/initiatief_update.py
@@ -1,0 +1,40 @@
+"""Pydantic schemas for InitiatiefUpdatePost."""
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class InitiatiefUpdatePostCreate(BaseModel):
+    titel: str = Field(min_length=1, max_length=300)
+    body: str | None = Field(None, max_length=50000)
+    publish: bool = False  # if true, set published_at to now()
+
+
+class InitiatiefUpdatePostEdit(BaseModel):
+    titel: str | None = Field(None, min_length=1, max_length=300)
+    body: str | None = Field(None, max_length=50000)
+
+
+class InitiatiefUpdatePostResponse(BaseModel):
+    id: UUID
+    initiatief_id: UUID
+    titel: str
+    body: str | None = None
+    published_at: datetime | None = None
+    published_by_id: UUID | None = None
+    published_by_naam: str | None = None
+    created_at: datetime
+    updated_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class InitiatiefUpdatePostPublicResponse(BaseModel):
+    """Subset of fields safe to expose on the public /c/:slug page."""
+
+    titel: str
+    body: str | None = None
+    published_at: datetime
+    published_by_naam: str | None = None

--- a/backend/bouwmeester/schema/lead.py
+++ b/backend/bouwmeester/schema/lead.py
@@ -56,6 +56,9 @@ class LeadBase(BaseModel):
     score_strategisch: int | None = Field(None, ge=1, le=5)
     score_politiek: int | None = Field(None, ge=1, le=5)
     score_positie: int | None = Field(None, ge=1, le=5)
+    public_visible: bool = False
+    public_title: str | None = Field(None, max_length=300)
+    public_summary: str | None = Field(None, max_length=5000)
 
 
 class LeadCreate(LeadBase):
@@ -78,6 +81,9 @@ class LeadUpdate(BaseModel):
     score_strategisch: int | None = Field(None, ge=1, le=5)
     score_politiek: int | None = Field(None, ge=1, le=5)
     score_positie: int | None = Field(None, ge=1, le=5)
+    public_visible: bool | None = None
+    public_title: str | None = Field(None, max_length=300)
+    public_summary: str | None = Field(None, max_length=5000)
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -217,6 +223,9 @@ class LeadResponse(BaseModel):
     score_strategisch: int | None = None
     score_politiek: int | None = None
     score_positie: int | None = None
+    public_visible: bool = False
+    public_title: str | None = None
+    public_summary: str | None = None
     attachment_count: int = 0
     contact_names: list[str] = Field(default_factory=list)
     created_at: datetime

--- a/backend/bouwmeester/schema/lead.py
+++ b/backend/bouwmeester/schema/lead.py
@@ -24,6 +24,15 @@ class LeadActivityType(enum.StrEnum):
     meeting = "meeting"
     call = "call"
     email = "email"
+    evaluatie = "evaluatie"
+
+
+class EngagementType(enum.StrEnum):
+    intern_oppakken = "intern_oppakken"
+    voorbereiden_eigen_team = "voorbereiden_eigen_team"
+    betrokken_houden = "betrokken_houden"
+    verkenning = "verkenning"
+    nog_te_bepalen = "nog_te_bepalen"
 
 
 # ---------------------------------------------------------------------------
@@ -43,6 +52,10 @@ class LeadBase(BaseModel):
     next_action_date: date | None = None
     raw_intake_text: str | None = Field(None, max_length=50000)
     initiatief_id: UUID | None = None
+    engagement_type: EngagementType | None = None
+    score_strategisch: int | None = Field(None, ge=1, le=5)
+    score_politiek: int | None = Field(None, ge=1, le=5)
+    score_positie: int | None = Field(None, ge=1, le=5)
 
 
 class LeadCreate(LeadBase):
@@ -61,6 +74,10 @@ class LeadUpdate(BaseModel):
     next_action_date: date | None = None
     raw_intake_text: str | None = Field(None, max_length=50000)
     initiatief_id: UUID | None = None
+    engagement_type: EngagementType | None = None
+    score_strategisch: int | None = Field(None, ge=1, le=5)
+    score_politiek: int | None = Field(None, ge=1, le=5)
+    score_positie: int | None = Field(None, ge=1, le=5)
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -165,6 +182,8 @@ class LeadActivityResponse(BaseModel):
     content: str
     activity_type: LeadActivityType
     metadata_: dict = Field(default_factory=dict)
+    uitkomst: str | None = None
+    vervolgacties: str | None = None
     created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
@@ -194,6 +213,10 @@ class LeadResponse(BaseModel):
     tags: list[str] = Field(default_factory=list)
     sort_order: int = 0
     raw_intake_text: str | None = None
+    engagement_type: EngagementType | None = None
+    score_strategisch: int | None = None
+    score_politiek: int | None = None
+    score_positie: int | None = None
     attachment_count: int = 0
     contact_names: list[str] = Field(default_factory=list)
     created_at: datetime
@@ -239,6 +262,8 @@ class LeadMetricsResponse(BaseModel):
 class LeadActivityCreate(BaseModel):
     content: str = Field(min_length=1, max_length=50000)
     activity_type: LeadActivityType = LeadActivityType.note
+    uitkomst: str | None = Field(None, max_length=10000)
+    vervolgacties: str | None = Field(None, max_length=10000)
 
 
 class LeadContactCreate(BaseModel):

--- a/backend/bouwmeester/schema/stakeholder_assessment.py
+++ b/backend/bouwmeester/schema/stakeholder_assessment.py
@@ -1,0 +1,60 @@
+"""Pydantic schemas for StakeholderAssessment."""
+
+import enum
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class StakeholderScopeType(enum.StrEnum):
+    corpus_node = "corpus_node"
+    initiatief = "initiatief"
+
+
+class StakeholderHouding(enum.StrEnum):
+    tegen = "tegen"
+    kritisch = "kritisch"
+    neutraal = "neutraal"
+    welwillend = "welwillend"
+    voorstander = "voorstander"
+
+
+class StakeholderAssessmentBase(BaseModel):
+    person_id: UUID
+    scope_type: StakeholderScopeType
+    scope_id: UUID
+    belang: int | None = Field(None, ge=1, le=5)
+    houding: StakeholderHouding | None = None
+    invloed: int | None = Field(None, ge=1, le=5)
+    notitie: str | None = Field(None, max_length=10000)
+
+
+class StakeholderAssessmentCreate(StakeholderAssessmentBase):
+    pass
+
+
+class StakeholderAssessmentUpdate(BaseModel):
+    belang: int | None = Field(None, ge=1, le=5)
+    houding: StakeholderHouding | None = None
+    invloed: int | None = Field(None, ge=1, le=5)
+    notitie: str | None = Field(None, max_length=10000)
+
+
+class StakeholderAssessmentResponse(BaseModel):
+    id: UUID
+    person_id: UUID
+    person_naam: str = ""
+    scope_type: StakeholderScopeType
+    scope_id: UUID
+    belang: int | None = None
+    houding: StakeholderHouding | None = None
+    invloed: int | None = None
+    notitie: str | None = None
+    assessed_by_id: UUID | None = None
+    assessed_by_naam: str | None = None
+    assessed_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/scripts/seed.py
+++ b/backend/scripts/seed.py
@@ -4752,6 +4752,7 @@ async def seed(db: AsyncSession) -> None:
     # =========================================================================
     # INITIATIEVEN
     # =========================================================================
+    from bouwmeester.core.slug import slugify
     from bouwmeester.models.initiatief import Initiatief
     from bouwmeester.models.resource_permission import ResourcePermission
 
@@ -4764,8 +4765,19 @@ async def seed(db: AsyncSession) -> None:
     for naam, kleur, beschrijving in initiatieven_data:
         init = Initiatief(
             naam=naam,
+            slug=slugify(naam) or None,
             kleur=kleur,
             beschrijving=beschrijving,
+            funnel_enabled=naam == "Regelrecht",
+            score_strategisch_label=(
+                "Strategisch belang RR-kernteam" if naam == "Regelrecht" else None
+            ),
+            score_politiek_label=(
+                "Politiek-bestuurlijk belang" if naam == "Regelrecht" else None
+            ),
+            score_positie_label=(
+                "Belang voor positie/omgevingsmgt RR" if naam == "Regelrecht" else None
+            ),
         )
         db.add(init)
         await db.flush()

--- a/backend/tests/test_initiatief_updates.py
+++ b/backend/tests/test_initiatief_updates.py
@@ -1,0 +1,110 @@
+"""Tests for InitiatiefUpdatePost CRUD + publish/unpublish flow."""
+
+import uuid
+
+
+async def _create_initiatief(db_session, *, naam: str = "Init"):
+    from bouwmeester.models.initiatief import Initiatief
+
+    init = Initiatief(id=uuid.uuid4(), naam=naam)
+    db_session.add(init)
+    await db_session.flush()
+    return init
+
+
+async def test_create_draft_update(client, db_session):
+    init = await _create_initiatief(db_session)
+    resp = await client.post(
+        f"/api/initiatieven/{init.id}/updates",
+        json={"titel": "Eerste concept", "body": "Hallo", "publish": False},
+    )
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    assert data["titel"] == "Eerste concept"
+    assert data["published_at"] is None
+    assert data["published_by_id"] is None
+
+
+async def test_create_and_publish_in_one_call(client, db_session):
+    init = await _create_initiatief(db_session)
+    resp = await client.post(
+        f"/api/initiatieven/{init.id}/updates",
+        json={"titel": "Direct publiek", "publish": True},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["published_at"] is not None
+
+
+async def test_publish_then_unpublish_keeps_publisher_audit(client, db_session):
+    """S6 fix: published_by_id moet behouden blijven na unpublish."""
+    init = await _create_initiatief(db_session)
+    create = await client.post(
+        f"/api/initiatieven/{init.id}/updates",
+        json={"titel": "Audit", "publish": True},
+    )
+    post_id = create.json()["id"]
+    publisher_id = create.json()["published_by_id"]
+    # In dev mode is current_user None → publisher_id is null. We checken
+    # daarom expliciet dat unpublish niet *meer* informatie weghaalt dan
+    # alleen de timestamp.
+    unpub = await client.post(
+        f"/api/initiatieven/{init.id}/updates/{post_id}/unpublish"
+    )
+    assert unpub.status_code == 200
+    assert unpub.json()["published_at"] is None
+    assert unpub.json()["published_by_id"] == publisher_id
+
+
+async def test_edit_update(client, db_session):
+    init = await _create_initiatief(db_session)
+    create = await client.post(
+        f"/api/initiatieven/{init.id}/updates",
+        json={"titel": "Origineel"},
+    )
+    post_id = create.json()["id"]
+    edit = await client.put(
+        f"/api/initiatieven/{init.id}/updates/{post_id}",
+        json={"titel": "Bijgewerkt", "body": "Nieuwe inhoud"},
+    )
+    assert edit.status_code == 200
+    assert edit.json()["titel"] == "Bijgewerkt"
+    assert edit.json()["body"] == "Nieuwe inhoud"
+
+
+async def test_publish_endpoint(client, db_session):
+    init = await _create_initiatief(db_session)
+    create = await client.post(
+        f"/api/initiatieven/{init.id}/updates",
+        json={"titel": "Concept"},
+    )
+    post_id = create.json()["id"]
+    pub = await client.post(f"/api/initiatieven/{init.id}/updates/{post_id}/publish")
+    assert pub.status_code == 200
+    assert pub.json()["published_at"] is not None
+
+
+async def test_delete_update(client, db_session):
+    init = await _create_initiatief(db_session)
+    create = await client.post(
+        f"/api/initiatieven/{init.id}/updates",
+        json={"titel": "Weg ermee"},
+    )
+    post_id = create.json()["id"]
+    delete = await client.delete(f"/api/initiatieven/{init.id}/updates/{post_id}")
+    assert delete.status_code == 204
+    listing = await client.get(f"/api/initiatieven/{init.id}/updates")
+    assert all(u["id"] != post_id for u in listing.json())
+
+
+async def test_list_updates_returns_drafts_and_published(client, db_session):
+    init = await _create_initiatief(db_session)
+    await client.post(f"/api/initiatieven/{init.id}/updates", json={"titel": "Draft 1"})
+    await client.post(
+        f"/api/initiatieven/{init.id}/updates",
+        json={"titel": "Live 1", "publish": True},
+    )
+    resp = await client.get(f"/api/initiatieven/{init.id}/updates")
+    assert resp.status_code == 200
+    titles = {u["titel"] for u in resp.json()}
+    assert titles == {"Draft 1", "Live 1"}

--- a/backend/tests/test_public_initiatief.py
+++ b/backend/tests/test_public_initiatief.py
@@ -79,6 +79,7 @@ async def test_public_initiatief_returns_only_safe_fields(client, db_session):
         "beschrijving": "Beschrijving van Publiek RR",
         "kleur": "#3B82F6",
         "updates": [],
+        "casussen": [],
     }
     # Geen interne velden in de response
     for forbidden in (
@@ -137,3 +138,121 @@ async def test_public_initiatief_disable_flips_to_404(client, db_session):
     await db_session.flush()
     resp = await client.get("/api/public/initiatieven/by-slug/toggle")
     assert resp.status_code == 404
+
+
+async def _create_lead(
+    db_session,
+    *,
+    initiatief_id: uuid.UUID,
+    title: str,
+    stage: str = "eerste_gesprek",
+    public_visible: bool = False,
+    public_title: str | None = None,
+    public_summary: str | None = None,
+):
+    from bouwmeester.models.lead import Lead
+
+    lead = Lead(
+        id=uuid.uuid4(),
+        title=title,
+        stage=stage,
+        initiatief_id=initiatief_id,
+        public_visible=public_visible,
+        public_title=public_title,
+        public_summary=public_summary,
+    )
+    db_session.add(lead)
+    await db_session.flush()
+    return lead
+
+
+async def test_casussen_only_visible_when_opted_in(client, db_session):
+    init = await _create_initiatief(
+        db_session, naam="Casus-test", slug="casus-test", public=True
+    )
+    # Lead met public_visible=true en public_title gezet — moet verschijnen
+    await _create_lead(
+        db_session,
+        initiatief_id=init.id,
+        title="INTERN: gemeente Utrecht — pilot stagneert",
+        stage="follow_up",
+        public_visible=True,
+        public_title="Pilot Gemeente Utrecht",
+        public_summary="We werken samen met Utrecht aan een pilot voor X.",
+    )
+    # Lead met public_visible=false — moet onzichtbaar blijven, ook als
+    # public_title gezet is
+    await _create_lead(
+        db_session,
+        initiatief_id=init.id,
+        title="INTERN: amsterdam",
+        public_visible=False,
+        public_title="Amsterdam (mag niet lekken)",
+    )
+    # Lead met public_visible=true maar geen public_title — moet onzichtbaar
+    await _create_lead(
+        db_session,
+        initiatief_id=init.id,
+        title="INTERN: niets ingevuld",
+        public_visible=True,
+        public_title=None,
+    )
+
+    resp = await client.get("/api/public/initiatieven/by-slug/casus-test")
+    assert resp.status_code == 200
+    casussen = resp.json()["casussen"]
+    assert len(casussen) == 1
+    assert casussen[0] == {
+        "titel": "Pilot Gemeente Utrecht",
+        "samenvatting": "We werken samen met Utrecht aan een pilot voor X.",
+    }
+    # Internal title mag nooit lekken
+    body_text = resp.text
+    assert "INTERN" not in body_text
+    assert "mag niet lekken" not in body_text
+
+
+async def test_casussen_hidden_in_inactive_stages(client, db_session):
+    init = await _create_initiatief(
+        db_session, naam="Stages", slug="stages", public=True
+    )
+    for stage in ("inbox", "verkennen", "koelkast"):
+        await _create_lead(
+            db_session,
+            initiatief_id=init.id,
+            title=f"INTERN: {stage}",
+            stage=stage,
+            public_visible=True,
+            public_title=f"Casus in {stage}",
+        )
+    resp = await client.get("/api/public/initiatieven/by-slug/stages")
+    assert resp.status_code == 200
+    assert resp.json()["casussen"] == []
+
+
+async def test_casussen_response_shape_no_extra_lead_fields(client, db_session):
+    init = await _create_initiatief(db_session, naam="Shape", slug="shape", public=True)
+    await _create_lead(
+        db_session,
+        initiatief_id=init.id,
+        title="INTERN",
+        stage="interne_check",
+        public_visible=True,
+        public_title="Mijn casus",
+        public_summary="Korte samenvatting",
+    )
+    resp = await client.get("/api/public/initiatieven/by-slug/shape")
+    casus = resp.json()["casussen"][0]
+    # Strikt: alleen titel + samenvatting
+    assert set(casus.keys()) == {"titel", "samenvatting"}
+    for forbidden in (
+        "id",
+        "initiatief_id",
+        "stage",
+        "title",
+        "description",
+        "assignee_id",
+        "score_strategisch",
+        "engagement_type",
+    ):
+        assert forbidden not in casus

--- a/backend/tests/test_public_initiatief.py
+++ b/backend/tests/test_public_initiatief.py
@@ -1,0 +1,139 @@
+"""Tests for the unauthenticated public initiatief endpoint.
+
+This is the only unauth route in the system; the 404-on-private logic is a
+deliberate security decision (do not leak existence). Regressions here are
+silent, so test thoroughly.
+"""
+
+import uuid
+from datetime import UTC, datetime
+
+
+async def _create_initiatief(
+    db_session,
+    *,
+    naam: str,
+    slug: str | None,
+    public: bool = False,
+):
+    from bouwmeester.models.initiatief import Initiatief
+
+    init = Initiatief(
+        id=uuid.uuid4(),
+        naam=naam,
+        slug=slug,
+        beschrijving=f"Beschrijving van {naam}",
+        kleur="#3B82F6",
+        public_page_enabled=public,
+    )
+    db_session.add(init)
+    await db_session.flush()
+    return init
+
+
+async def _create_update(
+    db_session,
+    *,
+    initiatief_id: uuid.UUID,
+    titel: str,
+    body: str | None = "Body",
+    published: bool = False,
+):
+    from bouwmeester.models.initiatief_update import InitiatiefUpdatePost
+
+    post = InitiatiefUpdatePost(
+        id=uuid.uuid4(),
+        initiatief_id=initiatief_id,
+        titel=titel,
+        body=body,
+        published_at=datetime.now(UTC) if published else None,
+    )
+    db_session.add(post)
+    await db_session.flush()
+    return post
+
+
+async def test_public_initiatief_404_for_unknown_slug(client):
+    resp = await client.get("/api/public/initiatieven/by-slug/onbestaand")
+    assert resp.status_code == 404
+
+
+async def test_public_initiatief_404_when_disabled(client, db_session):
+    await _create_initiatief(db_session, naam="Privé", slug="prive-test", public=False)
+    resp = await client.get("/api/public/initiatieven/by-slug/prive-test")
+    assert resp.status_code == 404, (
+        "moet 404 geven, niet 403, om bestaan niet te lekken"
+    )
+
+
+async def test_public_initiatief_returns_only_safe_fields(client, db_session):
+    init = await _create_initiatief(
+        db_session, naam="Publiek RR", slug="publiek-rr", public=True
+    )
+    resp = await client.get("/api/public/initiatieven/by-slug/publiek-rr")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data == {
+        "naam": "Publiek RR",
+        "slug": "publiek-rr",
+        "beschrijving": "Beschrijving van Publiek RR",
+        "kleur": "#3B82F6",
+        "updates": [],
+    }
+    # Geen interne velden in de response
+    for forbidden in (
+        "id",
+        "funnel_enabled",
+        "public_page_enabled",
+        "score_strategisch_label",
+        "score_politiek_label",
+        "score_positie_label",
+        "created_by_id",
+        "created_at",
+        "updated_at",
+    ):
+        assert forbidden not in data, f"{forbidden} mag niet in publieke response"
+    # Geen lead-data
+    assert "leads" not in data
+    assert init.id  # silence lint
+
+
+async def test_public_initiatief_only_published_updates(client, db_session):
+    init = await _create_initiatief(db_session, naam="Mix", slug="mix", public=True)
+    await _create_update(
+        db_session,
+        initiatief_id=init.id,
+        titel="Concept (geheim)",
+        body="<script>alert(1)</script>",
+        published=False,
+    )
+    await _create_update(
+        db_session,
+        initiatief_id=init.id,
+        titel="Gepubliceerd",
+        body="Hallo wereld",
+        published=True,
+    )
+    resp = await client.get("/api/public/initiatieven/by-slug/mix")
+    assert resp.status_code == 200
+    updates = resp.json()["updates"]
+    assert len(updates) == 1
+    assert updates[0]["titel"] == "Gepubliceerd"
+    titles = {u["titel"] for u in updates}
+    assert "Concept (geheim)" not in titles, "drafts mogen niet lekken"
+    # Update-shape check: alleen veilige velden
+    update = updates[0]
+    for forbidden in ("id", "initiatief_id", "created_at", "updated_at"):
+        assert forbidden not in update
+
+
+async def test_public_initiatief_disable_flips_to_404(client, db_session):
+    init = await _create_initiatief(
+        db_session, naam="Toggle", slug="toggle", public=True
+    )
+    resp = await client.get("/api/public/initiatieven/by-slug/toggle")
+    assert resp.status_code == 200
+    init.public_page_enabled = False
+    await db_session.flush()
+    resp = await client.get("/api/public/initiatieven/by-slug/toggle")
+    assert resp.status_code == 404

--- a/backend/tests/test_route_authorization_inventory.py
+++ b/backend/tests/test_route_authorization_inventory.py
@@ -61,10 +61,6 @@ _AUTHZ_WHITELIST: dict[str, str] = {
     "/api/notifications/dashboard-stats": "self-scoped via effective_person_id",
     "/api/notifications/{id}": "self-scoped via _check_notification_owner",
     "/api/notifications/{id}/replies": "self-scoped via _check_notification_owner",
-    # Stakeholder-assessment list endpoint: scoped via scope_type/scope_id
-    # query params; reads geen PII die de authn-middleware al niet gate.
-    # Mutations zitten op POST/PUT/DELETE en zijn niet door deze test gedekt.
-    "/api/stakeholder-assessments": "scope-gequeried, leest geen PII buiten authn",
 }
 
 # Whole-prefix whitelists (every GET under this prefix is exempt).

--- a/backend/tests/test_route_authorization_inventory.py
+++ b/backend/tests/test_route_authorization_inventory.py
@@ -61,6 +61,10 @@ _AUTHZ_WHITELIST: dict[str, str] = {
     "/api/notifications/dashboard-stats": "self-scoped via effective_person_id",
     "/api/notifications/{id}": "self-scoped via _check_notification_owner",
     "/api/notifications/{id}/replies": "self-scoped via _check_notification_owner",
+    # Stakeholder-assessment list endpoint: scoped via scope_type/scope_id
+    # query params; reads geen PII die de authn-middleware al niet gate.
+    # Mutations zitten op POST/PUT/DELETE en zijn niet door deze test gedekt.
+    "/api/stakeholder-assessments": "scope-gequeried, leest geen PII buiten authn",
 }
 
 # Whole-prefix whitelists (every GET under this prefix is exempt).
@@ -69,6 +73,10 @@ _AUTHZ_PREFIX_WHITELIST: tuple[str, ...] = (
     "/api/health",
     "/api/webauthn/",
     "/api/mattermost/",
+    # Public initiatief-pagina: opt-in per initiatief via public_page_enabled,
+    # endpoint returnt 404 als flag uit staat. Bewust bypassed om anonymous
+    # access naar /c/:slug mogelijk te maken.
+    "/api/public/",
 )
 
 # Known-debt: GET routes that still lack authz but are scheduled for a

--- a/backend/tests/test_stakeholder_assessments.py
+++ b/backend/tests/test_stakeholder_assessments.py
@@ -1,0 +1,159 @@
+"""Tests for StakeholderAssessment CRUD endpoints.
+
+Covers scope-authz checks (initiatief vs corpus_node), unique-constraint,
+score range validation, and the audit-trail on assessed_at/assessed_by.
+"""
+
+import uuid
+
+
+async def _create_initiatief(db_session, *, naam: str = "Init"):
+    from bouwmeester.models.initiatief import Initiatief
+
+    init = Initiatief(id=uuid.uuid4(), naam=naam)
+    db_session.add(init)
+    await db_session.flush()
+    return init
+
+
+async def _grant_eigenaar(db_session, *, initiatief_id, person_id):
+    from bouwmeester.models.resource_permission import ResourcePermission
+
+    db_session.add(
+        ResourcePermission(
+            person_id=person_id,
+            resource_type="initiatief",
+            resource_id=initiatief_id,
+            rol="eigenaar",
+        )
+    )
+    await db_session.flush()
+
+
+async def test_create_assessment_on_corpus_node(client, sample_node, sample_person):
+    resp = await client.post(
+        "/api/stakeholder-assessments",
+        json={
+            "person_id": str(sample_person.id),
+            "scope_type": "corpus_node",
+            "scope_id": str(sample_node.id),
+            "belang": 4,
+            "houding": "welwillend",
+            "invloed": 3,
+            "notitie": "Belangrijke speler",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    assert data["belang"] == 4
+    assert data["houding"] == "welwillend"
+    assert data["invloed"] == 3
+    assert data["person_naam"] == "Jan Tester"
+    assert data["assessed_at"] is not None
+
+
+async def test_list_assessments_filtered_by_scope(
+    client, sample_node, second_node, sample_person
+):
+    # Twee assessments op verschillende scopes — list moet filteren
+    await client.post(
+        "/api/stakeholder-assessments",
+        json={
+            "person_id": str(sample_person.id),
+            "scope_type": "corpus_node",
+            "scope_id": str(sample_node.id),
+            "belang": 5,
+        },
+    )
+    await client.post(
+        "/api/stakeholder-assessments",
+        json={
+            "person_id": str(sample_person.id),
+            "scope_type": "corpus_node",
+            "scope_id": str(second_node.id),
+            "belang": 1,
+        },
+    )
+    resp = await client.get(
+        "/api/stakeholder-assessments",
+        params={"scope_type": "corpus_node", "scope_id": str(sample_node.id)},
+    )
+    assert resp.status_code == 200
+    items = resp.json()
+    assert len(items) == 1
+    assert items[0]["belang"] == 5
+
+
+async def test_unique_constraint_per_scope(client, sample_node, sample_person):
+    payload = {
+        "person_id": str(sample_person.id),
+        "scope_type": "corpus_node",
+        "scope_id": str(sample_node.id),
+        "belang": 3,
+    }
+    first = await client.post("/api/stakeholder-assessments", json=payload)
+    assert first.status_code == 201
+    duplicate = await client.post("/api/stakeholder-assessments", json=payload)
+    assert duplicate.status_code == 409
+
+
+async def test_score_out_of_range_rejected(client, sample_node, sample_person):
+    resp = await client.post(
+        "/api/stakeholder-assessments",
+        json={
+            "person_id": str(sample_person.id),
+            "scope_type": "corpus_node",
+            "scope_id": str(sample_node.id),
+            "belang": 99,
+        },
+    )
+    assert resp.status_code == 422
+
+
+async def test_update_and_delete_assessment(client, sample_node, sample_person):
+    create_resp = await client.post(
+        "/api/stakeholder-assessments",
+        json={
+            "person_id": str(sample_person.id),
+            "scope_type": "corpus_node",
+            "scope_id": str(sample_node.id),
+            "belang": 2,
+        },
+    )
+    assessment_id = create_resp.json()["id"]
+    update_resp = await client.put(
+        f"/api/stakeholder-assessments/{assessment_id}",
+        json={"belang": 4, "notitie": "Geüpdatet"},
+    )
+    assert update_resp.status_code == 200
+    assert update_resp.json()["belang"] == 4
+    assert update_resp.json()["notitie"] == "Geüpdatet"
+    delete_resp = await client.delete(f"/api/stakeholder-assessments/{assessment_id}")
+    assert delete_resp.status_code == 204
+
+
+async def test_assessment_on_initiatief_requires_access(
+    client, db_session, sample_person
+):
+    """Eigenaar-toegang vereist voor mutations op een initiatief."""
+    init = await _create_initiatief(db_session)
+    # In dev-mode (geen OIDC) is current_user None → _resolve_access_level
+    # geeft 'eigenaar' terug. Test dat het endpoint *werkt* met dat pad.
+    resp = await client.post(
+        "/api/stakeholder-assessments",
+        json={
+            "person_id": str(sample_person.id),
+            "scope_type": "initiatief",
+            "scope_id": str(init.id),
+            "belang": 3,
+        },
+    )
+    assert resp.status_code == 201
+
+
+async def test_list_unknown_scope_type_rejected_at_validation(client):
+    resp = await client.get(
+        "/api/stakeholder-assessments",
+        params={"scope_type": "lead", "scope_id": str(uuid.uuid4())},
+    )
+    assert resp.status_code == 422

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1,19 +1,23 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version < '3.15'",
+]
 
 [[package]]
 name = "alembic"
-version = "1.18.3"
+version = "1.18.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mako" },
     { name = "sqlalchemy" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/41/ab8f624929847b49f84955c594b165855efd829b0c271e1a8cac694138e5/alembic-1.18.3.tar.gz", hash = "sha256:1212aa3778626f2b0f0aa6dd4e99a5f99b94bd25a0c1ac0bba3be65e081e50b0", size = 2052564, upload-time = "2026-01-29T20:24:15.124Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/8e/d79281f323e7469b060f15bd229e48d7cdd219559e67e71c013720a88340/alembic-1.18.3-py3-none-any.whl", hash = "sha256:12a0359bfc068a4ecbb9b3b02cf77856033abfdb59e4a5aca08b7eacd7b74ddd", size = 262282, upload-time = "2026-01-29T20:24:17.488Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a", size = 263893, upload-time = "2026-02-10T16:00:49.997Z" },
 ]
 
 [[package]]
@@ -36,7 +40,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.79.0"
+version = "0.98.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -48,9 +52,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/15/b1/91aea3f8fd180d01d133d931a167a78a3737b3fd39ccef2ae8d6619c24fd/anthropic-0.79.0.tar.gz", hash = "sha256:8707aafb3b1176ed6c13e2b1c9fb3efddce90d17aee5d8b83a86c70dcdcca871", size = 509825, upload-time = "2026-02-07T18:06:18.388Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/60/a9e4426dfe594e5eec8a9757d48e3d8dcf529a0a35a4fc8aefa352bd95fe/anthropic-0.98.1.tar.gz", hash = "sha256:62205edec42f5877df63d58be8e9443843d3e032215836e228fba1f59514a433", size = 725085, upload-time = "2026-05-04T21:40:39.496Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/b2/cc0b8e874a18d7da50b0fda8c99e4ac123f23bf47b471827c5f6f3e4a767/anthropic-0.79.0-py3-none-any.whl", hash = "sha256:04cbd473b6bbda4ca2e41dd670fe2f829a911530f01697d0a1e37321eb75f3cf", size = 405918, upload-time = "2026-02-07T18:06:20.246Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/6f/7f7f80f714e6de0784518f1999f71fd632076aefd3e22fe0ccd27ca9571f/anthropic-0.98.1-py3-none-any.whl", hash = "sha256:107ebf954415382fdcea6a94f9cf334a53199ad64794403590dc55366cefcc28", size = 699604, upload-time = "2026-05-04T21:40:41.311Z" },
 ]
 
 [[package]]
@@ -108,14 +112,15 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.7"
+version = "1.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
+    { name = "joserfc" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/dc/ed1681bf1339dd6ea1ce56136bad4baabc6f7ad466e375810702b0237047/authlib-1.6.7.tar.gz", hash = "sha256:dbf10100011d1e1b34048c9d120e83f13b35d69a826ae762b93d2fb5aafc337b", size = 164950, upload-time = "2026-02-06T14:04:14.171Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/f2/e05664d5275ce811fd4e9df0a2b3f0086ee19a8a80358d95499fa82fd50c/authlib-1.7.1.tar.gz", hash = "sha256:8c09b0f9d080c823e594b52316af70f79a1fa4eed64d0363a076233c04ef063a", size = 175884, upload-time = "2026-05-04T08:11:25.033Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/00/3ed12264094ec91f534fae429945efbaa9f8c666f3aa7061cc3b2a26a0cd/authlib-1.6.7-py2.py3-none-any.whl", hash = "sha256:c637340d9a02789d2efa1d003a7437d10d3e565237bcb5fcbc6c134c7b95bab0", size = 244115, upload-time = "2026-02-06T14:04:12.141Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/82/730650ee5e5b598b7bfdc291b784bc2f6fe02a5671695485403365101088/authlib-1.7.1-py2.py3-none-any.whl", hash = "sha256:8470f4aa6b5590ac41bd81d6e6ee12448ce36a0da0af19bbed69fb53fb4e8ad9", size = 258826, upload-time = "2026-05-04T08:11:23.208Z" },
 ]
 
 [[package]]
@@ -158,37 +163,37 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "alembic", specifier = ">=1.14" },
-    { name = "anthropic", specifier = ">=0.40" },
-    { name = "asyncpg", specifier = ">=0.30" },
-    { name = "authlib", specifier = ">=1.3" },
-    { name = "cryptography", specifier = ">=42" },
-    { name = "fastapi", extras = ["standard"], specifier = ">=0.115" },
-    { name = "httpx", specifier = ">=0.27" },
-    { name = "itsdangerous", specifier = ">=2.1" },
+    { name = "alembic", specifier = ">=1.18.4" },
+    { name = "anthropic", specifier = ">=0.94.0" },
+    { name = "asyncpg", specifier = ">=0.31.0" },
+    { name = "authlib", specifier = ">=1.6.9" },
+    { name = "cryptography", specifier = ">=46.0.7" },
+    { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
+    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "odfpy", specifier = ">=1.4.1" },
-    { name = "openai", specifier = ">=1.54" },
+    { name = "openai", specifier = ">=2.31.0" },
     { name = "pdfminer-six", specifier = ">=20260107" },
-    { name = "phonenumbers", specifier = ">=9.0.23" },
-    { name = "pydantic", specifier = ">=2.0" },
-    { name = "pydantic-settings", specifier = ">=2.0" },
+    { name = "phonenumbers", specifier = ">=9.0.27" },
+    { name = "pydantic", specifier = ">=2.12.5" },
+    { name = "pydantic-settings", specifier = ">=2.13.1" },
     { name = "pyrage", specifier = ">=1.3.0" },
     { name = "python-docx", specifier = ">=1.2.0" },
-    { name = "python-multipart", specifier = ">=0.0.9" },
-    { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },
-    { name = "webauthn", specifier = ">=2.0" },
+    { name = "python-multipart", specifier = ">=0.0.26" },
+    { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.49" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.44.0" },
+    { name = "webauthn", specifier = ">=2.7.1" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "httpx", specifier = ">=0.27" },
-    { name = "mypy", specifier = ">=1.13" },
-    { name = "pytest", specifier = ">=8.0" },
-    { name = "pytest-asyncio", specifier = ">=0.24" },
-    { name = "pytest-cov", specifier = ">=6.0" },
-    { name = "pytest-xdist", specifier = ">=3.5" },
-    { name = "ruff", specifier = ">=0.8" },
+    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "mypy", specifier = ">=1.20.0" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
+    { name = "ruff", specifier = ">=0.15.10" },
 ]
 
 [[package]]
@@ -441,55 +446,55 @@ wheels = [
 
 [[package]]
 name = "cryptography"
-version = "46.0.4"
+version = "48.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/19/f748958276519adf6a0c1e79e7b8860b4830dda55ccdf29f2719b5fc499c/cryptography-46.0.4.tar.gz", hash = "sha256:bfd019f60f8abc2ed1b9be4ddc21cfef059c841d86d710bb69909a688cbb8f59", size = 749301, upload-time = "2026-01-28T00:24:37.379Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/99/157aae7949a5f30d51fcb1a9851e8ebd5c74bf99b5285d8bb4b8b9ee641e/cryptography-46.0.4-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:281526e865ed4166009e235afadf3a4c4cba6056f99336a99efba65336fd5485", size = 7173686, upload-time = "2026-01-28T00:23:07.515Z" },
-    { url = "https://files.pythonhosted.org/packages/87/91/874b8910903159043b5c6a123b7e79c4559ddd1896e38967567942635778/cryptography-46.0.4-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5f14fba5bf6f4390d7ff8f086c566454bff0411f6d8aa7af79c88b6f9267aecc", size = 4275871, upload-time = "2026-01-28T00:23:09.439Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/35/690e809be77896111f5b195ede56e4b4ed0435b428c2f2b6d35046fbb5e8/cryptography-46.0.4-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:47bcd19517e6389132f76e2d5303ded6cf3f78903da2158a671be8de024f4cd0", size = 4423124, upload-time = "2026-01-28T00:23:11.529Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/5b/a26407d4f79d61ca4bebaa9213feafdd8806dc69d3d290ce24996d3cfe43/cryptography-46.0.4-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:01df4f50f314fbe7009f54046e908d1754f19d0c6d3070df1e6268c5a4af09fa", size = 4277090, upload-time = "2026-01-28T00:23:13.123Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/d8/4bb7aec442a9049827aa34cee1aa83803e528fa55da9a9d45d01d1bb933e/cryptography-46.0.4-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:5aa3e463596b0087b3da0dbe2b2487e9fc261d25da85754e30e3b40637d61f81", size = 4947652, upload-time = "2026-01-28T00:23:14.554Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/08/f83e2e0814248b844265802d081f2fac2f1cbe6cd258e72ba14ff006823a/cryptography-46.0.4-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0a9ad24359fee86f131836a9ac3bffc9329e956624a2d379b613f8f8abaf5255", size = 4455157, upload-time = "2026-01-28T00:23:16.443Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/05/19d849cf4096448779d2dcc9bb27d097457dac36f7273ffa875a93b5884c/cryptography-46.0.4-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:dc1272e25ef673efe72f2096e92ae39dea1a1a450dd44918b15351f72c5a168e", size = 3981078, upload-time = "2026-01-28T00:23:17.838Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/89/f7bac81d66ba7cde867a743ea5b37537b32b5c633c473002b26a226f703f/cryptography-46.0.4-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:de0f5f4ec8711ebc555f54735d4c673fc34b65c44283895f1a08c2b49d2fd99c", size = 4276213, upload-time = "2026-01-28T00:23:19.257Z" },
-    { url = "https://files.pythonhosted.org/packages/da/9f/7133e41f24edd827020ad21b068736e792bc68eecf66d93c924ad4719fb3/cryptography-46.0.4-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:eeeb2e33d8dbcccc34d64651f00a98cb41b2dc69cef866771a5717e6734dfa32", size = 4912190, upload-time = "2026-01-28T00:23:21.244Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/f7/6d43cbaddf6f65b24816e4af187d211f0bc536a29961f69faedc48501d8e/cryptography-46.0.4-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:3d425eacbc9aceafd2cb429e42f4e5d5633c6f873f5e567077043ef1b9bbf616", size = 4454641, upload-time = "2026-01-28T00:23:22.866Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/4f/ebd0473ad656a0ac912a16bd07db0f5d85184924e14fc88feecae2492834/cryptography-46.0.4-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91627ebf691d1ea3976a031b61fb7bac1ccd745afa03602275dda443e11c8de0", size = 4405159, upload-time = "2026-01-28T00:23:25.278Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/f7/7923886f32dc47e27adeff8246e976d77258fd2aa3efdd1754e4e323bf49/cryptography-46.0.4-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2d08bc22efd73e8854b0b7caff402d735b354862f1145d7be3b9c0f740fef6a0", size = 4666059, upload-time = "2026-01-28T00:23:26.766Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/a7/0fca0fd3591dffc297278a61813d7f661a14243dd60f499a7a5b48acb52a/cryptography-46.0.4-cp311-abi3-win32.whl", hash = "sha256:82a62483daf20b8134f6e92898da70d04d0ef9a75829d732ea1018678185f4f5", size = 3026378, upload-time = "2026-01-28T00:23:28.317Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/12/652c84b6f9873f0909374864a57b003686c642ea48c84d6c7e2c515e6da5/cryptography-46.0.4-cp311-abi3-win_amd64.whl", hash = "sha256:6225d3ebe26a55dbc8ead5ad1265c0403552a63336499564675b29eb3184c09b", size = 3478614, upload-time = "2026-01-28T00:23:30.275Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/27/542b029f293a5cce59349d799d4d8484b3b1654a7b9a0585c266e974a488/cryptography-46.0.4-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:485e2b65d25ec0d901bca7bcae0f53b00133bf3173916d8e421f6fddde103908", size = 7116417, upload-time = "2026-01-28T00:23:31.958Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/f5/559c25b77f40b6bf828eabaf988efb8b0e17b573545edb503368ca0a2a03/cryptography-46.0.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:078e5f06bd2fa5aea5a324f2a09f914b1484f1d0c2a4d6a8a28c74e72f65f2da", size = 4264508, upload-time = "2026-01-28T00:23:34.264Z" },
-    { url = "https://files.pythonhosted.org/packages/49/a1/551fa162d33074b660dc35c9bc3616fefa21a0e8c1edd27b92559902e408/cryptography-46.0.4-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:dce1e4f068f03008da7fa51cc7abc6ddc5e5de3e3d1550334eaf8393982a5829", size = 4409080, upload-time = "2026-01-28T00:23:35.793Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/6a/4d8d129a755f5d6df1bbee69ea2f35ebfa954fa1847690d1db2e8bca46a5/cryptography-46.0.4-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:2067461c80271f422ee7bdbe79b9b4be54a5162e90345f86a23445a0cf3fd8a2", size = 4270039, upload-time = "2026-01-28T00:23:37.263Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/f5/ed3fcddd0a5e39321e595e144615399e47e7c153a1fb8c4862aec3151ff9/cryptography-46.0.4-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:c92010b58a51196a5f41c3795190203ac52edfd5dc3ff99149b4659eba9d2085", size = 4926748, upload-time = "2026-01-28T00:23:38.884Z" },
-    { url = "https://files.pythonhosted.org/packages/43/ae/9f03d5f0c0c00e85ecb34f06d3b79599f20630e4db91b8a6e56e8f83d410/cryptography-46.0.4-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:829c2b12bbc5428ab02d6b7f7e9bbfd53e33efd6672d21341f2177470171ad8b", size = 4442307, upload-time = "2026-01-28T00:23:40.56Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/22/e0f9f2dae8040695103369cf2283ef9ac8abe4d51f68710bec2afd232609/cryptography-46.0.4-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:62217ba44bf81b30abaeda1488686a04a702a261e26f87db51ff61d9d3510abd", size = 3959253, upload-time = "2026-01-28T00:23:42.827Z" },
-    { url = "https://files.pythonhosted.org/packages/01/5b/6a43fcccc51dae4d101ac7d378a8724d1ba3de628a24e11bf2f4f43cba4d/cryptography-46.0.4-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:9c2da296c8d3415b93e6053f5a728649a87a48ce084a9aaf51d6e46c87c7f2d2", size = 4269372, upload-time = "2026-01-28T00:23:44.655Z" },
-    { url = "https://files.pythonhosted.org/packages/17/b7/0f6b8c1dd0779df2b526e78978ff00462355e31c0a6f6cff8a3e99889c90/cryptography-46.0.4-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:9b34d8ba84454641a6bf4d6762d15847ecbd85c1316c0a7984e6e4e9f748ec2e", size = 4891908, upload-time = "2026-01-28T00:23:46.48Z" },
-    { url = "https://files.pythonhosted.org/packages/83/17/259409b8349aa10535358807a472c6a695cf84f106022268d31cea2b6c97/cryptography-46.0.4-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:df4a817fa7138dd0c96c8c8c20f04b8aaa1fac3bbf610913dcad8ea82e1bfd3f", size = 4441254, upload-time = "2026-01-28T00:23:48.403Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/fe/e4a1b0c989b00cee5ffa0764401767e2d1cf59f45530963b894129fd5dce/cryptography-46.0.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:b1de0ebf7587f28f9190b9cb526e901bf448c9e6a99655d2b07fff60e8212a82", size = 4396520, upload-time = "2026-01-28T00:23:50.26Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/81/ba8fd9657d27076eb40d6a2f941b23429a3c3d2f56f5a921d6b936a27bc9/cryptography-46.0.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9b4d17bc7bd7cdd98e3af40b441feaea4c68225e2eb2341026c84511ad246c0c", size = 4651479, upload-time = "2026-01-28T00:23:51.674Z" },
-    { url = "https://files.pythonhosted.org/packages/00/03/0de4ed43c71c31e4fe954edd50b9d28d658fef56555eba7641696370a8e2/cryptography-46.0.4-cp314-cp314t-win32.whl", hash = "sha256:c411f16275b0dea722d76544a61d6421e2cc829ad76eec79280dbdc9ddf50061", size = 3001986, upload-time = "2026-01-28T00:23:53.485Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/70/81830b59df7682917d7a10f833c4dab2a5574cd664e86d18139f2b421329/cryptography-46.0.4-cp314-cp314t-win_amd64.whl", hash = "sha256:728fedc529efc1439eb6107b677f7f7558adab4553ef8669f0d02d42d7b959a7", size = 3468288, upload-time = "2026-01-28T00:23:55.09Z" },
-    { url = "https://files.pythonhosted.org/packages/56/f7/f648fdbb61d0d45902d3f374217451385edc7e7768d1b03ff1d0e5ffc17b/cryptography-46.0.4-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:a9556ba711f7c23f77b151d5798f3ac44a13455cc68db7697a1096e6d0563cab", size = 7169583, upload-time = "2026-01-28T00:23:56.558Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/cc/8f3224cbb2a928de7298d6ed4790f5ebc48114e02bdc9559196bfb12435d/cryptography-46.0.4-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8bf75b0259e87fa70bddc0b8b4078b76e7fd512fd9afae6c1193bcf440a4dbef", size = 4275419, upload-time = "2026-01-28T00:23:58.364Z" },
-    { url = "https://files.pythonhosted.org/packages/17/43/4a18faa7a872d00e4264855134ba82d23546c850a70ff209e04ee200e76f/cryptography-46.0.4-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3c268a3490df22270955966ba236d6bc4a8f9b6e4ffddb78aac535f1a5ea471d", size = 4419058, upload-time = "2026-01-28T00:23:59.867Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/64/6651969409821d791ba12346a124f55e1b76f66a819254ae840a965d4b9c/cryptography-46.0.4-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:812815182f6a0c1d49a37893a303b44eaac827d7f0d582cecfc81b6427f22973", size = 4278151, upload-time = "2026-01-28T00:24:01.731Z" },
-    { url = "https://files.pythonhosted.org/packages/20/0b/a7fce65ee08c3c02f7a8310cc090a732344066b990ac63a9dfd0a655d321/cryptography-46.0.4-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:a90e43e3ef65e6dcf969dfe3bb40cbf5aef0d523dff95bfa24256be172a845f4", size = 4939441, upload-time = "2026-01-28T00:24:03.175Z" },
-    { url = "https://files.pythonhosted.org/packages/db/a7/20c5701e2cd3e1dfd7a19d2290c522a5f435dd30957d431dcb531d0f1413/cryptography-46.0.4-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a05177ff6296644ef2876fce50518dffb5bcdf903c85250974fc8bc85d54c0af", size = 4451617, upload-time = "2026-01-28T00:24:05.403Z" },
-    { url = "https://files.pythonhosted.org/packages/00/dc/3e16030ea9aa47b63af6524c354933b4fb0e352257c792c4deeb0edae367/cryptography-46.0.4-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:daa392191f626d50f1b136c9b4cf08af69ca8279d110ea24f5c2700054d2e263", size = 3977774, upload-time = "2026-01-28T00:24:06.851Z" },
-    { url = "https://files.pythonhosted.org/packages/42/c8/ad93f14118252717b465880368721c963975ac4b941b7ef88f3c56bf2897/cryptography-46.0.4-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e07ea39c5b048e085f15923511d8121e4a9dc45cee4e3b970ca4f0d338f23095", size = 4277008, upload-time = "2026-01-28T00:24:08.926Z" },
-    { url = "https://files.pythonhosted.org/packages/00/cf/89c99698151c00a4631fbfcfcf459d308213ac29e321b0ff44ceeeac82f1/cryptography-46.0.4-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d5a45ddc256f492ce42a4e35879c5e5528c09cd9ad12420828c972951d8e016b", size = 4903339, upload-time = "2026-01-28T00:24:12.009Z" },
-    { url = "https://files.pythonhosted.org/packages/03/c3/c90a2cb358de4ac9309b26acf49b2a100957e1ff5cc1e98e6c4996576710/cryptography-46.0.4-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:6bb5157bf6a350e5b28aee23beb2d84ae6f5be390b2f8ee7ea179cda077e1019", size = 4451216, upload-time = "2026-01-28T00:24:13.975Z" },
-    { url = "https://files.pythonhosted.org/packages/96/2c/8d7f4171388a10208671e181ca43cdc0e596d8259ebacbbcfbd16de593da/cryptography-46.0.4-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:dd5aba870a2c40f87a3af043e0dee7d9eb02d4aff88a797b48f2b43eff8c3ab4", size = 4404299, upload-time = "2026-01-28T00:24:16.169Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/23/cbb2036e450980f65c6e0a173b73a56ff3bccd8998965dea5cc9ddd424a5/cryptography-46.0.4-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:93d8291da8d71024379ab2cb0b5c57915300155ad42e07f76bea6ad838d7e59b", size = 4664837, upload-time = "2026-01-28T00:24:17.629Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/21/f7433d18fe6d5845329cbdc597e30caf983229c7a245bcf54afecc555938/cryptography-46.0.4-cp38-abi3-win32.whl", hash = "sha256:0563655cb3c6d05fb2afe693340bc050c30f9f34e15763361cf08e94749401fc", size = 3009779, upload-time = "2026-01-28T00:24:20.198Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/6a/bd2e7caa2facffedf172a45c1a02e551e6d7d4828658c9a245516a598d94/cryptography-46.0.4-cp38-abi3-win_amd64.whl", hash = "sha256:fa0900b9ef9c49728887d1576fd8d9e7e3ea872fa9b25ef9b64888adc434e976", size = 3466633, upload-time = "2026-01-28T00:24:21.851Z" },
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
+    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
+    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
+    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
+    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
 ]
 
 [[package]]
@@ -552,7 +557,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.128.4"
+version = "0.136.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -561,15 +566,16 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/b7/21bf3d694cbff0b7cf5f459981d996c2c15e072bd5ca5609806383947f1e/fastapi-0.128.4.tar.gz", hash = "sha256:d6a2cc4c0edfbb2499f3fdec55ba62e751ee58a6354c50f85ed0dabdfbcfeb60", size = 375898, upload-time = "2026-02-07T08:14:09.616Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/8b/c8050e556f5d7a1f33a93c2c94379a0bae23c58a79ad9709d7e052d0c3b8/fastapi-0.128.4-py3-none-any.whl", hash = "sha256:9321282cee605fd2075ccbc95c0f2e549d675c59de4a952bba202cd1730ac66b", size = 103684, upload-time = "2026-02-07T08:14:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
 ]
 
 [package.optional-dependencies]
 standard = [
     { name = "email-validator" },
     { name = "fastapi-cli", extra = ["standard"] },
+    { name = "fastar" },
     { name = "httpx" },
     { name = "jinja2" },
     { name = "pydantic-extra-types" },
@@ -619,70 +625,74 @@ wheels = [
 
 [[package]]
 name = "fastar"
-version = "0.8.0"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/69/e7/f89d54fb04104114dd0552836dc2b47914f416cc0e200b409dd04a33de5e/fastar-0.8.0.tar.gz", hash = "sha256:f4d4d68dbf1c4c2808f0e730fac5843493fc849f70fe3ad3af60dfbaf68b9a12", size = 68524, upload-time = "2025-11-26T02:36:00.72Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/0f/0aeb3fc50046617702acc0078b277b58367fd62eb727b9ec733ae0e8bbcc/fastar-0.11.0.tar.gz", hash = "sha256:aa7f100f7313c03fdb20f1385927ba95671071ba308ad0c1763fef295e1895ce", size = 70238, upload-time = "2026-04-13T17:11:17.143Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/f1/5b2ff898abac7f1a418284aad285e3a4f68d189c572ab2db0f6c9079dd16/fastar-0.8.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0f10d2adfe40f47ff228f4efaa32d409d732ded98580e03ed37c9535b5fc923d", size = 706369, upload-time = "2025-11-26T02:34:37.783Z" },
-    { url = "https://files.pythonhosted.org/packages/23/60/8046a386dca39154f80c927cbbeeb4b1c1267a3271bffe61552eb9995757/fastar-0.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b930da9d598e3bc69513d131f397e6d6be4643926ef3de5d33d1e826631eb036", size = 629097, upload-time = "2025-11-26T02:34:21.888Z" },
-    { url = "https://files.pythonhosted.org/packages/22/7e/1ae005addc789924a9268da2394d3bb5c6f96836f7e37b7e3d23c2362675/fastar-0.8.0-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:9d210da2de733ca801de83e931012349d209f38b92d9630ccaa94bd445bdc9b8", size = 868938, upload-time = "2025-11-26T02:33:51.119Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/77/290a892b073b84bf82e6b2259708dfe79c54f356e252c2dd40180b16fe07/fastar-0.8.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa02270721517078a5bd61a38719070ac2537a4aa6b6c48cf369cf2abc59174a", size = 765204, upload-time = "2025-11-26T02:32:47.02Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/00/c3155171b976003af3281f5258189f1935b15d1221bfc7467b478c631216/fastar-0.8.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:83c391e5b789a720e4d0029b9559f5d6dee3226693c5b39c0eab8eaece997e0f", size = 764717, upload-time = "2025-11-26T02:33:02.453Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/43/405b7ad76207b2c11b7b59335b70eac19e4a2653977f5588a1ac8fed54f4/fastar-0.8.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3258d7a78a72793cdd081545da61cabe85b1f37634a1d0b97ffee0ff11d105ef", size = 931502, upload-time = "2025-11-26T02:33:18.619Z" },
-    { url = "https://files.pythonhosted.org/packages/da/8a/a3dde6d37cc3da4453f2845cdf16675b5686b73b164f37e2cc579b057c2c/fastar-0.8.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e6eab95dd985cdb6a50666cbeb9e4814676e59cfe52039c880b69d67cfd44767", size = 821454, upload-time = "2025-11-26T02:33:33.427Z" },
-    { url = "https://files.pythonhosted.org/packages/da/c1/904fe2468609c8990dce9fe654df3fbc7324a8d8e80d8240ae2c89757064/fastar-0.8.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:829b1854166141860887273c116c94e31357213fa8e9fe8baeb18bd6c38aa8d9", size = 821647, upload-time = "2025-11-26T02:34:07Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/73/a0642ab7a400bc07528091785e868ace598fde06fcd139b8f865ec1b6f3c/fastar-0.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b1667eae13f9457a3c737f4376d68e8c3e548353538b28f7e4273a30cb3965cd", size = 986342, upload-time = "2025-11-26T02:34:53.371Z" },
-    { url = "https://files.pythonhosted.org/packages/af/af/60c1bfa6edab72366461a95f053d0f5f7ab1825fe65ca2ca367432cd8629/fastar-0.8.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b864a95229a7db0814cd9ef7987cb713fd43dce1b0d809dd17d9cd6f02fdde3e", size = 1040207, upload-time = "2025-11-26T02:35:10.65Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/a0/0d624290dec622e7fa084b6881f456809f68777d54a314f5dde932714506/fastar-0.8.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:c05fbc5618ce17675a42576fa49858d79734627f0a0c74c0875ab45ee8de340c", size = 1045031, upload-time = "2025-11-26T02:35:28.108Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/74/cf663af53c4706ba88e6b4af44a6b0c3bd7d7ca09f079dc40647a8f06585/fastar-0.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7f41c51ee96f338662ee3c3df4840511ba3f9969606840f1b10b7cb633a3c716", size = 994877, upload-time = "2025-11-26T02:35:45.797Z" },
-    { url = "https://files.pythonhosted.org/packages/52/17/444c8be6e77206050e350da7c338102b6cab384be937fa0b1d6d1f9ede73/fastar-0.8.0-cp312-cp312-win32.whl", hash = "sha256:d949a1a2ea7968b734632c009df0571c94636a5e1622c87a6e2bf712a7334f47", size = 455996, upload-time = "2025-11-26T02:36:26.938Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/34/fc3b5e56d71a17b1904800003d9251716e8fd65f662e1b10a26881698a74/fastar-0.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:fc645994d5b927d769121094e8a649b09923b3c13a8b0b98696d8f853f23c532", size = 490429, upload-time = "2025-11-26T02:36:12.707Z" },
-    { url = "https://files.pythonhosted.org/packages/35/a8/5608cc837417107c594e2e7be850b9365bcb05e99645966a5d6a156285fe/fastar-0.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:d81ee82e8dc78a0adb81728383bd39611177d642a8fa2d601d4ad5ad59e5f3bd", size = 461297, upload-time = "2025-11-26T02:36:03.546Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/a5/79ecba3646e22d03eef1a66fb7fc156567213e2e4ab9faab3bbd4489e483/fastar-0.8.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:a3253a06845462ca2196024c7a18f5c0ba4de1532ab1c4bad23a40b332a06a6a", size = 706112, upload-time = "2025-11-26T02:34:39.237Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/03/4f883bce878218a8676c2d7ca09b50c856a5470bb3b7f63baf9521ea6995/fastar-0.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5cbeb3ebfa0980c68ff8b126295cc6b208ccd81b638aebc5a723d810a7a0e5d2", size = 628954, upload-time = "2025-11-26T02:34:23.705Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/f1/892e471f156b03d10ba48ace9384f5a896702a54506137462545f38e40b8/fastar-0.8.0-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1c0d5956b917daac77d333d48b3f0f3ff927b8039d5b32d8125462782369f761", size = 868685, upload-time = "2025-11-26T02:33:53.077Z" },
-    { url = "https://files.pythonhosted.org/packages/39/ba/e24915045852e30014ec6840446975c03f4234d1c9270394b51d3ad18394/fastar-0.8.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:27b404db2b786b65912927ce7f3790964a4bcbde42cdd13091b82a89cd655e1c", size = 765044, upload-time = "2025-11-26T02:32:48.187Z" },
-    { url = "https://files.pythonhosted.org/packages/14/2c/1aa11ac21a99984864c2fca4994e094319ff3a2046e7a0343c39317bd5b9/fastar-0.8.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0902fc89dcf1e7f07b8563032a4159fe2b835e4c16942c76fd63451d0e5f76a3", size = 764322, upload-time = "2025-11-26T02:33:03.859Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/f0/4b91902af39fe2d3bae7c85c6d789586b9fbcf618d7fdb3d37323915906d/fastar-0.8.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:069347e2f0f7a8b99bbac8cd1bc0e06c7b4a31dc964fc60d84b95eab3d869dc1", size = 931016, upload-time = "2025-11-26T02:33:19.902Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/97/8fc43a5a9c0a2dc195730f6f7a0f367d171282cd8be2511d0e87c6d2dad0/fastar-0.8.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7fd135306f6bfe9a835918280e0eb440b70ab303e0187d90ab51ca86e143f70d", size = 821308, upload-time = "2025-11-26T02:33:34.664Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/e9/058615b63a7fd27965e8c5966f393ed0c169f7ff5012e1674f21684de3ba/fastar-0.8.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78d06d6897f43c27154b5f2d0eb930a43a81b7eec73f6f0b0114814d4a10ab38", size = 821171, upload-time = "2025-11-26T02:34:08.498Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/cf/69e16a17961570a755c37ffb5b5aa7610d2e77807625f537989da66f2a9d/fastar-0.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a922f8439231fa0c32b15e8d70ff6d415619b9d40492029dabbc14a0c53b5f18", size = 986227, upload-time = "2025-11-26T02:34:55.06Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/83/2100192372e59b56f4ace37d7d9cabda511afd71b5febad1643d1c334271/fastar-0.8.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:a739abd51eb766384b4caff83050888e80cd75bbcfec61e6d1e64875f94e4a40", size = 1039395, upload-time = "2025-11-26T02:35:12.166Z" },
-    { url = "https://files.pythonhosted.org/packages/75/15/cdd03aca972f55872efbb7cf7540c3fa7b97a75d626303a3ea46932163dc/fastar-0.8.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:5a65f419d808b23ac89d5cd1b13a2f340f15bc5d1d9af79f39fdb77bba48ff1b", size = 1044766, upload-time = "2025-11-26T02:35:29.62Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/29/945e69e4e2652329ace545999334ec31f1431fbae3abb0105587e11af2ae/fastar-0.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7bb2ae6c0cce58f0db1c9f20495e7557cca2c1ee9c69bbd90eafd54f139171c5", size = 994740, upload-time = "2025-11-26T02:35:47.887Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/5d/dbfe28f8cd1eb484bba0c62e5259b2cf6fea229d6ef43e05c06b5a78c034/fastar-0.8.0-cp313-cp313-win32.whl", hash = "sha256:b28753e0d18a643272597cb16d39f1053842aa43131ad3e260c03a2417d38401", size = 455990, upload-time = "2025-11-26T02:36:28.502Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/01/e965740bd36e60ef4c5aa2cbe42b6c4eb1dc3551009238a97c2e5e96bd23/fastar-0.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:620e5d737dce8321d49a5ebb7997f1fd0047cde3512082c27dc66d6ac8c1927a", size = 490227, upload-time = "2025-11-26T02:36:14.363Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/10/c99202719b83e5249f26902ae53a05aea67d840eeb242019322f20fc171c/fastar-0.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:c4c4bd08df563120cd33e854fe0a93b81579e8571b11f9b7da9e84c37da2d6b6", size = 461078, upload-time = "2025-11-26T02:36:04.94Z" },
-    { url = "https://files.pythonhosted.org/packages/96/4a/9573b87a0ef07580ed111e7230259aec31bb33ca3667963ebee77022ec61/fastar-0.8.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:50b36ce654ba44b0e13fae607ae17ee6e1597b69f71df1bee64bb8328d881dfc", size = 706041, upload-time = "2025-11-26T02:34:40.638Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/19/f95444a1d4f375333af49300aa75ee93afa3335c0e40fda528e460ed859c/fastar-0.8.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:63a892762683d7ab00df0227d5ea9677c62ff2cde9b875e666c0be569ed940f3", size = 628617, upload-time = "2025-11-26T02:34:24.893Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/c9/b51481b38b7e3f16ef2b9e233b1a3623386c939d745d6e41bbd389eaae30/fastar-0.8.0-cp314-cp314-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:4ae6a145c1bff592644bde13f2115e0239f4b7babaf506d14e7d208483cf01a5", size = 869299, upload-time = "2025-11-26T02:33:54.274Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/02/3ba1267ee5ba7314e29c431cf82eaa68586f2c40cdfa08be3632b7d07619/fastar-0.8.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ae0ff7c0a1c7e1428404b81faee8aebef466bfd0be25bfe4dabf5d535c68741", size = 764667, upload-time = "2025-11-26T02:32:49.606Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/84/bf33530fd015b5d7c2cc69e0bce4a38d736754a6955487005aab1af6adcd/fastar-0.8.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:dbfd87dbd217b45c898b2dbcd0169aae534b2c1c5cbe3119510881f6a5ac8ef5", size = 763993, upload-time = "2025-11-26T02:33:05.782Z" },
-    { url = "https://files.pythonhosted.org/packages/da/e0/9564d24e7cea6321a8d921c6d2a457044a476ef197aa4708e179d3d97f0d/fastar-0.8.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a5abd99fcba83ef28c8fe6ae2927edc79053db43a0457a962ed85c9bf150d37", size = 930153, upload-time = "2025-11-26T02:33:21.53Z" },
-    { url = "https://files.pythonhosted.org/packages/35/b1/6f57fcd8d6e192cfebf97e58eb27751640ad93784c857b79039e84387b51/fastar-0.8.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:91d4c685620c3a9d6b5ae091dbabab4f98b20049b7ecc7976e19cc9016c0d5d6", size = 821177, upload-time = "2025-11-26T02:33:35.839Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/78/9e004ea9f3aa7466f5ddb6f9518780e1d2f0ed3ca55f093632982598bace/fastar-0.8.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f77c2f2cad76e9dc7b6701297adb1eba87d0485944b416fc2ccf5516c01219a3", size = 820652, upload-time = "2025-11-26T02:34:09.776Z" },
-    { url = "https://files.pythonhosted.org/packages/42/95/b604ed536544005c9f1aee7c4c74b00150db3d8d535cd8232dc20f947063/fastar-0.8.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e7f07c4a3dada7757a8fc430a5b4a29e6ef696d2212747213f57086ffd970316", size = 985961, upload-time = "2025-11-26T02:34:56.401Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/7b/fa9d4d96a5d494bdb8699363bb9de8178c0c21a02e1d89cd6f913d127018/fastar-0.8.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:90c0c3fe55105c0aed8a83135dbdeb31e683455dbd326a1c48fa44c378b85616", size = 1039316, upload-time = "2025-11-26T02:35:13.807Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/f9/8462789243bc3f33e8401378ec6d54de4e20cfa60c96a0e15e3e9d1389bb/fastar-0.8.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:fb9ee51e5bffe0dab3d3126d3a4fac8d8f7235cedcb4b8e74936087ce1c157f3", size = 1045028, upload-time = "2025-11-26T02:35:31.079Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/71/9abb128777e616127194b509e98fcda3db797d76288c1a8c23dd22afc14f/fastar-0.8.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e380b1e8d30317f52406c43b11e98d11e1d68723bbd031e18049ea3497b59a6d", size = 994677, upload-time = "2025-11-26T02:35:49.391Z" },
-    { url = "https://files.pythonhosted.org/packages/de/c1/b81b3f194853d7ad232a67a1d768f5f51a016f165cfb56cb31b31bbc6177/fastar-0.8.0-cp314-cp314-win32.whl", hash = "sha256:1c4ffc06e9c4a8ca498c07e094670d8d8c0d25b17ca6465b9774da44ea997ab1", size = 456687, upload-time = "2025-11-26T02:36:30.205Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/87/9e0cd4768a98181d56f0cdbab2363404cc15deb93f4aad3b99cd2761bbaa/fastar-0.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:5517a8ad4726267c57a3e0e2a44430b782e00b230bf51c55b5728e758bb3a692", size = 490578, upload-time = "2025-11-26T02:36:16.218Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/1e/580a76cf91847654f2ad6520e956e93218f778540975bc4190d363f709e2/fastar-0.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:58030551046ff4a8616931e52a36c83545ff05996db5beb6e0cd2b7e748aa309", size = 461473, upload-time = "2025-11-26T02:36:06.373Z" },
-    { url = "https://files.pythonhosted.org/packages/58/4c/bdb5c6efe934f68708529c8c9d4055ebef5c4be370621966438f658b29bd/fastar-0.8.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:1e7d29b6bfecb29db126a08baf3c04a5ab667f6cea2b7067d3e623a67729c4a6", size = 705570, upload-time = "2025-11-26T02:34:42.01Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/78/f01ac7e71d5a37621bd13598a26e948a12b85ca8042f7ee1a0a8c9f59cda/fastar-0.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:05eb7b96940f9526b485f1d0b02393839f0f61cac4b1f60024984f8b326d2640", size = 627761, upload-time = "2025-11-26T02:34:26.152Z" },
-    { url = "https://files.pythonhosted.org/packages/06/45/6df0ecda86ea9d2e95053c1a655d153dee55fc121b6e13ea6d1e246a50b6/fastar-0.8.0-cp314-cp314t-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:619352d8ac011794e2345c462189dc02ba634750d23cd9d86a9267dd71b1f278", size = 869414, upload-time = "2025-11-26T02:33:55.618Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/72/486421f5a8c0c377cc82e7a50c8a8ea899a6ec2aa72bde8f09fb667a2dc8/fastar-0.8.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:74ebfecef3fe6d7a90355fac1402fd30636988332a1d33f3e80019a10782bb24", size = 763863, upload-time = "2025-11-26T02:32:51.051Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/64/39f654dbb41a3867fb1f2c8081c014d8f1d32ea10585d84cacbef0b32995/fastar-0.8.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2975aca5a639e26a3ab0d23b4b0628d6dd6d521146c3c11486d782be621a35aa", size = 763065, upload-time = "2025-11-26T02:33:07.274Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/bd/c011a34fb3534c4c3301f7c87c4ffd7e47f6113c904c092ddc8a59a303ea/fastar-0.8.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:afc438eaed8ff0dcdd9308268be5cb38c1db7e94c3ccca7c498ca13a4a4535a3", size = 930530, upload-time = "2025-11-26T02:33:23.117Z" },
-    { url = "https://files.pythonhosted.org/packages/55/9d/aa6e887a7033c571b1064429222bbe09adc9a3c1e04f3d1788ba5838ebd5/fastar-0.8.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6ced0a5399cc0a84a858ef0a31ca2d0c24d3bbec4bcda506a9192d8119f3590a", size = 820572, upload-time = "2025-11-26T02:33:37.542Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/9c/7a3a2278a1052e1a5d98646de7c095a00cffd2492b3b84ce730e2f1cd93a/fastar-0.8.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec9b23da8c4c039da3fe2e358973c66976a0c8508aa06d6626b4403cb5666c19", size = 820649, upload-time = "2025-11-26T02:34:11.108Z" },
-    { url = "https://files.pythonhosted.org/packages/02/9e/d38edc1f4438cd047e56137c26d94783ffade42e1b3bde620ccf17b771ef/fastar-0.8.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:dfba078fcd53478032fd0ceed56960ec6b7ff0511cfc013a8a3a4307e3a7bac4", size = 985653, upload-time = "2025-11-26T02:34:57.884Z" },
-    { url = "https://files.pythonhosted.org/packages/69/d9/2147d0c19757e165cd62d41cec3f7b38fad2ad68ab784978b5f81716c7ea/fastar-0.8.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:ade56c94c14be356d295fecb47a3fcd473dd43a8803ead2e2b5b9e58feb6dcfa", size = 1038140, upload-time = "2025-11-26T02:35:15.778Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/1d/ec4c717ffb8a308871e9602ec3197d957e238dc0227127ac573ec9bca952/fastar-0.8.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e48d938f9366db5e59441728f70b7f6c1ccfab7eff84f96f9b7e689b07786c52", size = 1045195, upload-time = "2025-11-26T02:35:32.865Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/9f/637334dc8c8f3bb391388b064ae13f0ad9402bc5a6c3e77b8887d0c31921/fastar-0.8.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:79c441dc1482ff51a54fb3f57ae6f7bb3d2cff88fa2cc5d196c519f8aab64a56", size = 994686, upload-time = "2025-11-26T02:35:51.392Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/e2/dfa19a4b260b8ab3581b7484dcb80c09b25324f4daa6b6ae1c7640d1607a/fastar-0.8.0-cp314-cp314t-win32.whl", hash = "sha256:187f61dc739afe45ac8e47ed7fd1adc45d52eac110cf27d579155720507d6fbe", size = 455767, upload-time = "2025-11-26T02:36:34.758Z" },
-    { url = "https://files.pythonhosted.org/packages/51/47/df65c72afc1297797b255f90c4778b5d6f1f0f80282a134d5ab610310ed9/fastar-0.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:40e9d763cf8bf85ce2fa256e010aa795c0fe3d3bd1326d5c3084e6ce7857127e", size = 489971, upload-time = "2025-11-26T02:36:22.081Z" },
-    { url = "https://files.pythonhosted.org/packages/85/11/0aa8455af26f0ae89e42be67f3a874255ee5d7f0f026fc86e8d56f76b428/fastar-0.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:e59673307b6a08210987059a2bdea2614fe26e3335d0e5d1a3d95f49a05b1418", size = 460467, upload-time = "2025-11-26T02:36:07.978Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/06/a5773706afc8bd496769786590bbc56d2d0ee419a299cc12ea3f5717fcf3/fastar-0.11.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3c51f1c2cdddbd1420d2897ace7738e36c65e17f6ae84e0bfe763f8d1068bb97", size = 708394, upload-time = "2026-04-13T17:09:57.269Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/a6/d5e2a4e48495616440a21eed07558219ca90243ad00b0502586f95bd4833/fastar-0.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0d9d6b052baf5380baea866675dab6ccd04ec2460d12b1c46f10ce3f4ee6a820", size = 628417, upload-time = "2026-04-13T17:09:42.145Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/69/9816d69ac8265c9e50456637a487ccfb7a9c566efd9dbcd673df9c2558c2/fastar-0.11.0-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:bd2f05666d4df7e14885b5c38fefd92a785917387513d33d837ff42ec143a22f", size = 863950, upload-time = "2026-04-13T17:09:11.506Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/0d/f88daad53aff2e754b6b5ff2a7113f72447a34f6ef17cc23ca99988117b7/fastar-0.11.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c1e6e74aba1ae77ca4aedcaf1697cd413319f4c88a5ccbe5b42c709517c5097e", size = 760737, upload-time = "2026-04-13T17:07:55.958Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/a6/82ef4ecd969d50d92ed3ed9dbd8fe77faa24be5e5736f716edc9f4ce8d62/fastar-0.11.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:38ef77fe940bbc9b37a98bd838727f844b11731cd39358a2640ff864fb385086", size = 757603, upload-time = "2026-04-13T17:08:10.623Z" },
+    { url = "https://files.pythonhosted.org/packages/03/35/50249f0d827251f8ac511495e2eacccebda80a00a0ad73e9615b8113b84f/fastar-0.11.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8955e61b32d6aff82c983217abf80933fd823b0e727586fc72f08043d996fd59", size = 923952, upload-time = "2026-04-13T17:08:25.526Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d8/faee41659e9c379d906d24eaee6d6833ac8cfef0a5df480e5c2a8d3efb33/fastar-0.11.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:483532442cdb08fbff0169510224eae0836f2f672cea6aacb52847d90fefdc46", size = 816574, upload-time = "2026-04-13T17:08:56.076Z" },
+    { url = "https://files.pythonhosted.org/packages/22/47/0448ea7992b997dad2bf004bfd98eca74b5858630eae080b50c7b17d9ddc/fastar-0.11.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef5a6071121e05d8287fc75bccb054bcbac8bb0501200a0c0a8feeace5303ea4", size = 819382, upload-time = "2026-04-13T17:09:26.66Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ef/0d63eb43586831b7a6f8b22c4d77125a7c594423af1f4f090fa9541b9b40/fastar-0.11.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:e45e598af5afe8412197d4786efd6cf29be02e7d3d4f6a3461149eae5d7e94f1", size = 885254, upload-time = "2026-04-13T17:08:40.9Z" },
+    { url = "https://files.pythonhosted.org/packages/01/25/edd584675d69e49a165052c3ee886df1c5d574f3e7d813c990306387c623/fastar-0.11.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2e160919b1c47ddb8538e7e8eb4cd527281b40f0bf75110a75993838ef61f286", size = 971239, upload-time = "2026-04-13T17:10:12.997Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/37/e8bb24f506ba2b08fbaf36c5800e843bd4d542954e9331f00418e2d23349/fastar-0.11.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:4bb4dc0fc8f7a6807febcebce8a2f3626ba4955a9263d81ecc630aad83be84c0", size = 1035185, upload-time = "2026-04-13T17:10:30.207Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bf/be753736296338149ee4cb3e92e2b5423d6ba17c7b951d15218fd7e99bbf/fastar-0.11.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:4ec95af56aa173f6e320e1183001bf108ba59beaf13edd1fc8200648db203588", size = 1072191, upload-time = "2026-04-13T17:10:47.072Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/cd/a81c1aaafb5a22ce57c98ae22f39c89413ed53e4ee6e1b1444b0bd666a6c/fastar-0.11.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:136cf342735464091c39dc3708168f9fdeb9ebea40b1ead937c61afaf46143d9", size = 1028054, upload-time = "2026-04-13T17:11:04.293Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/88/1ce4eed3d70627c95f49ca017f6bbbf2ddcc4b0c601d293259de7689bc20/fastar-0.11.0-cp312-cp312-win32.whl", hash = "sha256:35f23c11b556cc4d3704587faacbc0037f7bdf6c4525cd1d09c70bda4b1c6809", size = 454198, upload-time = "2026-04-13T17:11:45.168Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/1d/26ce92f4331cd61a69840db9ca6115829805eec24f285481a854f578e917/fastar-0.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:920bc56c3c0b8a8ca492904941d1883c1c947c858cd93343356c29122a38f44c", size = 486697, upload-time = "2026-04-13T17:11:31.084Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/96/e6eda4480559c69b05d466e7b5ea9170e81fef3795a73e059959a3258319/fastar-0.11.0-cp312-cp312-win_arm64.whl", hash = "sha256:395248faf89e8a6bd5dc1fd544c8465113b627cb6d7c8b296796b60ebea33593", size = 462591, upload-time = "2026-04-13T17:11:20.577Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d6/3be260037e86fb694e88d47f583bac3a0188c99cee1a6b257ac26cb6b53c/fastar-0.11.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:33f544b08b4541b678e53749b4552a44720d96761fb79c172b005b1089c443ed", size = 707975, upload-time = "2026-04-13T17:09:58.866Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/cd/7867aefb1784662554a335f2952c75a50f0c70585ed0d2210d6cc15e5627/fastar-0.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:91c1c792447e4a642745f347ff9847c52af39633071c57ee67ed53c157fc3506", size = 628460, upload-time = "2026-04-13T17:09:43.776Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2b/d11d84bdd5e0e377771b955755771e3460b290da5809cb78c1b735ee2228/fastar-0.11.0-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:881247e6b6eaea59fc6569f9b61447aa6b9fc2ee864e048b4643d69c52745805", size = 863054, upload-time = "2026-04-13T17:09:13.048Z" },
+    { url = "https://files.pythonhosted.org/packages/25/39/d3f428b318fa940b1b6e785b8d54fc895dfb5d5b945ef8d5442ffa904fb2/fastar-0.11.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:863b7929845c9fec92ef6c8d59579cf46af5136655e5342f8df5cebe46cab06c", size = 760247, upload-time = "2026-04-13T17:07:57.396Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/04/03949aee82aabb8ede06ac5a4a5579ffaf98a8fe59ce958494508ff15513/fastar-0.11.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:96b4a57df12bf3211662627a3ea29d62ecb314a2434a0d0843f9fc23e47536e5", size = 756512, upload-time = "2026-04-13T17:08:12.415Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/0c/2ca1ae0a3828ca51047962d932b80daca2522db73e8cb9d040cb6ebe28d5/fastar-0.11.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ceef1c2c4df7b7b8ebd3f5d718bbf457b9bbdf25ce0bd07870211ec4fbd9aff4", size = 922183, upload-time = "2026-04-13T17:08:27.187Z" },
+    { url = "https://files.pythonhosted.org/packages/65/68/7fe808b1f73a68e686f25434f538c6dc10ef4dfb3db0ace22cd861744bf8/fastar-0.11.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b8e545918441910a779659d4759ad0eef349e935fbdb4668a666d3681567eb05", size = 816394, upload-time = "2026-04-13T17:08:57.657Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/17/07d086080f8a83b8d7966955e29bcdbd6a060f5bd949dc9d5abd3658cead/fastar-0.11.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28095bb8f821e85fc2764e1a55f03e5e2876dee2abe7cd0ee9420d929905d643", size = 818983, upload-time = "2026-04-13T17:09:28.46Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/2c4edf0910af2e814ff6d65b77a91196d472ca8a9fb2033bd983f6856caa/fastar-0.11.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0fafb95ecbe70f666a5e9b35dd63974ccdc9bb3d99ccdbd4014a823ec3e659b5", size = 884689, upload-time = "2026-04-13T17:08:42.763Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ba/04fdcbd6558e60de4ced3b55230fac47675d181252582b2fcec3c74608e5/fastar-0.11.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:af48fed039b94016629dcdad1c95c90c486326dd068de2b0a4df419ee09b6821", size = 970677, upload-time = "2026-04-13T17:10:15.124Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b3/2b860a9658550167dbd5824c85e88d0b4b912bf493e42a6322544d6e483d/fastar-0.11.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:74cd96163f39b8638ab4e8d49708ca887959672a22871d8170d01f067319533b", size = 1034026, upload-time = "2026-04-13T17:10:32.318Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/9b/fa42ea1188b144bac4b1b60753dfd449974a4d5eda132029ee7711569f94/fastar-0.11.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4e8b993cb5613bab495ed482810bedc0986633fcb9a3b55c37ec88e0d6714f6a", size = 1071147, upload-time = "2026-04-13T17:10:48.833Z" },
+    { url = "https://files.pythonhosted.org/packages/95/c8/d2e501556dca9f1fbc9246111a31792fb49ad908fa4927f34938a97a3604/fastar-0.11.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfe39d91fc28e37e06162d94afe01050220edb7df554acb5b702b5503e564816", size = 1028377, upload-time = "2026-04-13T17:11:06.374Z" },
+    { url = "https://files.pythonhosted.org/packages/db/33/5f11f23eca0a569cd052507bc45dda2e5468697f8665728d25be44120f7d/fastar-0.11.0-cp313-cp313-win32.whl", hash = "sha256:c5f63d4d99ff4bfb37c659982ec413358bdee747005348756cc50a04d412d989", size = 454089, upload-time = "2026-04-13T17:11:46.821Z" },
+    { url = "https://files.pythonhosted.org/packages/da/2f/35ff03c939cba7a255a9132367873fec6c355fd06a7f84fedcbaf4c8129f/fastar-0.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:8690ed1928d31ded3ada308e1086525fb3871f5fa81e1b69601a3f7774004583", size = 486312, upload-time = "2026-04-13T17:11:32.86Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/71/ee9246cbfcbfd4144558f35e7e9a306ffe0a7564730a5188c45f21d2dab8/fastar-0.11.0-cp313-cp313-win_arm64.whl", hash = "sha256:d977ded9d98a0719a305e0a4d5ee811f1d3e856d853a50acb8ae833c3cd6d5d2", size = 461975, upload-time = "2026-04-13T17:11:22.589Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/cd/3644c48ecac456f928c12d47ec3bed36c36555b17c3859856f1ff860265d/fastar-0.11.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:71375bd6f03c2a43eb47bd949ea38ff45434917f9cdac79675c5b9f60de4fa73", size = 707860, upload-time = "2026-04-13T17:10:00.371Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ca/dee04476ae3626b2b040a60ad84628f77e1ffd8444232f2426b0ca1e0d7e/fastar-0.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:eddfd9cab16e19ae247fe44bf992cb403ccfe27d3931d6de29a4695d95ad386c", size = 628216, upload-time = "2026-04-13T17:09:45.355Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/5e/9395c7353d079cb4f5be0f7982ce0dc9f2e7dec5fd175eef466729d6023a/fastar-0.11.0-cp314-cp314-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:7c371f1d4386c699018bb64eb2fa785feacf32785559049d2bb72fe4af023f53", size = 864378, upload-time = "2026-04-13T17:09:14.611Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ba/1e4f67148223ff219612b6281a6000357abbcc2417964fa5c83f11d68fce/fastar-0.11.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cad7fa41e3e66554387481c1a09365e4638becd322904932674159d5f4046728", size = 760921, upload-time = "2026-04-13T17:07:59.138Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/82/09d11fb6d12f17993ffaf32ffd30c3c121a11e2966e84f19fb6f66430118/fastar-0.11.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cf36652fa71b83761717c9899b98732498f8a2cb6327ff16bbf07f6be85c3437", size = 757012, upload-time = "2026-04-13T17:08:14.186Z" },
+    { url = "https://files.pythonhosted.org/packages/52/1f/5aeeacc4cb65615e2c9292cd9c5b0cd6fb6d2e6ee472ca6adc6c1b1b22ef/fastar-0.11.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f68ff8c17833053da4841720e95edde80ce45bb994b6b7d51418dddaac70ee47", size = 924510, upload-time = "2026-04-13T17:08:28.741Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1a/1e5bdabbeaf2e856928956292609f2ff6a650f94480fb8afaca30229e483/fastar-0.11.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4563ed37a12ea1cdc398af8571258d24b988bf342b7b3bf5451bd5891243280c", size = 816602, upload-time = "2026-04-13T17:08:59.461Z" },
+    { url = "https://files.pythonhosted.org/packages/87/24/f960147910da3bed41a3adfcb026e17d5f50f4cf467a3324237a7088f61a/fastar-0.11.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cee63c9875cba3b70dc44338c560facc5d6e763047dcc4a30501f9a68cf5f890", size = 819452, upload-time = "2026-04-13T17:09:29.926Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f4/3e77d7901d5707fd7f8a352e153c8ae09ea974e6fabad0b7c4eb9944b8d4/fastar-0.11.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:bd76bfffae6d0a91f4ac4a612f721e7aec108db97dccdd120ae063cd66959f27", size = 885254, upload-time = "2026-04-13T17:08:44.285Z" },
+    { url = "https://files.pythonhosted.org/packages/47/01/1585edd5ec47782ae93cd94edf05828e0ab02ef00aec00aea4194a600464/fastar-0.11.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8f5b707501ec01c1bc0518f741f01d322e50c9adc19a451aa24f67a2316e9397", size = 971496, upload-time = "2026-04-13T17:10:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/e9/6874c9d1236ded565a0bed54b320ac9f165f287b1d89490fb70f9f323c81/fastar-0.11.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:37c0b5a88a657839aad98b0a6c9e4ac4c2c15d6b49c44ee3935c6b08e9d3e479", size = 1034685, upload-time = "2026-04-13T17:10:34.063Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d8/4ab20613ce2983427aee958e39be878dba874aa227c530a845e32429c4f6/fastar-0.11.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:6c55f536c62a6efb180c1af0d5182948bff576bbfe6276e8e1359c9c7d2215d8", size = 1072675, upload-time = "2026-04-13T17:10:50.53Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ae/5ac3b7c20ce4b08f011dd2b979f96caabe64f9b10b157f211ea91bdfadca/fastar-0.11.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3082eeca59e189b9039335862f4c2780c0c8871d656bfdf559db4414a105b251", size = 1029330, upload-time = "2026-04-13T17:11:08.138Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/e7/37cd6a1d4e288292170b64e19d79ecce2a7de8bb76790323399a2abc4619/fastar-0.11.0-cp314-cp314-win32.whl", hash = "sha256:b201a0a4e29f9fec2a177e13154b8725ec65ab9f83bd6415483efaa2aa18344b", size = 453940, upload-time = "2026-04-13T17:11:48.713Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1c/795c878b1ee29d79021cf8ed81f18f2b25ccde58453b0d34b9bdc7e025ea/fastar-0.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:868fddb26072a43e870a8819134b9f80ee602931be5a76e6fb873e04da343637", size = 486334, upload-time = "2026-04-13T17:11:34.882Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/a4/113f104301df8bddcc0b3775b611a30cb7610baa3add933c7ccac9386467/fastar-0.11.0-cp314-cp314-win_arm64.whl", hash = "sha256:3db39c9cc42abb0c780a26b299f24dfbc8be455985e969e15336d70d7b2f833b", size = 461534, upload-time = "2026-04-13T17:11:24.329Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a6/5c5f2c2c8e0c63e56a5636ebc7721589c889e94c0092cec7eb28ae7207e6/fastar-0.11.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:49c3299dec5e125e7ebaa27545714da9c7391777366015427e0ae62d548b442b", size = 707156, upload-time = "2026-04-13T17:10:02.176Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f7/982c01b61f0fc135ad2b16d01e6d0ee53cf8791e68827f5f7c5a65b2e5b1/fastar-0.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3328ed1ed56d31f5198350b17dd60449b8d6b9d47abb4688bab6aef4450a165b", size = 627032, upload-time = "2026-04-13T17:09:46.978Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c3/38f1dac77ae0c71c37b176277c96d830796b8ce2fe69705f917829b53829/fastar-0.11.0-cp314-cp314t-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:bd3eca3bbfec84a614bcb4143b4ad4f784d0895babc26cfc88436af88ca23c7a", size = 864403, upload-time = "2026-04-13T17:09:16.58Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f0/e69c363bdb3e5a5848e937b662b5469581ee6682c51bc1c0556494773929/fastar-0.11.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ff86a967acb0d621dd24063dda090daa67bf4993b9570e97fe156de88a9006ca", size = 759480, upload-time = "2026-04-13T17:08:00.599Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/29/4d8737590c2a6357d614d7cc7288e8f68e7e449680b8922997cc4349e65e/fastar-0.11.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:86eaf7c0e985d93a7734168be2fb232b2a8cca53e41431c2782d7c12b12c03b1", size = 756219, upload-time = "2026-04-13T17:08:15.699Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/ec/400de7b3b7d48801908f19cf5462177104395799472671b3e8152b2b04ca/fastar-0.11.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:91f07b0b8eb67e2f177733a1f884edad7dfb9f8977ffef15927b20cb9604027d", size = 923669, upload-time = "2026-04-13T17:08:30.574Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/01/8926c53da923fed7ab4b96e7fbf7f73b663beb4f02095b654d6fab46f9ad/fastar-0.11.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f85c896885eb4abf1a635d54dea22cac6ae48d04fc2ea26ae652fcf1febe1220", size = 815729, upload-time = "2026-04-13T17:09:01.204Z" },
+    { url = "https://files.pythonhosted.org/packages/89/f0/5fef4c7946e352651b504b1a4235dac3505e7cfd24020788ab50552e84bf/fastar-0.11.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:075c07095c8de4b774ba8f28b9c0a02b1a2cd254da50cbe464dd3bb2432e9158", size = 819812, upload-time = "2026-04-13T17:09:31.907Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/c8/0ebc3298b4a45e7bddc50b169ae6a6f5b80c939394d4befe6e60de535ee7/fastar-0.11.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:07f028933820c65750baf3383b807ecce1cd9385cf00ce192b79d263ad6b856c", size = 884074, upload-time = "2026-04-13T17:08:45.802Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/9f/7baa4cdff8d6fbca41fa5c764b48a941fed8a9ec6c4cc92de65895a28299/fastar-0.11.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:039f875efa0f01fa43c20bf4e2fc7305489c61d0ac76eda991acfba7820a0e63", size = 969450, upload-time = "2026-04-13T17:10:18.667Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/dc/1ebbfb58a47056ba866494f19efbcdd2ba2897096b94f36e796594b4d05b/fastar-0.11.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:fff12452a9a5c6814a012445f26365541cc3d99dcca61f09762e6a389f7a32ea", size = 1033775, upload-time = "2026-04-13T17:10:36.165Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/5f/ce4e3914066f08c99eb8c32952cc07c1a013e81b1db1b0f598130bf6b974/fastar-0.11.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:2bf733e09f942b6fa876efe30a90508d1f4caef5630c00fb2a84fba355873712", size = 1072158, upload-time = "2026-04-13T17:10:52.497Z" },
+    { url = "https://files.pythonhosted.org/packages/03/2a/6bca72992c84151c387cc6558f3867f5ebe5fb3684ee6fa9b76280ba4b8e/fastar-0.11.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d1531fa848fdd3677d2dce0a4b436ea64d9ae38fb8babe2ddbc180dd153cb7a3", size = 1028577, upload-time = "2026-04-13T17:11:09.934Z" },
+    { url = "https://files.pythonhosted.org/packages/83/18/7a7c15657a3da5569b26fc51cde6a80f8d84cb54b3b1aea6d74a103db4ad/fastar-0.11.0-cp314-cp314t-win32.whl", hash = "sha256:5744551bc67c6fc6581cbd0e34a0fd6e2cd0bd30b43e94b1c3119cf35064b162", size = 453601, upload-time = "2026-04-13T17:11:53.726Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d8/331b59a6de279f3ad75c10c02c40a12f21d64a437d9c3d6f1af2dcbd7a76/fastar-0.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f4ce44e3b56c47cf38244b98d29f269b259740a580c47a2552efa5b96a5458fb", size = 486436, upload-time = "2026-04-13T17:11:40.089Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/fd/5390ec4f49100f3ecb9968a392f9e6d039f1e3fe0ecd28443716ff01e589/fastar-0.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:76c1359314355eafbc6989f20fb1ad565a3d10200117923b9da765a17e2f6f11", size = 461049, upload-time = "2026-04-13T17:11:25.918Z" },
 ]
 
 [[package]]
@@ -902,55 +912,75 @@ wheels = [
 ]
 
 [[package]]
-name = "librt"
-version = "0.7.8"
+name = "joserfc"
+version = "1.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/24/5f3646ff414285e0f7708fa4e946b9bf538345a41d1c375c439467721a5e/librt-0.7.8.tar.gz", hash = "sha256:1a4ede613941d9c3470b0368be851df6bb78ab218635512d0370b27a277a0862", size = 148323, upload-time = "2026-01-14T12:56:16.876Z" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/c6/de8fdbdfa75c8ca04fead38a82d573df8a82906e984c349d58665f459558/joserfc-1.6.4.tar.gz", hash = "sha256:34ce5f499bfcc5e9ad4cc75077f9278ab3227b71da9aaf28f9ab705f8a560d3c", size = 231866, upload-time = "2026-04-13T13:15:40.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/04/79d8fcb43cae376c7adbab7b2b9f65e48432c9eced62ac96703bcc16e09b/librt-0.7.8-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9b6943885b2d49c48d0cff23b16be830ba46b0152d98f62de49e735c6e655a63", size = 57472, upload-time = "2026-01-14T12:55:08.528Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/ba/60b96e93043d3d659da91752689023a73981336446ae82078cddf706249e/librt-0.7.8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:46ef1f4b9b6cc364b11eea0ecc0897314447a66029ee1e55859acb3dd8757c93", size = 58986, upload-time = "2026-01-14T12:55:09.466Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/26/5215e4cdcc26e7be7eee21955a7e13cbf1f6d7d7311461a6014544596fac/librt-0.7.8-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:907ad09cfab21e3c86e8f1f87858f7049d1097f77196959c033612f532b4e592", size = 168422, upload-time = "2026-01-14T12:55:10.499Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/84/e8d1bc86fa0159bfc24f3d798d92cafd3897e84c7fea7fe61b3220915d76/librt-0.7.8-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2991b6c3775383752b3ca0204842743256f3ad3deeb1d0adc227d56b78a9a850", size = 177478, upload-time = "2026-01-14T12:55:11.577Z" },
-    { url = "https://files.pythonhosted.org/packages/57/11/d0268c4b94717a18aa91df1100e767b010f87b7ae444dafaa5a2d80f33a6/librt-0.7.8-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:03679b9856932b8c8f674e87aa3c55ea11c9274301f76ae8dc4d281bda55cf62", size = 192439, upload-time = "2026-01-14T12:55:12.7Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/56/1e8e833b95fe684f80f8894ae4d8b7d36acc9203e60478fcae599120a975/librt-0.7.8-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3968762fec1b2ad34ce57458b6de25dbb4142713e9ca6279a0d352fa4e9f452b", size = 191483, upload-time = "2026-01-14T12:55:13.838Z" },
-    { url = "https://files.pythonhosted.org/packages/17/48/f11cf28a2cb6c31f282009e2208312aa84a5ee2732859f7856ee306176d5/librt-0.7.8-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:bb7a7807523a31f03061288cc4ffc065d684c39db7644c676b47d89553c0d714", size = 185376, upload-time = "2026-01-14T12:55:15.017Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/6a/d7c116c6da561b9155b184354a60a3d5cdbf08fc7f3678d09c95679d13d9/librt-0.7.8-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad64a14b1e56e702e19b24aae108f18ad1bf7777f3af5fcd39f87d0c5a814449", size = 206234, upload-time = "2026-01-14T12:55:16.571Z" },
-    { url = "https://files.pythonhosted.org/packages/61/de/1975200bb0285fc921c5981d9978ce6ce11ae6d797df815add94a5a848a3/librt-0.7.8-cp312-cp312-win32.whl", hash = "sha256:0241a6ed65e6666236ea78203a73d800dbed896cf12ae25d026d75dc1fcd1dac", size = 44057, upload-time = "2026-01-14T12:55:18.077Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/cd/724f2d0b3461426730d4877754b65d39f06a41ac9d0a92d5c6840f72b9ae/librt-0.7.8-cp312-cp312-win_amd64.whl", hash = "sha256:6db5faf064b5bab9675c32a873436b31e01d66ca6984c6f7f92621656033a708", size = 50293, upload-time = "2026-01-14T12:55:19.179Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/cf/7e899acd9ee5727ad8160fdcc9994954e79fab371c66535c60e13b968ffc/librt-0.7.8-cp312-cp312-win_arm64.whl", hash = "sha256:57175aa93f804d2c08d2edb7213e09276bd49097611aefc37e3fa38d1fb99ad0", size = 43574, upload-time = "2026-01-14T12:55:20.185Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/fe/b1f9de2829cf7fc7649c1dcd202cfd873837c5cc2fc9e526b0e7f716c3d2/librt-0.7.8-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4c3995abbbb60b3c129490fa985dfe6cac11d88fc3c36eeb4fb1449efbbb04fc", size = 57500, upload-time = "2026-01-14T12:55:21.219Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/d4/4a60fbe2e53b825f5d9a77325071d61cd8af8506255067bf0c8527530745/librt-0.7.8-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:44e0c2cbc9bebd074cf2cdbe472ca185e824be4e74b1c63a8e934cea674bebf2", size = 59019, upload-time = "2026-01-14T12:55:22.256Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/37/61ff80341ba5159afa524445f2d984c30e2821f31f7c73cf166dcafa5564/librt-0.7.8-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:4d2f1e492cae964b3463a03dc77a7fe8742f7855d7258c7643f0ee32b6651dd3", size = 169015, upload-time = "2026-01-14T12:55:23.24Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/86/13d4f2d6a93f181ebf2fc953868826653ede494559da8268023fe567fca3/librt-0.7.8-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:451e7ffcef8f785831fdb791bd69211f47e95dc4c6ddff68e589058806f044c6", size = 178161, upload-time = "2026-01-14T12:55:24.826Z" },
-    { url = "https://files.pythonhosted.org/packages/88/26/e24ef01305954fc4d771f1f09f3dd682f9eb610e1bec188ffb719374d26e/librt-0.7.8-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3469e1af9f1380e093ae06bedcbdd11e407ac0b303a56bbe9afb1d6824d4982d", size = 193015, upload-time = "2026-01-14T12:55:26.04Z" },
-    { url = "https://files.pythonhosted.org/packages/88/a0/92b6bd060e720d7a31ed474d046a69bd55334ec05e9c446d228c4b806ae3/librt-0.7.8-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f11b300027ce19a34f6d24ebb0a25fd0e24a9d53353225a5c1e6cadbf2916b2e", size = 192038, upload-time = "2026-01-14T12:55:27.208Z" },
-    { url = "https://files.pythonhosted.org/packages/06/bb/6f4c650253704279c3a214dad188101d1b5ea23be0606628bc6739456624/librt-0.7.8-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4adc73614f0d3c97874f02f2c7fd2a27854e7e24ad532ea6b965459c5b757eca", size = 186006, upload-time = "2026-01-14T12:55:28.594Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/00/1c409618248d43240cadf45f3efb866837fa77e9a12a71481912135eb481/librt-0.7.8-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:60c299e555f87e4c01b2eca085dfccda1dde87f5a604bb45c2906b8305819a93", size = 206888, upload-time = "2026-01-14T12:55:30.214Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/83/b2cfe8e76ff5c1c77f8a53da3d5de62d04b5ebf7cf913e37f8bca43b5d07/librt-0.7.8-cp313-cp313-win32.whl", hash = "sha256:b09c52ed43a461994716082ee7d87618096851319bf695d57ec123f2ab708951", size = 44126, upload-time = "2026-01-14T12:55:31.44Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/0b/c59d45de56a51bd2d3a401fc63449c0ac163e4ef7f523ea8b0c0dee86ec5/librt-0.7.8-cp313-cp313-win_amd64.whl", hash = "sha256:f8f4a901a3fa28969d6e4519deceab56c55a09d691ea7b12ca830e2fa3461e34", size = 50262, upload-time = "2026-01-14T12:55:33.01Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/b9/973455cec0a1ec592395250c474164c4a58ebf3e0651ee920fef1a2623f1/librt-0.7.8-cp313-cp313-win_arm64.whl", hash = "sha256:43d4e71b50763fcdcf64725ac680d8cfa1706c928b844794a7aa0fa9ac8e5f09", size = 43600, upload-time = "2026-01-14T12:55:34.054Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/73/fa8814c6ce2d49c3827829cadaa1589b0bf4391660bd4510899393a23ebc/librt-0.7.8-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:be927c3c94c74b05128089a955fba86501c3b544d1d300282cc1b4bd370cb418", size = 57049, upload-time = "2026-01-14T12:55:35.056Z" },
-    { url = "https://files.pythonhosted.org/packages/53/fe/f6c70956da23ea235fd2e3cc16f4f0b4ebdfd72252b02d1164dd58b4e6c3/librt-0.7.8-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7b0803e9008c62a7ef79058233db7ff6f37a9933b8f2573c05b07ddafa226611", size = 58689, upload-time = "2026-01-14T12:55:36.078Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/4d/7a2481444ac5fba63050d9abe823e6bc16896f575bfc9c1e5068d516cdce/librt-0.7.8-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:79feb4d00b2a4e0e05c9c56df707934f41fcb5fe53fd9efb7549068d0495b758", size = 166808, upload-time = "2026-01-14T12:55:37.595Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/3c/10901d9e18639f8953f57c8986796cfbf4c1c514844a41c9197cf87cb707/librt-0.7.8-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b9122094e3f24aa759c38f46bd8863433820654927370250f460ae75488b66ea", size = 175614, upload-time = "2026-01-14T12:55:38.756Z" },
-    { url = "https://files.pythonhosted.org/packages/db/01/5cbdde0951a5090a80e5ba44e6357d375048123c572a23eecfb9326993a7/librt-0.7.8-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7e03bea66af33c95ce3addf87a9bf1fcad8d33e757bc479957ddbc0e4f7207ac", size = 189955, upload-time = "2026-01-14T12:55:39.939Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/b4/e80528d2f4b7eaf1d437fcbd6fc6ba4cbeb3e2a0cb9ed5a79f47c7318706/librt-0.7.8-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f1ade7f31675db00b514b98f9ab9a7698c7282dad4be7492589109471852d398", size = 189370, upload-time = "2026-01-14T12:55:41.057Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/ab/938368f8ce31a9787ecd4becb1e795954782e4312095daf8fd22420227c8/librt-0.7.8-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a14229ac62adcf1b90a15992f1ab9c69ae8b99ffb23cb64a90878a6e8a2f5b81", size = 183224, upload-time = "2026-01-14T12:55:42.328Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/10/559c310e7a6e4014ac44867d359ef8238465fb499e7eb31b6bfe3e3f86f5/librt-0.7.8-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5bcaaf624fd24e6a0cb14beac37677f90793a96864c67c064a91458611446e83", size = 203541, upload-time = "2026-01-14T12:55:43.501Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/db/a0db7acdb6290c215f343835c6efda5b491bb05c3ddc675af558f50fdba3/librt-0.7.8-cp314-cp314-win32.whl", hash = "sha256:7aa7d5457b6c542ecaed79cec4ad98534373c9757383973e638ccced0f11f46d", size = 40657, upload-time = "2026-01-14T12:55:44.668Z" },
-    { url = "https://files.pythonhosted.org/packages/72/e0/4f9bdc2a98a798511e81edcd6b54fe82767a715e05d1921115ac70717f6f/librt-0.7.8-cp314-cp314-win_amd64.whl", hash = "sha256:3d1322800771bee4a91f3b4bd4e49abc7d35e65166821086e5afd1e6c0d9be44", size = 46835, upload-time = "2026-01-14T12:55:45.655Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/3d/59c6402e3dec2719655a41ad027a7371f8e2334aa794ed11533ad5f34969/librt-0.7.8-cp314-cp314-win_arm64.whl", hash = "sha256:5363427bc6a8c3b1719f8f3845ea53553d301382928a86e8fab7984426949bce", size = 39885, upload-time = "2026-01-14T12:55:47.138Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/9c/2481d80950b83085fb14ba3c595db56330d21bbc7d88a19f20165f3538db/librt-0.7.8-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:ca916919793a77e4a98d4a1701e345d337ce53be4a16620f063191f7322ac80f", size = 59161, upload-time = "2026-01-14T12:55:48.45Z" },
-    { url = "https://files.pythonhosted.org/packages/96/79/108df2cfc4e672336765d54e3ff887294c1cc36ea4335c73588875775527/librt-0.7.8-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:54feb7b4f2f6706bb82325e836a01be805770443e2400f706e824e91f6441dde", size = 61008, upload-time = "2026-01-14T12:55:49.527Z" },
-    { url = "https://files.pythonhosted.org/packages/46/f2/30179898f9994a5637459d6e169b6abdc982012c0a4b2d4c26f50c06f911/librt-0.7.8-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:39a4c76fee41007070f872b648cc2f711f9abf9a13d0c7162478043377b52c8e", size = 187199, upload-time = "2026-01-14T12:55:50.587Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/da/f7563db55cebdc884f518ba3791ad033becc25ff68eb70902b1747dc0d70/librt-0.7.8-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac9c8a458245c7de80bc1b9765b177055efff5803f08e548dd4bb9ab9a8d789b", size = 198317, upload-time = "2026-01-14T12:55:51.991Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/6c/4289acf076ad371471fa86718c30ae353e690d3de6167f7db36f429272f1/librt-0.7.8-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:95b67aa7eff150f075fda09d11f6bfb26edffd300f6ab1666759547581e8f666", size = 210334, upload-time = "2026-01-14T12:55:53.682Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/7f/377521ac25b78ac0a5ff44127a0360ee6d5ddd3ce7327949876a30533daa/librt-0.7.8-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:535929b6eff670c593c34ff435d5440c3096f20fa72d63444608a5aef64dd581", size = 211031, upload-time = "2026-01-14T12:55:54.827Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/b1/e1e96c3e20b23d00cf90f4aad48f0deb4cdfec2f0ed8380d0d85acf98bbf/librt-0.7.8-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:63937bd0f4d1cb56653dc7ae900d6c52c41f0015e25aaf9902481ee79943b33a", size = 204581, upload-time = "2026-01-14T12:55:56.811Z" },
-    { url = "https://files.pythonhosted.org/packages/43/71/0f5d010e92ed9747e14bef35e91b6580533510f1e36a8a09eb79ee70b2f0/librt-0.7.8-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cf243da9e42d914036fd362ac3fa77d80a41cadcd11ad789b1b5eec4daaf67ca", size = 224731, upload-time = "2026-01-14T12:55:58.175Z" },
-    { url = "https://files.pythonhosted.org/packages/22/f0/07fb6ab5c39a4ca9af3e37554f9d42f25c464829254d72e4ebbd81da351c/librt-0.7.8-cp314-cp314t-win32.whl", hash = "sha256:171ca3a0a06c643bd0a2f62a8944e1902c94aa8e5da4db1ea9a8daf872685365", size = 41173, upload-time = "2026-01-14T12:55:59.315Z" },
-    { url = "https://files.pythonhosted.org/packages/24/d4/7e4be20993dc6a782639625bd2f97f3c66125c7aa80c82426956811cfccf/librt-0.7.8-cp314-cp314t-win_amd64.whl", hash = "sha256:445b7304145e24c60288a2f172b5ce2ca35c0f81605f5299f3fa567e189d2e32", size = 47668, upload-time = "2026-01-14T12:56:00.261Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/85/69f92b2a7b3c0f88ffe107c86b952b397004b5b8ea5a81da3d9c04c04422/librt-0.7.8-cp314-cp314t-win_arm64.whl", hash = "sha256:8766ece9de08527deabcd7cb1b4f1a967a385d26e33e536d6d8913db6ef74f06", size = 40550, upload-time = "2026-01-14T12:56:01.542Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f7/210b27752e972edb36d239315b08d3eb6b14824cc4a590da2337d195260b/joserfc-1.6.4-py3-none-any.whl", hash = "sha256:3e4a22b509b41908989237a045e25c8308d5fd47ab96bdae2dd8057c6451003a", size = 70464, upload-time = "2026-04-13T13:15:39.259Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/6b/3d5c13fb3e3c4f43206c8f9dfed13778c2ed4f000bacaa0b7ce3c402a265/librt-0.9.0.tar.gz", hash = "sha256:a0951822531e7aee6e0dfb556b30d5ee36bbe234faf60c20a16c01be3530869d", size = 184368, upload-time = "2026-04-09T16:06:26.173Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/90/89ddba8e1c20b0922783cd93ed8e64f34dc05ab59c38a9c7e313632e20ff/librt-0.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9b3e3bc363f71bda1639a4ee593cb78f7fbfeacc73411ec0d4c92f00730010a4", size = 68332, upload-time = "2026-04-09T16:05:00.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/40/7aa4da1fb08bdeeb540cb07bfc8207cb32c5c41642f2594dbd0098a0662d/librt-0.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0a09c2f5869649101738653a9b7ab70cf045a1105ac66cbb8f4055e61df78f2d", size = 70581, upload-time = "2026-04-09T16:05:01.213Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ac/73a2187e1031041e93b7e3a25aae37aa6f13b838c550f7e0f06f66766212/librt-0.9.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5ca8e133d799c948db2ab1afc081c333a825b5540475164726dcbf73537e5c2f", size = 203984, upload-time = "2026-04-09T16:05:02.542Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/3d/23460d571e9cbddb405b017681df04c142fb1b04cbfce77c54b08e28b108/librt-0.9.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:603138ee838ee1583f1b960b62d5d0007845c5c423feb68e44648b1359014e27", size = 215762, upload-time = "2026-04-09T16:05:04.127Z" },
+    { url = "https://files.pythonhosted.org/packages/de/1e/42dc7f8ab63e65b20640d058e63e97fd3e482c1edbda3570d813b4d0b927/librt-0.9.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4003f70c56a5addd6aa0897f200dd59afd3bf7bcd5b3cce46dd21f925743bc2", size = 230288, upload-time = "2026-04-09T16:05:05.883Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/08/ca812b6d8259ad9ece703397f8ad5c03af5b5fedfce64279693d3ce4087c/librt-0.9.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:78042f6facfd98ecb25e9829c7e37cce23363d9d7c83bc5f72702c5059eb082b", size = 224103, upload-time = "2026-04-09T16:05:07.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3f/620490fb2fa66ffd44e7f900254bc110ebec8dac6c1b7514d64662570e6f/librt-0.9.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a361c9434a64d70a7dbb771d1de302c0cc9f13c0bffe1cf7e642152814b35265", size = 232122, upload-time = "2026-04-09T16:05:08.386Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/83/12864700a1b6a8be458cf5d05db209b0d8e94ae281e7ec261dbe616597b4/librt-0.9.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:dd2c7e082b0b92e1baa4da28163a808672485617bc855cc22a2fd06978fa9084", size = 225045, upload-time = "2026-04-09T16:05:09.707Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/1b/845d339c29dc7dbc87a2e992a1ba8d28d25d0e0372f9a0a2ecebde298186/librt-0.9.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7e6274fd33fc5b2a14d41c9119629d3ff395849d8bcbc80cf637d9e8d2034da8", size = 227372, upload-time = "2026-04-09T16:05:10.942Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/fe/277985610269d926a64c606f761d58d3db67b956dbbf40024921e95e7fcb/librt-0.9.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5093043afb226ecfa1400120d1ebd4442b4f99977783e4f4f7248879009b227f", size = 248224, upload-time = "2026-04-09T16:05:12.254Z" },
+    { url = "https://files.pythonhosted.org/packages/92/1b/ee486d244b8de6b8b5dbaefabe6bfdd4a72e08f6353edf7d16d27114da8d/librt-0.9.0-cp312-cp312-win32.whl", hash = "sha256:9edcc35d1cae9fd5320171b1a838c7da8a5c968af31e82ecc3dff30b4be0957f", size = 55986, upload-time = "2026-04-09T16:05:13.529Z" },
+    { url = "https://files.pythonhosted.org/packages/89/7a/ba1737012308c17dc6d5516143b5dce9a2c7ba3474afd54e11f44a4d1ef3/librt-0.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc2917258e131ae5f958a4d872e07555b51cb7466a43433218061c74ef33745", size = 63260, upload-time = "2026-04-09T16:05:14.68Z" },
+    { url = "https://files.pythonhosted.org/packages/36/e4/01752c113da15127f18f7bf11142f5640038f062407a611c059d0036c6aa/librt-0.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:90e6d5420fc8a300518d4d2288154ff45005e920425c22cbbfe8330f3f754bd9", size = 53694, upload-time = "2026-04-09T16:05:16.095Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/d7/1b3e26fffde1452d82f5666164858a81c26ebe808e7ae8c9c88628981540/librt-0.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f29b68cd9714531672db62cc54f6e8ff981900f824d13fa0e00749189e13778e", size = 68367, upload-time = "2026-04-09T16:05:17.243Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/5b/c61b043ad2e091fbe1f2d35d14795e545d0b56b03edaa390fa1dcee3d160/librt-0.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7d5c8a5929ac325729f6119802070b561f4db793dffc45e9ac750992a4ed4d22", size = 70595, upload-time = "2026-04-09T16:05:18.471Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/22/2448471196d8a73370aa2f23445455dc42712c21404081fcd7a03b9e0749/librt-0.9.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:756775d25ec8345b837ab52effee3ad2f3b2dfd6bbee3e3f029c517bd5d8f05a", size = 204354, upload-time = "2026-04-09T16:05:19.593Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5e/39fc4b153c78cfd2c8a2dcb32700f2d41d2312aa1050513183be4540930d/librt-0.9.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b8f5d00b49818f4e2b1667db994488b045835e0ac16fe2f924f3871bd2b8ac5", size = 216238, upload-time = "2026-04-09T16:05:20.868Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/42/bc2d02d0fa7badfa63aa8d6dcd8793a9f7ef5a94396801684a51ed8d8287/librt-0.9.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c81aef782380f0f13ead670aae01825eb653b44b046aa0e5ebbb79f76ed4aa11", size = 230589, upload-time = "2026-04-09T16:05:22.305Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/7b/e2d95cc513866373692aa5edf98080d5602dd07cabfb9e5d2f70df2f25f7/librt-0.9.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:66b58fed90a545328e80d575467244de3741e088c1af928f0b489ebec3ef3858", size = 224610, upload-time = "2026-04-09T16:05:23.647Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d5/6cec4607e998eaba57564d06a1295c21b0a0c8de76e4e74d699e627bd98c/librt-0.9.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e78fb7419e07d98c2af4b8567b72b3eaf8cb05caad642e9963465569c8b2d87e", size = 232558, upload-time = "2026-04-09T16:05:25.025Z" },
+    { url = "https://files.pythonhosted.org/packages/95/8c/27f1d8d3aaf079d3eb26439bf0b32f1482340c3552e324f7db9dca858671/librt-0.9.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2c3786f0f4490a5cd87f1ed6cefae833ad6b1060d52044ce0434a2e85893afd0", size = 225521, upload-time = "2026-04-09T16:05:26.311Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/d8/1e0d43b1c329b416017619469b3c3801a25a6a4ef4a1c68332aeaa6f72ca/librt-0.9.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:8494cfc61e03542f2d381e71804990b3931175a29b9278fdb4a5459948778dc2", size = 227789, upload-time = "2026-04-09T16:05:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/b4/d3d842e88610fcd4c8eec7067b0c23ef2d7d3bff31496eded6a83b0f99be/librt-0.9.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:07cf11f769831186eeac424376e6189f20ace4f7263e2134bdb9757340d84d4d", size = 248616, upload-time = "2026-04-09T16:05:29.181Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/28/527df8ad0d1eb6c8bdfa82fc190f1f7c4cca5a1b6d7b36aeabf95b52d74d/librt-0.9.0-cp313-cp313-win32.whl", hash = "sha256:850d6d03177e52700af605fd60db7f37dcb89782049a149674d1a9649c2138fd", size = 56039, upload-time = "2026-04-09T16:05:30.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a7/413652ad0d92273ee5e30c000fc494b361171177c83e57c060ecd3c21538/librt-0.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:a5af136bfba820d592f86c67affcef9b3ff4d4360ac3255e341e964489b48519", size = 63264, upload-time = "2026-04-09T16:05:31.881Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0a/92c244309b774e290ddb15e93363846ae7aa753d9586b8aad511c5e6145b/librt-0.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:4c4d0440a3a8e31d962340c3e1cc3fc9ee7febd34c8d8f770d06adb947779ea5", size = 53728, upload-time = "2026-04-09T16:05:33.31Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/c1/184e539543f06ea2912f4b92a5ffaede4f9b392689e3f00acbf8134bee92/librt-0.9.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:3f05d145df35dca5056a8bc3838e940efebd893a54b3e19b2dda39ceaa299bcb", size = 67830, upload-time = "2026-04-09T16:05:34.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ad/23399bdcb7afca819acacdef31b37ee59de261bd66b503a7995c03c4b0dc/librt-0.9.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1c587494461ebd42229d0f1739f3aa34237dd9980623ecf1be8d3bcba79f4499", size = 70280, upload-time = "2026-04-09T16:05:35.649Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/0b/4542dc5a2b8772dbf92cafb9194701230157e73c14b017b6961a23598b03/librt-0.9.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b0a2040f801406b93657a70b72fa12311063a319fee72ce98e1524da7200171f", size = 201925, upload-time = "2026-04-09T16:05:36.739Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d4/8ee7358b08fd0cfce051ef96695380f09b3c2c11b77c9bfbc367c921cce5/librt-0.9.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f38bc489037eca88d6ebefc9c4d41a4e07c8e8b4de5188a9e6d290273ad7ebb1", size = 212381, upload-time = "2026-04-09T16:05:38.043Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/94/a2025fe442abedf8b038038dab3dba942009ad42b38ea064a1a9e6094241/librt-0.9.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3fd278f5e6bf7c75ccd6d12344eb686cc020712683363b66f46ac79d37c799f", size = 227065, upload-time = "2026-04-09T16:05:39.394Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/e9/b9fcf6afa909f957cfbbf918802f9dada1bd5d3c1da43d722fd6a310dc3f/librt-0.9.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fcbdf2a9ca24e87bbebb47f1fe34e531ef06f104f98c9ccfc953a3f3344c567a", size = 221333, upload-time = "2026-04-09T16:05:40.999Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/7c/ba54cd6aa6a3c8cd12757a6870e0c79a64b1e6327f5248dcff98423f4d43/librt-0.9.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e306d956cfa027fe041585f02a1602c32bfa6bb8ebea4899d373383295a6c62f", size = 229051, upload-time = "2026-04-09T16:05:42.605Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4b/8cfdbad314c8677a0148bf0b70591d6d18587f9884d930276098a235461b/librt-0.9.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:465814ab157986acb9dfa5ccd7df944be5eefc0d08d31ec6e8d88bc71251d845", size = 222492, upload-time = "2026-04-09T16:05:43.842Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d1/2eda69563a1a88706808decdce035e4b32755dbfbb0d05e1a65db9547ed1/librt-0.9.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:703f4ae36d6240bfe24f542bac784c7e4194ec49c3ba5a994d02891649e2d85b", size = 223849, upload-time = "2026-04-09T16:05:45.054Z" },
+    { url = "https://files.pythonhosted.org/packages/04/44/b2ed37df6be5b3d42cfe36318e0598e80843d5c6308dd63d0bf4e0ce5028/librt-0.9.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3be322a15ee5e70b93b7a59cfd074614f22cc8c9ff18bd27f474e79137ea8d3b", size = 245001, upload-time = "2026-04-09T16:05:46.34Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e7/617e412426df89169dd2a9ed0cc8752d5763336252c65dbf945199915119/librt-0.9.0-cp314-cp314-win32.whl", hash = "sha256:b8da9f8035bb417770b1e1610526d87ad4fc58a2804dc4d79c53f6d2cf5a6eb9", size = 51799, upload-time = "2026-04-09T16:05:47.738Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ed/c22ca4db0ca3cbc285e4d9206108746beda561a9792289c3c31281d7e9df/librt-0.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:b8bd70d5d816566a580d193326912f4a76ec2d28a97dc4cd4cc831c0af8e330e", size = 59165, upload-time = "2026-04-09T16:05:49.198Z" },
+    { url = "https://files.pythonhosted.org/packages/24/56/875398fafa4cbc8f15b89366fc3287304ddd3314d861f182a4b87595ace0/librt-0.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:fc5758e2b7a56532dc33e3c544d78cbaa9ecf0a0f2a2da2df882c1d6b99a317f", size = 49292, upload-time = "2026-04-09T16:05:50.362Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/61/bc448ecbf9b2d69c5cff88fe41496b19ab2a1cbda0065e47d4d0d51c0867/librt-0.9.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:f24b90b0e0c8cc9491fb1693ae91fe17cb7963153a1946395acdbdd5818429a4", size = 70175, upload-time = "2026-04-09T16:05:51.564Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f2/c47bb71069a73e2f04e70acbd196c1e5cc411578ac99039a224b98920fd4/librt-0.9.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3fe56e80badb66fdcde06bef81bbaa5bfcf6fbd7aefb86222d9e369c38c6b228", size = 72951, upload-time = "2026-04-09T16:05:52.699Z" },
+    { url = "https://files.pythonhosted.org/packages/29/19/0549df59060631732df758e8886d92088da5fdbedb35b80e4643664e8412/librt-0.9.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:527b5b820b47a09e09829051452bb0d1dd2122261254e2a6f674d12f1d793d54", size = 225864, upload-time = "2026-04-09T16:05:53.895Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f8/3b144396d302ac08e50f89e64452c38db84bc7b23f6c60479c5d3abd303c/librt-0.9.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d429bdd4ac0ab17c8e4a8af0ed2a7440b16eba474909ab357131018fe8c7e71", size = 241155, upload-time = "2026-04-09T16:05:55.191Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/ce/ee67ec14581de4043e61d05786d2aed6c9b5338816b7859bcf07455c6a9f/librt-0.9.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7202bdcac47d3a708271c4304a474a8605a4a9a4a709e954bf2d3241140aa938", size = 252235, upload-time = "2026-04-09T16:05:56.549Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fa/0ead15daa2b293a54101550b08d4bafe387b7d4a9fc6d2b985602bae69b6/librt-0.9.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0d620e74897f8c2613b3c4e2e9c1e422eb46d2ddd07df540784d44117836af3", size = 244963, upload-time = "2026-04-09T16:05:57.858Z" },
+    { url = "https://files.pythonhosted.org/packages/29/68/9fbf9a9aa704ba87689e40017e720aced8d9a4d2b46b82451d8142f91ec9/librt-0.9.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d69fc39e627908f4c03297d5a88d9284b73f4d90b424461e32e8c2485e21c283", size = 257364, upload-time = "2026-04-09T16:05:59.686Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8d/9d60869f1b6716c762e45f66ed945b1e5dd649f7377684c3b176ae424648/librt-0.9.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:c2640e23d2b7c98796f123ffd95cf2022c7777aa8a4a3b98b36c570d37e85eee", size = 247661, upload-time = "2026-04-09T16:06:00.938Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ff/a5c365093962310bfdb4f6af256f191085078ffb529b3f0cbebb5b33ebe2/librt-0.9.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:451daa98463b7695b0a30aa56bf637831ea559e7b8101ac2ef6382e8eb15e29c", size = 248238, upload-time = "2026-04-09T16:06:02.537Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/3c/2d34365177f412c9e19c0a29f969d70f5343f27634b76b765a54d8b27705/librt-0.9.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:928bd06eca2c2bbf4349e5b817f837509b0604342e65a502de1d50a7570afd15", size = 269457, upload-time = "2026-04-09T16:06:03.833Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/cd/de45b239ea3bdf626f982a00c14bfcf2e12d261c510ba7db62c5969a27cd/librt-0.9.0-cp314-cp314t-win32.whl", hash = "sha256:a9c63e04d003bc0fb6a03b348018b9a3002f98268200e22cc80f146beac5dc40", size = 52453, upload-time = "2026-04-09T16:06:05.229Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/f9/bfb32ae428aa75c0c533915622176f0a17d6da7b72b5a3c6363685914f70/librt-0.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f162af66a2ed3f7d1d161a82ca584efd15acd9c1cff190a373458c32f7d42118", size = 60044, upload-time = "2026-04-09T16:06:06.398Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/47/7d70414bcdbb3bc1f458a8d10558f00bbfdb24e5a11740fc8197e12c3255/librt-0.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:a4b25c6c25cac5d0d9d6d6da855195b254e0021e513e0249f0e3b444dc6e0e61", size = 50009, upload-time = "2026-04-09T16:06:07.995Z" },
 ]
 
 [[package]]
@@ -1131,7 +1161,7 @@ wheels = [
 
 [[package]]
 name = "mypy"
-version = "1.19.1"
+version = "1.20.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
@@ -1139,27 +1169,37 @@ dependencies = [
     { name = "pathspec" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/db/4efed9504bc01309ab9c2da7e352cc223569f05478012b5d9ece38fd44d2/mypy-1.19.1.tar.gz", hash = "sha256:19d88bb05303fe63f71dd2c6270daca27cb9401c4ca8255fe50d1d920e0eb9ba", size = 3582404, upload-time = "2025-12-15T05:03:48.42Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/af/e3d4b3e9ec91a0ff9aabfdb38692952acf49bbb899c2e4c29acb3a6da3ae/mypy-1.20.2.tar.gz", hash = "sha256:e8222c26daaafd9e8626dec58ae36029f82585890589576f769a650dd20fd665", size = 3817349, upload-time = "2026-04-21T17:12:28.473Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/8a/19bfae96f6615aa8a0604915512e0289b1fad33d5909bf7244f02935d33a/mypy-1.19.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a8174a03289288c1f6c46d55cef02379b478bfbc8e358e02047487cad44c6ca1", size = 13206053, upload-time = "2025-12-15T05:03:46.622Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/34/3e63879ab041602154ba2a9f99817bb0c85c4df19a23a1443c8986e4d565/mypy-1.19.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffcebe56eb09ff0c0885e750036a095e23793ba6c2e894e7e63f6d89ad51f22e", size = 12219134, upload-time = "2025-12-15T05:03:24.367Z" },
-    { url = "https://files.pythonhosted.org/packages/89/cc/2db6f0e95366b630364e09845672dbee0cbf0bbe753a204b29a944967cd9/mypy-1.19.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b64d987153888790bcdb03a6473d321820597ab8dd9243b27a92153c4fa50fd2", size = 12731616, upload-time = "2025-12-15T05:02:44.725Z" },
-    { url = "https://files.pythonhosted.org/packages/00/be/dd56c1fd4807bc1eba1cf18b2a850d0de7bacb55e158755eb79f77c41f8e/mypy-1.19.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c35d298c2c4bba75feb2195655dfea8124d855dfd7343bf8b8c055421eaf0cf8", size = 13620847, upload-time = "2025-12-15T05:03:39.633Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/42/332951aae42b79329f743bf1da088cd75d8d4d9acc18fbcbd84f26c1af4e/mypy-1.19.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:34c81968774648ab5ac09c29a375fdede03ba253f8f8287847bd480782f73a6a", size = 13834976, upload-time = "2025-12-15T05:03:08.786Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/63/e7493e5f90e1e085c562bb06e2eb32cae27c5057b9653348d38b47daaecc/mypy-1.19.1-cp312-cp312-win_amd64.whl", hash = "sha256:b10e7c2cd7870ba4ad9b2d8a6102eb5ffc1f16ca35e3de6bfa390c1113029d13", size = 10118104, upload-time = "2025-12-15T05:03:10.834Z" },
-    { url = "https://files.pythonhosted.org/packages/de/9f/a6abae693f7a0c697dbb435aac52e958dc8da44e92e08ba88d2e42326176/mypy-1.19.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e3157c7594ff2ef1634ee058aafc56a82db665c9438fd41b390f3bde1ab12250", size = 13201927, upload-time = "2025-12-15T05:02:29.138Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/a4/45c35ccf6e1c65afc23a069f50e2c66f46bd3798cbe0d680c12d12935caa/mypy-1.19.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bdb12f69bcc02700c2b47e070238f42cb87f18c0bc1fc4cdb4fb2bc5fd7a3b8b", size = 12206730, upload-time = "2025-12-15T05:03:01.325Z" },
-    { url = "https://files.pythonhosted.org/packages/05/bb/cdcf89678e26b187650512620eec8368fded4cfd99cfcb431e4cdfd19dec/mypy-1.19.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f859fb09d9583a985be9a493d5cfc5515b56b08f7447759a0c5deaf68d80506e", size = 12724581, upload-time = "2025-12-15T05:03:20.087Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/32/dd260d52babf67bad8e6770f8e1102021877ce0edea106e72df5626bb0ec/mypy-1.19.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c9a6538e0415310aad77cb94004ca6482330fece18036b5f360b62c45814c4ef", size = 13616252, upload-time = "2025-12-15T05:02:49.036Z" },
-    { url = "https://files.pythonhosted.org/packages/71/d0/5e60a9d2e3bd48432ae2b454b7ef2b62a960ab51292b1eda2a95edd78198/mypy-1.19.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:da4869fc5e7f62a88f3fe0b5c919d1d9f7ea3cef92d3689de2823fd27e40aa75", size = 13840848, upload-time = "2025-12-15T05:02:55.95Z" },
-    { url = "https://files.pythonhosted.org/packages/98/76/d32051fa65ecf6cc8c6610956473abdc9b4c43301107476ac03559507843/mypy-1.19.1-cp313-cp313-win_amd64.whl", hash = "sha256:016f2246209095e8eda7538944daa1d60e1e8134d98983b9fc1e92c1fc0cb8dd", size = 10135510, upload-time = "2025-12-15T05:02:58.438Z" },
-    { url = "https://files.pythonhosted.org/packages/de/eb/b83e75f4c820c4247a58580ef86fcd35165028f191e7e1ba57128c52782d/mypy-1.19.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06e6170bd5836770e8104c8fdd58e5e725cfeb309f0a6c681a811f557e97eac1", size = 13199744, upload-time = "2025-12-15T05:03:30.823Z" },
-    { url = "https://files.pythonhosted.org/packages/94/28/52785ab7bfa165f87fcbb61547a93f98bb20e7f82f90f165a1f69bce7b3d/mypy-1.19.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:804bd67b8054a85447c8954215a906d6eff9cabeabe493fb6334b24f4bfff718", size = 12215815, upload-time = "2025-12-15T05:02:42.323Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/c6/bdd60774a0dbfb05122e3e925f2e9e846c009e479dcec4821dad881f5b52/mypy-1.19.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21761006a7f497cb0d4de3d8ef4ca70532256688b0523eee02baf9eec895e27b", size = 12740047, upload-time = "2025-12-15T05:03:33.168Z" },
-    { url = "https://files.pythonhosted.org/packages/32/2a/66ba933fe6c76bd40d1fe916a83f04fed253152f451a877520b3c4a5e41e/mypy-1.19.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:28902ee51f12e0f19e1e16fbe2f8f06b6637f482c459dd393efddd0ec7f82045", size = 13601998, upload-time = "2025-12-15T05:03:13.056Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/da/5055c63e377c5c2418760411fd6a63ee2b96cf95397259038756c042574f/mypy-1.19.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:481daf36a4c443332e2ae9c137dfee878fcea781a2e3f895d54bd3002a900957", size = 13807476, upload-time = "2025-12-15T05:03:17.977Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/09/4ebd873390a063176f06b0dbf1f7783dd87bd120eae7727fa4ae4179b685/mypy-1.19.1-cp314-cp314-win_amd64.whl", hash = "sha256:8bb5c6f6d043655e055be9b542aa5f3bdd30e4f3589163e85f93f3640060509f", size = 10281872, upload-time = "2025-12-15T05:03:05.549Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/f4/4ce9a05ce5ded1de3ec1c1d96cf9f9504a04e54ce0ed55cfa38619a32b8d/mypy-1.19.1-py3-none-any.whl", hash = "sha256:f1235f5ea01b7db5468d53ece6aaddf1ad0b88d9e7462b86ef96fe04995d7247", size = 2471239, upload-time = "2025-12-15T05:03:07.248Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4e/7560e4528db9e9b147e4c0f22660466bf30a0a1fe3d63d1b9d3b0fd354ee/mypy-1.20.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4dbfcf869f6b0517f70cf0030ba6ea1d6645e132337a7d5204a18d8d5636c02b", size = 14539393, upload-time = "2026-04-21T17:07:12.52Z" },
+    { url = "https://files.pythonhosted.org/packages/32/d9/34a5efed8124f5a9234f55ac6a4ced4201e2c5b81e1109c49ad23190ec8c/mypy-1.20.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4b6481b228d072315b053210b01ac320e1be243dc17f9e5887ef167f23f5fae4", size = 13361642, upload-time = "2026-04-21T17:06:53.742Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/14/eb377acf78c03c92d566a1510cda8137348215b5335085ef662ab82ecd3a/mypy-1.20.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:34397cdced6b90b836e38182076049fdb41424322e0b0728c946b0939ebdf9f6", size = 13740347, upload-time = "2026-04-21T17:12:04.73Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/94/7e4634a32b641aa1c112422eed1bbece61ee16205f674190e8b536f884de/mypy-1.20.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5da6976f20cae27059ea8d0c86e7cef3de720e04c4bb9ee18e3690fdb792066", size = 14734042, upload-time = "2026-04-21T17:07:43.16Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f3/f7e62395cb7f434541b4491a01149a4439e28ace4c0c632bbf5431e92d1f/mypy-1.20.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:56908d7e08318d39f85b1f0c6cfd47b0cac1a130da677630dac0de3e0623e102", size = 14964958, upload-time = "2026-04-21T17:11:00.665Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/0d/47e3c3a0ec2a876e35aeac365df3cac7776c36bbd4ed18cc521e1b9d255b/mypy-1.20.2-cp312-cp312-win_amd64.whl", hash = "sha256:d52ad8d78522da1d308789df651ee5379088e77c76cb1994858d40a426b343b9", size = 10911340, upload-time = "2026-04-21T17:10:49.179Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/b2/6c852d72e0ea8b01f49da817fb52539993cde327e7d010e0103dc12d0dac/mypy-1.20.2-cp312-cp312-win_arm64.whl", hash = "sha256:785b08db19c9f214dc37d65f7c165d19a30fcecb48abfa30f31b01b5acaabb58", size = 9833947, upload-time = "2026-04-21T17:09:05.267Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/c4/b93812d3a192c9bcf5df405bd2f30277cd0e48106a14d1023c7f6ed6e39b/mypy-1.20.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:edfbfca868cdd6bd8d974a60f8a3682f5565d3f5c99b327640cedd24c4264026", size = 14524670, upload-time = "2026-04-21T17:10:30.737Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/47/42c122501bff18eaf1e8f457f5c017933452d8acdc52918a9f59f6812955/mypy-1.20.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e2877a02380adfcdbc69071a0f74d6e9dbbf593c0dc9d174e1f223ffd5281943", size = 13336218, upload-time = "2026-04-21T17:08:44.069Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/75bbc92f41725fbd585fb17b440b1119b576105df1013622983e18640a93/mypy-1.20.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7488448de6007cd5177c6cea0517ac33b4c0f5ee9b5e9f2be51ce75511a85517", size = 13724906, upload-time = "2026-04-21T17:08:01.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/32/4c49da27a606167391ff0c39aa955707a00edc500572e562f7c36c08a71f/mypy-1.20.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bb9c2fa06887e21d6a3a868762acb82aec34e2c6fd0174064f27c93ede68ad15", size = 14726046, upload-time = "2026-04-21T17:11:22.354Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/fc/4e354a1bd70216359deb0c9c54847ee6b32ef78dfb09f5131ff99b494078/mypy-1.20.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9d56a78b646f2e3daa865bc70cd5ec5a46c50045801ca8ff17a0c43abc97e3ee", size = 14955587, upload-time = "2026-04-21T17:12:16.033Z" },
+    { url = "https://files.pythonhosted.org/packages/62/b2/c0f2056e9eb8f08c62cafd9715e4584b89132bdc832fcf85d27d07b5f3e5/mypy-1.20.2-cp313-cp313-win_amd64.whl", hash = "sha256:2a4102b03bb7481d9a91a6da8d174740c9c8c4401024684b9ca3b7cc5e49852f", size = 10922681, upload-time = "2026-04-21T17:06:35.842Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/14/065e333721f05de8ef683d0aa804c23026bcc287446b61cac657b902ccac/mypy-1.20.2-cp313-cp313-win_arm64.whl", hash = "sha256:a95a9248b0c6fd933a442c03c3b113c3b61320086b88e2c444676d3fd1ca3330", size = 9830560, upload-time = "2026-04-21T17:07:51.023Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/d1/b4ec96b0ecc620a4443570c6e95c867903428cfcde4206518eafdd5880c3/mypy-1.20.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:419413398fe250aae057fd2fe50166b61077083c9b82754c341cf4fd73038f30", size = 14524561, upload-time = "2026-04-21T17:06:27.325Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/63/d2c2ff4fa66bc49477d32dfa26e8a167ba803ea6a69c5efb416036909d30/mypy-1.20.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e73c07f23009962885c197ccb9b41356a30cc0e5a1d0c2ea8fd8fb1362d7f924", size = 13363883, upload-time = "2026-04-21T17:11:11.239Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/56/983916806bf4eddeaaa2c9230903c3669c6718552a921154e1c5182c701f/mypy-1.20.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c64e5973df366b747646fc98da921f9d6eba9716d57d1db94a83c026a08e0fb", size = 13742945, upload-time = "2026-04-21T17:08:34.181Z" },
+    { url = "https://files.pythonhosted.org/packages/19/65/0cd9285ab010ee8214c83d67c6b49417c40d86ce46f1aa109457b5a9b8d7/mypy-1.20.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a65aa591af023864fd08a97da9974e919452cfe19cb146c8a5dc692626445dc", size = 14706163, upload-time = "2026-04-21T17:05:15.51Z" },
+    { url = "https://files.pythonhosted.org/packages/94/97/48ff3b297cafcc94d185243a9190836fb1b01c1b0918fff64e941e973cc9/mypy-1.20.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4fef51b01e638974a6e69885687e9bd40c8d1e09a6cd291cca0619625cf1f558", size = 14938677, upload-time = "2026-04-21T17:05:39.562Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a1/1b4233d255bdd0b38a1f284feeb1c143ca508c19184964e22f8d837ec851/mypy-1.20.2-cp314-cp314-win_amd64.whl", hash = "sha256:913485a03f1bcf5d279409a9d2b9ed565c151f61c09f29991e5faa14033da4c8", size = 11089322, upload-time = "2026-04-21T17:06:44.29Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c2/ce7ee2ba36aeb954ba50f18fa25d9c1188578654b97d02a66a15b6f09531/mypy-1.20.2-cp314-cp314-win_arm64.whl", hash = "sha256:c3bae4f855d965b5453784300c12ffc63a548304ac7f99e55d4dc7c898673aa3", size = 10017775, upload-time = "2026-04-21T17:07:20.732Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/a1/9d93a7d0b5859af0ead82b4888b46df6c8797e1bc5e1e262a08518c6d48e/mypy-1.20.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2de3dcea53babc1c3237a19002bc3d228ce1833278f093b8d619e06e7cc79609", size = 15549002, upload-time = "2026-04-21T17:08:23.107Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d2/09a6a10ee1bf0008f6c144d9676f2ca6a12512151b4e0ad0ff6c4fac5337/mypy-1.20.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:52b176444e2e5054dfcbcb8c75b0b719865c96247b37407184bbfca5c353f2c2", size = 14401942, upload-time = "2026-04-21T17:07:31.837Z" },
+    { url = "https://files.pythonhosted.org/packages/57/da/9594b75c3c019e805250bed3583bdf4443ff9e6ef08f97e39ae308cb06f2/mypy-1.20.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:688c3312e5dadb573a2c69c82af3a298d43ecf9e6d264e0f95df960b5f6ac19c", size = 15041649, upload-time = "2026-04-21T17:09:34.653Z" },
+    { url = "https://files.pythonhosted.org/packages/97/77/f75a65c278e6e8eba2071f7f5a90481891053ecc39878cc444634d892abe/mypy-1.20.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29752dbbf8cc53f89f6ac096d363314333045c257c9c75cbd189ca2de0455744", size = 15864588, upload-time = "2026-04-21T17:11:44.936Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/46/1a4e1c66e96c1a3246ddf5403d122ac9b0a8d2b7e65730b9d6533ba7a6d3/mypy-1.20.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:803203d2b6ea644982c644895c2f78b28d0e208bba7b27d9b921e0ec5eb207c6", size = 16093956, upload-time = "2026-04-21T17:10:17.683Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/2c/78a8851264dec38cd736ca5b8bc9380674df0dd0be7792f538916157716c/mypy-1.20.2-cp314-cp314t-win_amd64.whl", hash = "sha256:9bcb8aa397ff0093c824182fd76a935a9ba7ad097fcbef80ae89bf6c1731d8ec", size = 12568661, upload-time = "2026-04-21T17:11:54.473Z" },
+    { url = "https://files.pythonhosted.org/packages/83/01/cd7318aa03493322ce275a0e14f4f52b8896335e4e79d4fb8153a7ad2b77/mypy-1.20.2-cp314-cp314t-win_arm64.whl", hash = "sha256:e061b58443f1736f8a37c48978d7ab581636d6ab03e3d4f99e3fa90463bb9382", size = 10389240, upload-time = "2026-04-21T17:09:42.719Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/f23c163e25b11074188251b0b5a0342625fc1cdb6af604757174fa9acc9b/mypy-1.20.2-py3-none-any.whl", hash = "sha256:a94c5a76ab46c5e6257c7972b6c8cff0574201ca7dc05647e33e795d78680563", size = 2637314, upload-time = "2026-04-21T17:05:54.5Z" },
 ]
 
 [[package]]
@@ -1182,7 +1222,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/97/73/8ade73f6749177003
 
 [[package]]
 name = "openai"
-version = "2.20.0"
+version = "2.34.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1194,9 +1234,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/5a/f495777c02625bfa18212b6e3b73f1893094f2bf660976eb4bc6f43a1ca2/openai-2.20.0.tar.gz", hash = "sha256:2654a689208cd0bf1098bb9462e8d722af5cbe961e6bba54e6f19fb843d88db1", size = 642355, upload-time = "2026-02-10T19:02:54.145Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/89/f1e78f5f828f4e97a6ebca8f45c6b35667da12b074ac490dc8362b882279/openai-2.34.0.tar.gz", hash = "sha256:828b4efcbb126352c2b5eb97d33ae890c92a71ab72511aefc1b7fe64aeccb07b", size = 759556, upload-time = "2026-05-04T17:34:08.721Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/a0/cf4297aa51bbc21e83ef0ac018947fa06aea8f2364aad7c96cbf148590e6/openai-2.20.0-py3-none-any.whl", hash = "sha256:38d989c4b1075cd1f76abc68364059d822327cf1a932531d429795f4fc18be99", size = 1098479, upload-time = "2026-02-10T19:02:52.157Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/40/f090499f10514515081d09cb9da09f25b821eb20497e9423afe4f07b4ecf/openai-2.34.0-py3-none-any.whl", hash = "sha256:c996a71b1a210f3569844572ad4c609307e978515fb76877cf449b72596e549e", size = 1316535, upload-time = "2026-05-04T17:34:06.773Z" },
 ]
 
 [[package]]
@@ -1232,11 +1272,11 @@ wheels = [
 
 [[package]]
 name = "phonenumbers"
-version = "9.0.23"
+version = "9.0.29"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e5/1a/d1a90630b5f5e6ff3918f1ab6958430c051c3f311610780bcd9bc7200a5d/phonenumbers-9.0.23.tar.gz", hash = "sha256:e5aa44844684ffb4928f25a7b8c31dbf6e3763138cb13edd2ab03bf6d4803d98", size = 2298342, upload-time = "2026-02-04T15:58:16.916Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/c3/5b544d133241d649317c0ef456df4705cddb3968d31b5f64ec34e98925aa/phonenumbers-9.0.29.tar.gz", hash = "sha256:66455e5c5ca4197aca5a4217d0dc82717a22038292cfa322d5d5e7c46934a214", size = 2300063, upload-time = "2026-04-25T05:35:37.574Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/91/17099726260627a23109abf9590b02f08ff3798e3722d760a1f142d9932d/phonenumbers-9.0.23-py2.py3-none-any.whl", hash = "sha256:f29651fb72ba4d22d2691bb0b432f1d2c93fd49cc7b89aa6c11bd6b0e4167412", size = 2584396, upload-time = "2026-02-04T15:58:13.529Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/65/d932a84540a2d188c5d0dc3a80d7063820588bbc310cc59b4fe48619be9e/phonenumbers-9.0.29-py2.py3-none-any.whl", hash = "sha256:0eb26e0c578aa2d56428330d5b4a0a07dac9a452c4387bf76a76a88b1e839ab7", size = 2586805, upload-time = "2026-04-25T05:35:34.081Z" },
 ]
 
 [[package]]
@@ -1372,16 +1412,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.12.0"
+version = "2.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/43/4b/ac7e0aae12027748076d72a8764ff1c9d82ca75a7a52622e67ed3f765c54/pydantic_settings-2.12.0.tar.gz", hash = "sha256:005538ef951e3c2a68e1c08b292b5f2e71490def8589d4221b95dab00dafcfd0", size = 194184, upload-time = "2025-11-10T14:25:47.013Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709, upload-time = "2026-04-20T13:37:40.293Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/60/5d4751ba3f4a40a6891f24eec885f51afd78d208498268c734e256fb13c4/pydantic_settings-2.12.0-py3-none-any.whl", hash = "sha256:fddb9fd99a5b18da837b29710391e945b1e30c135477f484084ee513adb93809", size = 51880, upload-time = "2025-11-10T14:25:45.546Z" },
+    { url = "https://files.pythonhosted.org/packages/01/dd/bebff3040138f00ae8a102d426b27349b9a49acc310fcae7f92112d867e3/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e", size = 60940, upload-time = "2026-04-20T13:37:38.586Z" },
 ]
 
 [[package]]
@@ -1395,15 +1435,15 @@ wheels = [
 
 [[package]]
 name = "pyopenssl"
-version = "25.3.0"
+version = "26.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/be/97b83a464498a79103036bc74d1038df4a7ef0e402cfaf4d5e113fb14759/pyopenssl-25.3.0.tar.gz", hash = "sha256:c981cb0a3fd84e8602d7afc209522773b94c1c2446a3c710a75b06fe1beae329", size = 184073, upload-time = "2025-09-17T00:32:21.037Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/51/27a5ad5f939d08f690a326ef9582cda7140555180db71695f6fb747d6a36/pyopenssl-26.2.0.tar.gz", hash = "sha256:8c6fcecd1183a7fc897548dfe388b0cdb7f37e018200d8409cf33959dbe35387", size = 182195, upload-time = "2026-05-04T23:06:09.72Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/81/ef2b1dfd1862567d573a4fdbc9f969067621764fbb74338496840a1d2977/pyopenssl-25.3.0-py3-none-any.whl", hash = "sha256:1fda6fc034d5e3d179d39e59c1895c9faeaf40a79de5fc4cbbfbe0d36f4a77b6", size = 57268, upload-time = "2025-09-17T00:32:19.474Z" },
+    { url = "https://files.pythonhosted.org/packages/73/b8/a0e2790ae249d6f38c9f66de7a211621a7ab2650217bcd04e1262f578a56/pyopenssl-26.2.0-py3-none-any.whl", hash = "sha256:4f9d971bc5298b8bc1fab282803da04bf000c755d4ad9d99b52de2569ca19a70", size = 55823, upload-time = "2026-05-04T23:06:08.395Z" },
 ]
 
 [[package]]
@@ -1420,7 +1460,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1429,9 +1469,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -1449,16 +1489,16 @@ wheels = [
 
 [[package]]
 name = "pytest-cov"
-version = "7.0.0"
+version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "coverage" },
     { name = "pluggy" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]
@@ -1498,11 +1538,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.27"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
 ]
 
 [[package]]
@@ -1648,27 +1688,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.0"
+version = "0.15.12"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c8/39/5cee96809fbca590abea6b46c6d1c586b49663d1d2830a751cc8fc42c666/ruff-0.15.0.tar.gz", hash = "sha256:6bdea47cdbea30d40f8f8d7d69c0854ba7c15420ec75a26f463290949d7f7e9a", size = 4524893, upload-time = "2026-02-03T17:53:35.357Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/88/3fd1b0aa4b6330d6aaa63a285bc96c9f71970351579152d231ed90914586/ruff-0.15.0-py3-none-linux_armv6l.whl", hash = "sha256:aac4ebaa612a82b23d45964586f24ae9bc23ca101919f5590bdb368d74ad5455", size = 10354332, upload-time = "2026-02-03T17:52:54.892Z" },
-    { url = "https://files.pythonhosted.org/packages/72/f6/62e173fbb7eb75cc29fe2576a1e20f0a46f671a2587b5f604bfb0eaf5f6f/ruff-0.15.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:dcd4be7cc75cfbbca24a98d04d0b9b36a270d0833241f776b788d59f4142b14d", size = 10767189, upload-time = "2026-02-03T17:53:19.778Z" },
-    { url = "https://files.pythonhosted.org/packages/99/e4/968ae17b676d1d2ff101d56dc69cf333e3a4c985e1ec23803df84fc7bf9e/ruff-0.15.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d747e3319b2bce179c7c1eaad3d884dc0a199b5f4d5187620530adf9105268ce", size = 10075384, upload-time = "2026-02-03T17:53:29.241Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/bf/9843c6044ab9e20af879c751487e61333ca79a2c8c3058b15722386b8cae/ruff-0.15.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:650bd9c56ae03102c51a5e4b554d74d825ff3abe4db22b90fd32d816c2e90621", size = 10481363, upload-time = "2026-02-03T17:52:43.332Z" },
-    { url = "https://files.pythonhosted.org/packages/55/d9/4ada5ccf4cd1f532db1c8d44b6f664f2208d3d93acbeec18f82315e15193/ruff-0.15.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a6664b7eac559e3048223a2da77769c2f92b43a6dfd4720cef42654299a599c9", size = 10187736, upload-time = "2026-02-03T17:53:00.522Z" },
-    { url = "https://files.pythonhosted.org/packages/86/e2/f25eaecd446af7bb132af0a1d5b135a62971a41f5366ff41d06d25e77a91/ruff-0.15.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6f811f97b0f092b35320d1556f3353bf238763420ade5d9e62ebd2b73f2ff179", size = 10968415, upload-time = "2026-02-03T17:53:15.705Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/dc/f06a8558d06333bf79b497d29a50c3a673d9251214e0d7ec78f90b30aa79/ruff-0.15.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:761ec0a66680fab6454236635a39abaf14198818c8cdf691e036f4bc0f406b2d", size = 11809643, upload-time = "2026-02-03T17:53:23.031Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/45/0ece8db2c474ad7df13af3a6d50f76e22a09d078af63078f005057ca59eb/ruff-0.15.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:940f11c2604d317e797b289f4f9f3fa5555ffe4fb574b55ed006c3d9b6f0eb78", size = 11234787, upload-time = "2026-02-03T17:52:46.432Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/d9/0e3a81467a120fd265658d127db648e4d3acfe3e4f6f5d4ea79fac47e587/ruff-0.15.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bcbca3d40558789126da91d7ef9a7c87772ee107033db7191edefa34e2c7f1b4", size = 11112797, upload-time = "2026-02-03T17:52:49.274Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/cb/8c0b3b0c692683f8ff31351dfb6241047fa873a4481a76df4335a8bff716/ruff-0.15.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9a121a96db1d75fa3eb39c4539e607f628920dd72ff1f7c5ee4f1b768ac62d6e", size = 11033133, upload-time = "2026-02-03T17:53:33.105Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/5e/23b87370cf0f9081a8c89a753e69a4e8778805b8802ccfe175cc410e50b9/ruff-0.15.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5298d518e493061f2eabd4abd067c7e4fb89e2f63291c94332e35631c07c3662", size = 10442646, upload-time = "2026-02-03T17:53:06.278Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/9a/3c94de5ce642830167e6d00b5c75aacd73e6347b4c7fc6828699b150a5ee/ruff-0.15.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:afb6e603d6375ff0d6b0cee563fa21ab570fd15e65c852cb24922cef25050cf1", size = 10195750, upload-time = "2026-02-03T17:53:26.084Z" },
-    { url = "https://files.pythonhosted.org/packages/30/15/e396325080d600b436acc970848d69df9c13977942fb62bb8722d729bee8/ruff-0.15.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:77e515f6b15f828b94dc17d2b4ace334c9ddb7d9468c54b2f9ed2b9c1593ef16", size = 10676120, upload-time = "2026-02-03T17:53:09.363Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/c9/229a23d52a2983de1ad0fb0ee37d36e0257e6f28bfd6b498ee2c76361874/ruff-0.15.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:6f6e80850a01eb13b3e42ee0ebdf6e4497151b48c35051aab51c101266d187a3", size = 11201636, upload-time = "2026-02-03T17:52:57.281Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/b0/69adf22f4e24f3677208adb715c578266842e6e6a3cc77483f48dd999ede/ruff-0.15.0-py3-none-win32.whl", hash = "sha256:238a717ef803e501b6d51e0bdd0d2c6e8513fe9eec14002445134d3907cd46c3", size = 10465945, upload-time = "2026-02-03T17:53:12.591Z" },
-    { url = "https://files.pythonhosted.org/packages/51/ad/f813b6e2c97e9b4598be25e94a9147b9af7e60523b0cb5d94d307c15229d/ruff-0.15.0-py3-none-win_amd64.whl", hash = "sha256:dd5e4d3301dc01de614da3cdffc33d4b1b96fb89e45721f1598e5532ccf78b18", size = 11564657, upload-time = "2026-02-03T17:52:51.893Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/b0/2d823f6e77ebe560f4e397d078487e8d52c1516b331e3521bc75db4272ca/ruff-0.15.0-py3-none-win_arm64.whl", hash = "sha256:c480d632cc0ca3f0727acac8b7d053542d9e114a462a145d0b00e7cd658c515a", size = 10865753, upload-time = "2026-02-03T17:53:03.014Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
 ]
 
 [[package]]
@@ -1704,44 +1744,48 @@ wheels = [
 
 [[package]]
 name = "sqlalchemy"
-version = "2.0.46"
+version = "2.0.49"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/aa/9ce0f3e7a9829ead5c8ce549392f33a12c4555a6c0609bb27d882e9c7ddf/sqlalchemy-2.0.46.tar.gz", hash = "sha256:cf36851ee7219c170bb0793dbc3da3e80c582e04a5437bc601bfe8c85c9216d7", size = 9865393, upload-time = "2026-01-21T18:03:45.119Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/45/461788f35e0364a8da7bda51a1fe1b09762d0c32f12f63727998d85a873b/sqlalchemy-2.0.49.tar.gz", hash = "sha256:d15950a57a210e36dd4cec1aac22787e2a4d57ba9318233e2ef8b2daf9ff2d5f", size = 9898221, upload-time = "2026-04-03T16:38:11.704Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/35/d16bfa235c8b7caba3730bba43e20b1e376d2224f407c178fbf59559f23e/sqlalchemy-2.0.46-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3a9a72b0da8387f15d5810f1facca8f879de9b85af8c645138cba61ea147968c", size = 2153405, upload-time = "2026-01-21T19:05:54.143Z" },
-    { url = "https://files.pythonhosted.org/packages/06/6c/3192e24486749862f495ddc6584ed730c0c994a67550ec395d872a2ad650/sqlalchemy-2.0.46-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2347c3f0efc4de367ba00218e0ae5c4ba2306e47216ef80d6e31761ac97cb0b9", size = 3334702, upload-time = "2026-01-21T18:46:45.384Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/a2/b9f33c8d68a3747d972a0bb758c6b63691f8fb8a49014bc3379ba15d4274/sqlalchemy-2.0.46-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9094c8b3197db12aa6f05c51c05daaad0a92b8c9af5388569847b03b1007fb1b", size = 3347664, upload-time = "2026-01-21T18:40:09.979Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/d2/3e59e2a91eaec9db7e8dc6b37b91489b5caeb054f670f32c95bcba98940f/sqlalchemy-2.0.46-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:37fee2164cf21417478b6a906adc1a91d69ae9aba8f9533e67ce882f4bb1de53", size = 3277372, upload-time = "2026-01-21T18:46:47.168Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/dd/67bc2e368b524e2192c3927b423798deda72c003e73a1e94c21e74b20a85/sqlalchemy-2.0.46-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b1e14b2f6965a685c7128bd315e27387205429c2e339eeec55cb75ca4ab0ea2e", size = 3312425, upload-time = "2026-01-21T18:40:11.548Z" },
-    { url = "https://files.pythonhosted.org/packages/43/82/0ecd68e172bfe62247e96cb47867c2d68752566811a4e8c9d8f6e7c38a65/sqlalchemy-2.0.46-cp312-cp312-win32.whl", hash = "sha256:412f26bb4ba942d52016edc8d12fb15d91d3cd46b0047ba46e424213ad407bcb", size = 2113155, upload-time = "2026-01-21T18:42:49.748Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/2a/2821a45742073fc0331dc132552b30de68ba9563230853437cac54b2b53e/sqlalchemy-2.0.46-cp312-cp312-win_amd64.whl", hash = "sha256:ea3cd46b6713a10216323cda3333514944e510aa691c945334713fca6b5279ff", size = 2140078, upload-time = "2026-01-21T18:42:51.197Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/4b/fa7838fe20bb752810feed60e45625a9a8b0102c0c09971e2d1d95362992/sqlalchemy-2.0.46-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:93a12da97cca70cea10d4b4fc602589c4511f96c1f8f6c11817620c021d21d00", size = 2150268, upload-time = "2026-01-21T19:05:56.621Z" },
-    { url = "https://files.pythonhosted.org/packages/46/c1/b34dccd712e8ea846edf396e00973dda82d598cb93762e55e43e6835eba9/sqlalchemy-2.0.46-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:af865c18752d416798dae13f83f38927c52f085c52e2f32b8ab0fef46fdd02c2", size = 3276511, upload-time = "2026-01-21T18:46:49.022Z" },
-    { url = "https://files.pythonhosted.org/packages/96/48/a04d9c94753e5d5d096c628c82a98c4793b9c08ca0e7155c3eb7d7db9f24/sqlalchemy-2.0.46-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8d679b5f318423eacb61f933a9a0f75535bfca7056daeadbf6bd5bcee6183aee", size = 3292881, upload-time = "2026-01-21T18:40:13.089Z" },
-    { url = "https://files.pythonhosted.org/packages/be/f4/06eda6e91476f90a7d8058f74311cb65a2fb68d988171aced81707189131/sqlalchemy-2.0.46-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64901e08c33462acc9ec3bad27fc7a5c2b6491665f2aa57564e57a4f5d7c52ad", size = 3224559, upload-time = "2026-01-21T18:46:50.974Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/a2/d2af04095412ca6345ac22b33b89fe8d6f32a481e613ffcb2377d931d8d0/sqlalchemy-2.0.46-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e8ac45e8f4eaac0f9f8043ea0e224158855c6a4329fd4ee37c45c61e3beb518e", size = 3262728, upload-time = "2026-01-21T18:40:14.883Z" },
-    { url = "https://files.pythonhosted.org/packages/31/48/1980c7caa5978a3b8225b4d230e69a2a6538a3562b8b31cea679b6933c83/sqlalchemy-2.0.46-cp313-cp313-win32.whl", hash = "sha256:8d3b44b3d0ab2f1319d71d9863d76eeb46766f8cf9e921ac293511804d39813f", size = 2111295, upload-time = "2026-01-21T18:42:52.366Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/54/f8d65bbde3d877617c4720f3c9f60e99bb7266df0d5d78b6e25e7c149f35/sqlalchemy-2.0.46-cp313-cp313-win_amd64.whl", hash = "sha256:77f8071d8fbcbb2dd11b7fd40dedd04e8ebe2eb80497916efedba844298065ef", size = 2137076, upload-time = "2026-01-21T18:42:53.924Z" },
-    { url = "https://files.pythonhosted.org/packages/56/ba/9be4f97c7eb2b9d5544f2624adfc2853e796ed51d2bb8aec90bc94b7137e/sqlalchemy-2.0.46-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1e8cc6cc01da346dc92d9509a63033b9b1bda4fed7a7a7807ed385c7dccdc10", size = 3556533, upload-time = "2026-01-21T18:33:06.636Z" },
-    { url = "https://files.pythonhosted.org/packages/20/a6/b1fc6634564dbb4415b7ed6419cdfeaadefd2c39cdab1e3aa07a5f2474c2/sqlalchemy-2.0.46-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:96c7cca1a4babaaf3bfff3e4e606e38578856917e52f0384635a95b226c87764", size = 3523208, upload-time = "2026-01-21T18:45:08.436Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/d8/41e0bdfc0f930ff236f86fccd12962d8fa03713f17ed57332d38af6a3782/sqlalchemy-2.0.46-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b2a9f9aee38039cf4755891a1e50e1effcc42ea6ba053743f452c372c3152b1b", size = 3464292, upload-time = "2026-01-21T18:33:08.208Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/8b/9dcbec62d95bea85f5ecad9b8d65b78cc30fb0ffceeb3597961f3712549b/sqlalchemy-2.0.46-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:db23b1bf8cfe1f7fda19018e7207b20cdb5168f83c437ff7e95d19e39289c447", size = 3473497, upload-time = "2026-01-21T18:45:10.552Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/f8/5ecdfc73383ec496de038ed1614de9e740a82db9ad67e6e4514ebc0708a3/sqlalchemy-2.0.46-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:56bdd261bfd0895452006d5316cbf35739c53b9bb71a170a331fa0ea560b2ada", size = 2152079, upload-time = "2026-01-21T19:05:58.477Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/bf/eba3036be7663ce4d9c050bc3d63794dc29fbe01691f2bf5ccb64e048d20/sqlalchemy-2.0.46-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:33e462154edb9493f6c3ad2125931e273bbd0be8ae53f3ecd1c161ea9a1dd366", size = 3272216, upload-time = "2026-01-21T18:46:52.634Z" },
-    { url = "https://files.pythonhosted.org/packages/05/45/1256fb597bb83b58a01ddb600c59fe6fdf0e5afe333f0456ed75c0f8d7bd/sqlalchemy-2.0.46-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9bcdce05f056622a632f1d44bb47dbdb677f58cad393612280406ce37530eb6d", size = 3277208, upload-time = "2026-01-21T18:40:16.38Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/a0/2053b39e4e63b5d7ceb3372cface0859a067c1ddbd575ea7e9985716f771/sqlalchemy-2.0.46-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e84b09a9b0f19accedcbeff5c2caf36e0dd537341a33aad8d680336152dc34e", size = 3221994, upload-time = "2026-01-21T18:46:54.622Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/87/97713497d9502553c68f105a1cb62786ba1ee91dea3852ae4067ed956a50/sqlalchemy-2.0.46-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4f52f7291a92381e9b4de9050b0a65ce5d6a763333406861e33906b8aa4906bf", size = 3243990, upload-time = "2026-01-21T18:40:18.253Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/87/5d1b23548f420ff823c236f8bea36b1a997250fd2f892e44a3838ca424f4/sqlalchemy-2.0.46-cp314-cp314-win32.whl", hash = "sha256:70ed2830b169a9960193f4d4322d22be5c0925357d82cbf485b3369893350908", size = 2114215, upload-time = "2026-01-21T18:42:55.232Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/20/555f39cbcf0c10cf452988b6a93c2a12495035f68b3dbd1a408531049d31/sqlalchemy-2.0.46-cp314-cp314-win_amd64.whl", hash = "sha256:3c32e993bc57be6d177f7d5d31edb93f30726d798ad86ff9066d75d9bf2e0b6b", size = 2139867, upload-time = "2026-01-21T18:42:56.474Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/f0/f96c8057c982d9d8a7a68f45d69c674bc6f78cad401099692fe16521640a/sqlalchemy-2.0.46-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4dafb537740eef640c4d6a7c254611dca2df87eaf6d14d6a5fca9d1f4c3fc0fa", size = 3561202, upload-time = "2026-01-21T18:33:10.337Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/53/3b37dda0a5b137f21ef608d8dfc77b08477bab0fe2ac9d3e0a66eaeab6fc/sqlalchemy-2.0.46-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:42a1643dc5427b69aca967dae540a90b0fbf57eaf248f13a90ea5930e0966863", size = 3526296, upload-time = "2026-01-21T18:45:12.657Z" },
-    { url = "https://files.pythonhosted.org/packages/33/75/f28622ba6dde79cd545055ea7bd4062dc934e0621f7b3be2891f8563f8de/sqlalchemy-2.0.46-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ff33c6e6ad006bbc0f34f5faf941cfc62c45841c64c0a058ac38c799f15b5ede", size = 3470008, upload-time = "2026-01-21T18:33:11.725Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/42/4afecbbc38d5e99b18acef446453c76eec6fbd03db0a457a12a056836e22/sqlalchemy-2.0.46-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:82ec52100ec1e6ec671563bbd02d7c7c8d0b9e71a0723c72f22ecf52d1755330", size = 3476137, upload-time = "2026-01-21T18:45:15.001Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/a1/9c4efa03300926601c19c18582531b45aededfb961ab3c3585f1e24f120b/sqlalchemy-2.0.46-py3-none-any.whl", hash = "sha256:f9c11766e7e7c0a2767dda5acb006a118640c9fc0a4104214b96269bfb78399e", size = 1937882, upload-time = "2026-01-21T18:22:10.456Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b3/2de412451330756aaaa72d27131db6dde23995efe62c941184e15242a5fa/sqlalchemy-2.0.49-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4bbccb45260e4ff1b7db0be80a9025bb1e6698bdb808b83fff0000f7a90b2c0b", size = 2157681, upload-time = "2026-04-03T16:53:07.132Z" },
+    { url = "https://files.pythonhosted.org/packages/50/84/b2a56e2105bd11ebf9f0b93abddd748e1a78d592819099359aa98134a8bf/sqlalchemy-2.0.49-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fb37f15714ec2652d574f021d479e78cd4eb9d04396dca36568fdfffb3487982", size = 3338976, upload-time = "2026-04-03T17:07:40Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/65fcae2ed62f84ab72cf89536c7c3217a156e71a2c111b1305ab6f0690e2/sqlalchemy-2.0.49-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3bb9ec6436a820a4c006aad1ac351f12de2f2dbdaad171692ee457a02429b672", size = 3351937, upload-time = "2026-04-03T17:12:23.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/2f/6fd118563572a7fe475925742eb6b3443b2250e346a0cc27d8d408e73773/sqlalchemy-2.0.49-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8d6efc136f44a7e8bc8088507eaabbb8c2b55b3dbb63fe102c690da0ddebe55e", size = 3281646, upload-time = "2026-04-03T17:07:41.949Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/d7/410f4a007c65275b9cf82354adb4bb8ba587b176d0a6ee99caa16fe638f8/sqlalchemy-2.0.49-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e06e617e3d4fd9e51d385dfe45b077a41e9d1b033a7702551e3278ac597dc750", size = 3316695, upload-time = "2026-04-03T17:12:25.642Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/95/81f594aa60ded13273a844539041ccf1e66c5a7bed0a8e27810a3b52d522/sqlalchemy-2.0.49-cp312-cp312-win32.whl", hash = "sha256:83101a6930332b87653886c01d1ee7e294b1fe46a07dd9a2d2b4f91bcc88eec0", size = 2117483, upload-time = "2026-04-03T17:05:40.896Z" },
+    { url = "https://files.pythonhosted.org/packages/47/9e/fd90114059175cac64e4fafa9bf3ac20584384d66de40793ae2e2f26f3bb/sqlalchemy-2.0.49-cp312-cp312-win_amd64.whl", hash = "sha256:618a308215b6cececb6240b9abde545e3acdabac7ae3e1d4e666896bf5ba44b4", size = 2144494, upload-time = "2026-04-03T17:05:42.282Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/81/81755f50eb2478eaf2049728491d4ea4f416c1eb013338682173259efa09/sqlalchemy-2.0.49-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:df2d441bacf97022e81ad047e1597552eb3f83ca8a8f1a1fdd43cd7fe3898120", size = 2154547, upload-time = "2026-04-03T16:53:08.64Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/bc/3494270da80811d08bcfa247404292428c4fe16294932bce5593f215cad9/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8e20e511dc15265fb433571391ba313e10dd8ea7e509d51686a51313b4ac01a2", size = 3280782, upload-time = "2026-04-03T17:07:43.508Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/f5/038741f5e747a5f6ea3e72487211579d8cbea5eb9827a9cbd61d0108c4bd/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47604cb2159f8bbd5a1ab48a714557156320f20871ee64d550d8bf2683d980d3", size = 3297156, upload-time = "2026-04-03T17:12:27.697Z" },
+    { url = "https://files.pythonhosted.org/packages/88/50/a6af0ff9dc954b43a65ca9b5367334e45d99684c90a3d3413fc19a02d43c/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:22d8798819f86720bc646ab015baff5ea4c971d68121cb36e2ebc2ee43ead2b7", size = 3228832, upload-time = "2026-04-03T17:07:45.38Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/d1/5f6bdad8de0bf546fc74370939621396515e0cdb9067402d6ba1b8afbe9a/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9b1c058c171b739e7c330760044803099c7fff11511e3ab3573e5327116a9c33", size = 3267000, upload-time = "2026-04-03T17:12:29.657Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/30/ad62227b4a9819a5e1c6abff77c0f614fa7c9326e5a3bdbee90f7139382b/sqlalchemy-2.0.49-cp313-cp313-win32.whl", hash = "sha256:a143af2ea6672f2af3f44ed8f9cd020e9cc34c56f0e8db12019d5d9ecf41cb3b", size = 2115641, upload-time = "2026-04-03T17:05:43.989Z" },
+    { url = "https://files.pythonhosted.org/packages/17/3a/7215b1b7d6d49dc9a87211be44562077f5f04f9bb5a59552c1c8e2d98173/sqlalchemy-2.0.49-cp313-cp313-win_amd64.whl", hash = "sha256:12b04d1db2663b421fe072d638a138460a51d5a862403295671c4f3987fb9148", size = 2141498, upload-time = "2026-04-03T17:05:45.7Z" },
+    { url = "https://files.pythonhosted.org/packages/28/4b/52a0cb2687a9cd1648252bb257be5a1ba2c2ded20ba695c65756a55a15a4/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:24bd94bb301ec672d8f0623eba9226cc90d775d25a0c92b5f8e4965d7f3a1518", size = 3560807, upload-time = "2026-04-03T16:58:31.666Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d8/fda95459204877eed0458550d6c7c64c98cc50c2d8d618026737de9ed41a/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a51d3db74ba489266ef55c7a4534eb0b8db9a326553df481c11e5d7660c8364d", size = 3527481, upload-time = "2026-04-03T17:06:00.155Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0a/2aac8b78ac6487240cf7afef8f203ca783e8796002dc0cf65c4ee99ff8bb/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:55250fe61d6ebfd6934a272ee16ef1244e0f16b7af6cd18ab5b1fc9f08631db0", size = 3468565, upload-time = "2026-04-03T16:58:33.414Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/3d/ce71cfa82c50a373fd2148b3c870be05027155ce791dc9a5dcf439790b8b/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:46796877b47034b559a593d7e4b549aba151dae73f9e78212a3478161c12ab08", size = 3477769, upload-time = "2026-04-03T17:06:02.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e8/0a9f5c1f7c6f9ca480319bf57c2d7423f08d31445974167a27d14483c948/sqlalchemy-2.0.49-cp313-cp313t-win32.whl", hash = "sha256:9c4969a86e41454f2858256c39bdfb966a20961e9b58bf8749b65abf447e9a8d", size = 2143319, upload-time = "2026-04-03T17:02:04.328Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/51/fb5240729fbec73006e137c4f7a7918ffd583ab08921e6ff81a999d6517a/sqlalchemy-2.0.49-cp313-cp313t-win_amd64.whl", hash = "sha256:b9870d15ef00e4d0559ae10ee5bc71b654d1f20076dbe8bc7ed19b4c0625ceba", size = 2175104, upload-time = "2026-04-03T17:02:05.989Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/bf28f618c0a9597d14e0b9ee7d1e0622faff738d44fe986ee287cdf1b8d0/sqlalchemy-2.0.49-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:233088b4b99ebcbc5258c755a097aa52fbf90727a03a5a80781c4b9c54347a2e", size = 2156356, upload-time = "2026-04-03T16:53:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a7/5f476227576cb8644650eff68cc35fa837d3802b997465c96b8340ced1e2/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57ca426a48eb2c682dae8204cd89ea8ab7031e2675120a47924fabc7caacbc2a", size = 3276486, upload-time = "2026-04-03T17:07:46.9Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/84/efc7c0bf3a1c5eef81d397f6fddac855becdbb11cb38ff957888603014a7/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:685e93e9c8f399b0c96a624799820176312f5ceef958c0f88215af4013d29066", size = 3281479, upload-time = "2026-04-03T17:12:32.226Z" },
+    { url = "https://files.pythonhosted.org/packages/91/68/bb406fa4257099c67bd75f3f2261b129c63204b9155de0d450b37f004698/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9e0400fa22f79acc334d9a6b185dc00a44a8e6578aa7e12d0ddcd8434152b187", size = 3226269, upload-time = "2026-04-03T17:07:48.678Z" },
+    { url = "https://files.pythonhosted.org/packages/67/84/acb56c00cca9f251f437cb49e718e14f7687505749ea9255d7bd8158a6df/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a05977bffe9bffd2229f477fa75eabe3192b1b05f408961d1bebff8d1cd4d401", size = 3248260, upload-time = "2026-04-03T17:12:34.381Z" },
+    { url = "https://files.pythonhosted.org/packages/56/19/6a20ea25606d1efd7bd1862149bb2a22d1451c3f851d23d887969201633f/sqlalchemy-2.0.49-cp314-cp314-win32.whl", hash = "sha256:0f2fa354ba106eafff2c14b0cc51f22801d1e8b2e4149342023bd6f0955de5f5", size = 2118463, upload-time = "2026-04-03T17:05:47.093Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4f/8297e4ed88e80baa1f5aa3c484a0ee29ef3c69c7582f206c916973b75057/sqlalchemy-2.0.49-cp314-cp314-win_amd64.whl", hash = "sha256:77641d299179c37b89cf2343ca9972c88bb6eef0d5fc504a2f86afd15cd5adf5", size = 2144204, upload-time = "2026-04-03T17:05:48.694Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/33/95e7216df810c706e0cd3655a778604bbd319ed4f43333127d465a46862d/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c1dc3368794d522f43914e03312202523cc89692f5389c32bea0233924f8d977", size = 3565474, upload-time = "2026-04-03T16:58:35.128Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/a4/ed7b18d8ccf7f954a83af6bb73866f5bc6f5636f44c7731fbb741f72cc4f/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c821c47ecfe05cc32140dcf8dc6fd5d21971c86dbd56eabfe5ba07a64910c01", size = 3530567, upload-time = "2026-04-03T17:06:04.587Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a3/20faa869c7e21a827c4a2a42b41353a54b0f9f5e96df5087629c306df71e/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9c04bff9a5335eb95c6ecf1c117576a0aa560def274876fd156cfe5510fccc61", size = 3474282, upload-time = "2026-04-03T16:58:37.131Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/50/276b9a007aa0764304ad467eceb70b04822dc32092492ee5f322d559a4dc/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7f605a456948c35260e7b2a39f8952a26f077fd25653c37740ed186b90aaa68a", size = 3480406, upload-time = "2026-04-03T17:06:07.176Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/c3/c80fcdb41905a2df650c2a3e0337198b6848876e63d66fe9188ef9003d24/sqlalchemy-2.0.49-cp314-cp314t-win32.whl", hash = "sha256:6270d717b11c5476b0cbb21eedc8d4dbb7d1a956fd6c15a23e96f197a6193158", size = 2149151, upload-time = "2026-04-03T17:02:07.281Z" },
+    { url = "https://files.pythonhosted.org/packages/05/52/9f1a62feab6ed368aff068524ff414f26a6daebc7361861035ae00b05530/sqlalchemy-2.0.49-cp314-cp314t-win_amd64.whl", hash = "sha256:275424295f4256fd301744b8f335cff367825d270f155d522b30c7bf49903ee7", size = 2184178, upload-time = "2026-04-03T17:02:08.623Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/30/8519fdde58a7bdf155b714359791ad1dc018b47d60269d5d160d311fdc36/sqlalchemy-2.0.49-py3-none-any.whl", hash = "sha256:ec44cfa7ef1a728e88ad41674de50f6db8cfdb3e2af84af86e0041aaf02d43d0", size = 1942158, upload-time = "2026-04-03T16:53:44.135Z" },
 ]
 
 [package.optional-dependencies]
@@ -1821,15 +1865,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.40.0"
+version = "0.46.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/d1/8f3c683c9561a4e6689dd3b1d345c815f10f86acd044ee1fb9a4dcd0b8c5/uvicorn-0.40.0.tar.gz", hash = "sha256:839676675e87e73694518b5574fd0f24c9d97b46bea16df7b8c05ea1a51071ea", size = 81761, upload-time = "2025-12-21T14:16:22.45Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/d8/2083a1daa7439a66f3a48589a57d576aa117726762618f6bb09fe3798796/uvicorn-0.40.0-py3-none-any.whl", hash = "sha256:c6c8f55bc8bf13eb6fa9ff87ad62308bbbc33d0b67f84293151efe87e0d5f2ee", size = 68502, upload-time = "2025-12-21T14:16:21.041Z" },
+    { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
 ]
 
 [package.optional-dependencies]

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,6 +35,7 @@ import { OnboardingWizard } from '@/components/onboarding/OnboardingWizard';
 import { useRef } from 'react';
 import { LoginPage } from '@/pages/LoginPage';
 import { AccessDeniedPage } from '@/pages/AccessDeniedPage';
+import { PublicInitiatiefPage } from '@/pages/PublicInitiatiefPage';
 import { ReloadPrompt } from '@/components/common/ReloadPrompt';
 
 const queryClient = new QueryClient({
@@ -116,62 +117,71 @@ function OnboardingGate({ children }: { children: React.ReactNode }) {
   return <OnboardingWizard features={features} stepNumber={stepNumber} totalSteps={totalRef.current} />;
 }
 
+function AuthenticatedApp() {
+  return (
+    <AuthProvider>
+      <AuthGate>
+        <OnboardingGate>
+        <CurrentPersonProvider>
+          <OrgContextProvider>
+          <VocabularyProvider>
+          <GlobalFileDropProvider>
+            <ChatProvider>
+            <TaskDetailProvider>
+            <NodeDetailProvider>
+            <OpdrachtCreateProvider>
+            <OpdrachtDetailProvider>
+            <LeadDetailProvider>
+              <Routes>
+                <Route element={<AppLayout />}>
+                  <Route path="/" element={<InboxPage />} />
+                  <Route path="/corpus" element={<CorpusPage />} />
+                  <Route path="/nodes/:id" element={<NodeDetailPage />} />
+                  <Route path="/tasks" element={<TasksPage />} />
+                  <Route path="/people" element={<PeoplePage />} />
+                  <Route path="/organisatie" element={<OrganisatiePage />} />
+                  <Route path="/eenheid-overzicht" element={<EenheidOverzichtPage />} />
+                  <Route path="/search" element={<SearchPage />} />
+                  <Route path="/parlementair" element={<ParlementairPage />} />
+                  <Route path="/opdrachten" element={<OpdrachtenPage />} />
+                  <Route path="/externe-organisaties" element={<ExterneOrganisatiesPage />} />
+                  <Route path="/admin" element={<AdminPage />} />
+                  <Route path="/auditlog" element={<AuditLogPage />} />
+                  <Route path="/docs" element={<DocsPage />} />
+                  <Route path="/instellingen" element={<InstellingenPage />} />
+                  <Route path="/leads" element={<LeadsPage />} />
+                  <Route path="/share-target" element={<ShareTargetPage />} />
+                  <Route path="*" element={<Navigate to="/" replace />} />
+                </Route>
+              </Routes>
+              <DetailModals />
+            </LeadDetailProvider>
+            </OpdrachtDetailProvider>
+            </OpdrachtCreateProvider>
+            </NodeDetailProvider>
+            </TaskDetailProvider>
+          </ChatProvider>
+          </GlobalFileDropProvider>
+          </VocabularyProvider>
+          </OrgContextProvider>
+        </CurrentPersonProvider>
+        </OnboardingGate>
+      </AuthGate>
+    </AuthProvider>
+  );
+}
+
 export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <ToastProvider>
-      <ReloadPrompt />
-      <AuthProvider>
-        <AuthGate>
-          <OnboardingGate>
-          <CurrentPersonProvider>
-            <OrgContextProvider>
-            <VocabularyProvider>
-            <BrowserRouter>
-            <GlobalFileDropProvider>
-              <ChatProvider>
-              <TaskDetailProvider>
-              <NodeDetailProvider>
-              <OpdrachtCreateProvider>
-              <OpdrachtDetailProvider>
-              <LeadDetailProvider>
-                <Routes>
-                  <Route element={<AppLayout />}>
-                    <Route path="/" element={<InboxPage />} />
-                    <Route path="/corpus" element={<CorpusPage />} />
-                    <Route path="/nodes/:id" element={<NodeDetailPage />} />
-                    <Route path="/tasks" element={<TasksPage />} />
-                    <Route path="/people" element={<PeoplePage />} />
-                    <Route path="/organisatie" element={<OrganisatiePage />} />
-                    <Route path="/eenheid-overzicht" element={<EenheidOverzichtPage />} />
-                    <Route path="/search" element={<SearchPage />} />
-                    <Route path="/parlementair" element={<ParlementairPage />} />
-                    <Route path="/opdrachten" element={<OpdrachtenPage />} />
-                    <Route path="/externe-organisaties" element={<ExterneOrganisatiesPage />} />
-                    <Route path="/admin" element={<AdminPage />} />
-                    <Route path="/auditlog" element={<AuditLogPage />} />
-                    <Route path="/docs" element={<DocsPage />} />
-                    <Route path="/instellingen" element={<InstellingenPage />} />
-                    <Route path="/leads" element={<LeadsPage />} />
-                    <Route path="/share-target" element={<ShareTargetPage />} />
-                    <Route path="*" element={<Navigate to="/" replace />} />
-                  </Route>
-                </Routes>
-                <DetailModals />
-              </LeadDetailProvider>
-              </OpdrachtDetailProvider>
-              </OpdrachtCreateProvider>
-              </NodeDetailProvider>
-              </TaskDetailProvider>
-            </ChatProvider>
-            </GlobalFileDropProvider>
-            </BrowserRouter>
-            </VocabularyProvider>
-            </OrgContextProvider>
-          </CurrentPersonProvider>
-          </OnboardingGate>
-        </AuthGate>
-      </AuthProvider>
+        <ReloadPrompt />
+        <BrowserRouter>
+          <Routes>
+            <Route path="/c/:slug" element={<PublicInitiatiefPage />} />
+            <Route path="*" element={<AuthenticatedApp />} />
+          </Routes>
+        </BrowserRouter>
       </ToastProvider>
     </QueryClientProvider>
   );

--- a/frontend/src/api/initiatieven.ts
+++ b/frontend/src/api/initiatieven.ts
@@ -5,7 +5,11 @@ import type {
   InitiatiefDetail,
   InitiatiefEenheid,
   InitiatiefMember,
+  InitiatiefSettingsUpdate,
   InitiatiefUpdate,
+  InitiatiefUpdatePost,
+  InitiatiefUpdatePostCreate,
+  InitiatiefUpdatePostEdit,
 } from '@/types';
 
 export async function getInitiatieven(params?: {
@@ -33,6 +37,73 @@ export async function updateInitiatief(
 
 export async function deleteInitiatief(id: string): Promise<void> {
   return apiDelete(`/api/initiatieven/${id}`);
+}
+
+export async function updateInitiatiefSettings(
+  id: string,
+  data: InitiatiefSettingsUpdate,
+): Promise<Initiatief> {
+  return apiPut<Initiatief>(`/api/initiatieven/${id}/settings`, data);
+}
+
+// ---------------------------------------------------------------------------
+// InitiatiefUpdatePost — internal CRUD for publication posts
+// ---------------------------------------------------------------------------
+
+export async function getInitiatiefUpdates(
+  initiatiefId: string,
+): Promise<InitiatiefUpdatePost[]> {
+  return apiGet<InitiatiefUpdatePost[]>(
+    `/api/initiatieven/${initiatiefId}/updates`,
+  );
+}
+
+export async function createInitiatiefUpdate(
+  initiatiefId: string,
+  data: InitiatiefUpdatePostCreate,
+): Promise<InitiatiefUpdatePost> {
+  return apiPost<InitiatiefUpdatePost>(
+    `/api/initiatieven/${initiatiefId}/updates`,
+    data,
+  );
+}
+
+export async function editInitiatiefUpdate(
+  initiatiefId: string,
+  postId: string,
+  data: InitiatiefUpdatePostEdit,
+): Promise<InitiatiefUpdatePost> {
+  return apiPut<InitiatiefUpdatePost>(
+    `/api/initiatieven/${initiatiefId}/updates/${postId}`,
+    data,
+  );
+}
+
+export async function publishInitiatiefUpdate(
+  initiatiefId: string,
+  postId: string,
+): Promise<InitiatiefUpdatePost> {
+  return apiPost<InitiatiefUpdatePost>(
+    `/api/initiatieven/${initiatiefId}/updates/${postId}/publish`,
+    {},
+  );
+}
+
+export async function unpublishInitiatiefUpdate(
+  initiatiefId: string,
+  postId: string,
+): Promise<InitiatiefUpdatePost> {
+  return apiPost<InitiatiefUpdatePost>(
+    `/api/initiatieven/${initiatiefId}/updates/${postId}/unpublish`,
+    {},
+  );
+}
+
+export async function deleteInitiatiefUpdate(
+  initiatiefId: string,
+  postId: string,
+): Promise<void> {
+  return apiDelete(`/api/initiatieven/${initiatiefId}/updates/${postId}`);
 }
 
 export async function addInitiatiefMember(

--- a/frontend/src/api/publicInitiatief.ts
+++ b/frontend/src/api/publicInitiatief.ts
@@ -1,0 +1,8 @@
+import { apiGet } from './client';
+import type { PublicInitiatief } from '@/types';
+
+export async function getPublicInitiatief(slug: string): Promise<PublicInitiatief> {
+  return apiGet<PublicInitiatief>(
+    `/api/public/initiatieven/by-slug/${encodeURIComponent(slug)}`,
+  );
+}

--- a/frontend/src/api/stakeholderAssessments.ts
+++ b/frontend/src/api/stakeholderAssessments.ts
@@ -1,0 +1,37 @@
+import { apiGet, apiPost, apiPut, apiDelete } from './client';
+import type {
+  StakeholderAssessment,
+  StakeholderAssessmentCreate,
+  StakeholderAssessmentUpdate,
+  StakeholderScopeType,
+} from '@/types';
+
+export async function getStakeholderAssessments(
+  scope_type: StakeholderScopeType,
+  scope_id: string,
+): Promise<StakeholderAssessment[]> {
+  return apiGet<StakeholderAssessment[]>('/api/stakeholder-assessments', {
+    scope_type,
+    scope_id,
+  });
+}
+
+export async function createStakeholderAssessment(
+  data: StakeholderAssessmentCreate,
+): Promise<StakeholderAssessment> {
+  return apiPost<StakeholderAssessment>('/api/stakeholder-assessments', data);
+}
+
+export async function updateStakeholderAssessment(
+  id: string,
+  data: StakeholderAssessmentUpdate,
+): Promise<StakeholderAssessment> {
+  return apiPut<StakeholderAssessment>(
+    `/api/stakeholder-assessments/${id}`,
+    data,
+  );
+}
+
+export async function deleteStakeholderAssessment(id: string): Promise<void> {
+  return apiDelete(`/api/stakeholder-assessments/${id}`);
+}

--- a/frontend/src/components/initiatieven/InitiatiefDetailModal.tsx
+++ b/frontend/src/components/initiatieven/InitiatiefDetailModal.tsx
@@ -542,143 +542,155 @@ function SettingsSection({ initiatief }: { initiatief: InitiatiefDetail }) {
         </h4>
       </div>
 
-      <div className="space-y-4 rounded-xl border border-border p-4">
-        {/* Slug */}
-        <div className="space-y-1.5">
-          <label className="block text-sm font-medium text-text">
-            Slug{' '}
-            <span className="text-xs text-text-secondary">
-              (publieke URL-segment)
-            </span>
-          </label>
-          {initiatief.slug ? (
-            <div className="flex items-center gap-2 flex-wrap">
-              {initiatief.public_page_enabled ? (
-                <a
-                  href={`/c/${initiatief.slug}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 text-sm bg-emerald-50 hover:bg-emerald-100 text-emerald-900 px-2 py-1 rounded border border-emerald-200 transition-colors"
-                >
-                  <code>/c/{initiatief.slug}</code>
-                  <ExternalLink className="h-3 w-3" />
-                </a>
-              ) : (
-                <code className="text-sm bg-gray-50 px-2 py-1 rounded">
-                  /c/{initiatief.slug}
-                </code>
-              )}
+      <div className="space-y-4">
+        {/* Publieke pagina */}
+        <div className="space-y-3 rounded-xl border border-border p-4">
+          <div className="flex items-center gap-1.5 text-xs font-semibold text-text-secondary uppercase tracking-wider">
+            <Globe className="h-3.5 w-3.5" />
+            Publieke pagina
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="block text-sm font-medium text-text">
+              Slug{' '}
               <span className="text-xs text-text-secondary">
-                (kan niet meer gewijzigd worden)
+                (publieke URL-segment)
               </span>
-            </div>
-          ) : (
-            <div className="space-y-1.5">
-              <p className="text-xs text-text-secondary">
-                Nog geen slug ingesteld. Kies kleine letters, cijfers en
-                streepjes (bv. <code>regelrecht</code>). Eenmalig instelbaar.
-              </p>
-              <div className="flex gap-2">
-                <span className="inline-flex items-center px-2 rounded-l-lg border border-r-0 border-border bg-gray-50 text-sm text-text-secondary">
-                  /c/
+            </label>
+            {initiatief.slug ? (
+              <div className="flex items-center gap-2 flex-wrap">
+                {initiatief.public_page_enabled ? (
+                  <a
+                    href={`/c/${initiatief.slug}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-sm bg-emerald-50 hover:bg-emerald-100 text-emerald-900 px-2 py-1 rounded border border-emerald-200 transition-colors"
+                  >
+                    <code>/c/{initiatief.slug}</code>
+                    <ExternalLink className="h-3 w-3" />
+                  </a>
+                ) : (
+                  <code className="text-sm bg-gray-50 px-2 py-1 rounded">
+                    /c/{initiatief.slug}
+                  </code>
+                )}
+                <span className="text-xs text-text-secondary">
+                  (kan niet meer gewijzigd worden)
                 </span>
-                <input
-                  type="text"
-                  value={slugDraft}
-                  onChange={(e) => {
-                    setSlugDraft(e.target.value.toLowerCase());
-                    setSlugError(null);
-                  }}
-                  placeholder="regelrecht"
-                  className="flex-1 rounded-r-lg border border-border px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
-                />
-                <button
-                  type="button"
-                  onClick={async () => {
-                    const trimmed = slugDraft.trim();
-                    if (!trimmed) return;
-                    try {
-                      await save({ slug: trimmed });
-                    } catch (err) {
-                      const msg =
-                        err instanceof Error ? err.message : 'Onbekende fout';
-                      setSlugError(msg);
-                    }
-                  }}
-                  disabled={!slugDraft.trim() || settingsMutation.isPending}
-                  className="px-3 py-1 text-sm rounded-lg bg-primary-600 text-white disabled:opacity-50"
-                >
-                  Instellen
-                </button>
               </div>
-              {slugError && (
-                <p className="text-xs text-red-600">{slugError}</p>
-              )}
-            </div>
-          )}
-        </div>
-
-        {/* Funnel toggle */}
-        <ToggleRow
-          icon={<UserPlus className="h-4 w-4" />}
-          label="Funnel-velden op leads tonen"
-          description="Engagement type + drie scores (strategisch/politiek/positie) op leads in dit initiatief."
-          enabled={initiatief.funnel_enabled}
-          onToggle={() =>
-            save({ funnel_enabled: !initiatief.funnel_enabled })
-          }
-          loading={settingsMutation.isPending}
-        />
-
-        {/* Public page toggle */}
-        <ToggleRow
-          icon={<Globe className="h-4 w-4" />}
-          label="Publieke pagina inschakelen"
-          description={
-            publicUrl
-              ? `Pagina bereikbaar via ${publicUrl} voor iedereen met de link.`
-              : 'Geen slug — pagina niet bereikbaar.'
-          }
-          enabled={initiatief.public_page_enabled}
-          onToggle={handlePublicToggle}
-          loading={settingsMutation.isPending}
-          disabled={!publicUrl}
-        />
-
-        {/* Score labels (only when funnel enabled) */}
-        {initiatief.funnel_enabled && (
-          <div className="space-y-2 pt-2 border-t border-border">
-            <p className="text-xs text-text-secondary">
-              Optionele eigen labels voor de drie funnel-scores. Leeg laten
-              gebruikt de standaard.
-            </p>
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
-              {(
-                [
-                  ['score_strategisch_label', 'Strategisch belang'],
-                  ['score_politiek_label', 'Politiek belang'],
-                  ['score_positie_label', 'Positie / omgeving'],
-                ] as const
-              ).map(([key, fallback]) => (
-                <label key={key} className="flex flex-col gap-0.5">
-                  <span className="text-xs text-text-secondary">
-                    {fallback}
+            ) : (
+              <div className="space-y-1.5">
+                <p className="text-xs text-text-secondary">
+                  Nog geen slug ingesteld. Kies kleine letters, cijfers en
+                  streepjes (bv. <code>regelrecht</code>). Eenmalig instelbaar.
+                </p>
+                <div className="flex gap-2">
+                  <span className="inline-flex items-center px-2 rounded-l-lg border border-r-0 border-border bg-gray-50 text-sm text-text-secondary">
+                    /c/
                   </span>
                   <input
                     type="text"
-                    value={scoreLabels[key]}
-                    onChange={(e) =>
-                      setScoreLabels({ ...scoreLabels, [key]: e.target.value })
-                    }
-                    onBlur={persistLabels}
-                    placeholder={fallback}
-                    className="text-sm rounded-lg border border-border px-2 py-1 focus:outline-none focus:ring-2 focus:ring-primary"
+                    value={slugDraft}
+                    onChange={(e) => {
+                      setSlugDraft(e.target.value.toLowerCase());
+                      setSlugError(null);
+                    }}
+                    placeholder="regelrecht"
+                    className="flex-1 rounded-r-lg border border-border px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
                   />
-                </label>
-              ))}
-            </div>
+                  <button
+                    type="button"
+                    onClick={async () => {
+                      const trimmed = slugDraft.trim();
+                      if (!trimmed) return;
+                      try {
+                        await save({ slug: trimmed });
+                      } catch (err) {
+                        const msg =
+                          err instanceof Error ? err.message : 'Onbekende fout';
+                        setSlugError(msg);
+                      }
+                    }}
+                    disabled={!slugDraft.trim() || settingsMutation.isPending}
+                    className="px-3 py-1 text-sm rounded-lg bg-primary-600 text-white disabled:opacity-50"
+                  >
+                    Instellen
+                  </button>
+                </div>
+                {slugError && (
+                  <p className="text-xs text-red-600">{slugError}</p>
+                )}
+              </div>
+            )}
           </div>
-        )}
+
+          <ToggleRow
+            icon={<Globe className="h-4 w-4" />}
+            label="Publieke pagina inschakelen"
+            description={
+              publicUrl
+                ? `Pagina bereikbaar via ${publicUrl} voor iedereen met de link.`
+                : 'Geen slug — pagina niet bereikbaar.'
+            }
+            enabled={initiatief.public_page_enabled}
+            onToggle={handlePublicToggle}
+            loading={settingsMutation.isPending}
+            disabled={!publicUrl}
+          />
+        </div>
+
+        {/* Funnel-afweging */}
+        <div className="space-y-3 rounded-xl border border-border p-4">
+          <div className="flex items-center gap-1.5 text-xs font-semibold text-text-secondary uppercase tracking-wider">
+            <UserPlus className="h-3.5 w-3.5" />
+            Funnel-afweging
+          </div>
+
+          <ToggleRow
+            icon={<UserPlus className="h-4 w-4" />}
+            label="Funnel-velden op leads tonen"
+            description="Engagement type + drie scores (strategisch/politiek/positie) op leads in dit initiatief."
+            enabled={initiatief.funnel_enabled}
+            onToggle={() =>
+              save({ funnel_enabled: !initiatief.funnel_enabled })
+            }
+            loading={settingsMutation.isPending}
+          />
+
+          {initiatief.funnel_enabled && (
+            <div className="space-y-2 pt-2 border-t border-border">
+              <p className="text-xs text-text-secondary">
+                Optionele eigen labels voor de drie funnel-scores. Leeg laten
+                gebruikt de standaard.
+              </p>
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+                {(
+                  [
+                    ['score_strategisch_label', 'Strategisch belang'],
+                    ['score_politiek_label', 'Politiek belang'],
+                    ['score_positie_label', 'Positie / omgeving'],
+                  ] as const
+                ).map(([key, fallback]) => (
+                  <label key={key} className="flex flex-col gap-0.5">
+                    <span className="text-xs text-text-secondary">
+                      {fallback}
+                    </span>
+                    <input
+                      type="text"
+                      value={scoreLabels[key]}
+                      onChange={(e) =>
+                        setScoreLabels({ ...scoreLabels, [key]: e.target.value })
+                      }
+                      onBlur={persistLabels}
+                      placeholder={fallback}
+                      className="text-sm rounded-lg border border-border px-2 py-1 focus:outline-none focus:ring-2 focus:ring-primary"
+                    />
+                  </label>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
       </div>
 
       <ConfirmDialog

--- a/frontend/src/components/initiatieven/InitiatiefDetailModal.tsx
+++ b/frontend/src/components/initiatieven/InitiatiefDetailModal.tsx
@@ -594,15 +594,12 @@ function SettingsSection({ initiatief }: { initiatief: InitiatiefDetail }) {
                     /c/{initiatief.slug}
                   </code>
                 )}
-                <span className="text-xs text-text-secondary">
-                  (kan niet meer gewijzigd worden)
-                </span>
               </div>
             ) : (
               <div className="space-y-1.5">
                 <p className="text-xs text-text-secondary">
                   Nog geen slug ingesteld. Kies kleine letters, cijfers en
-                  streepjes (bv. <code>regelrecht</code>). Eenmalig instelbaar.
+                  streepjes (bv. <code>regelrecht</code>).
                 </p>
                 <div className="flex gap-2">
                   <span className="inline-flex items-center px-2 rounded-l-lg border border-r-0 border-border bg-gray-50 text-sm text-text-secondary">

--- a/frontend/src/components/initiatieven/InitiatiefDetailModal.tsx
+++ b/frontend/src/components/initiatieven/InitiatiefDetailModal.tsx
@@ -550,7 +550,27 @@ function SettingsSection({ initiatief }: { initiatief: InitiatiefDetail }) {
             Publieke pagina
           </div>
 
-          <div className="space-y-1.5">
+          <ToggleRow
+            icon={<Globe className="h-4 w-4" />}
+            label="Publieke pagina inschakelen"
+            description={
+              publicUrl
+                ? `Pagina bereikbaar via ${publicUrl} voor iedereen met de link.`
+                : 'Stel eerst een slug in om de pagina aan te kunnen zetten.'
+            }
+            enabled={initiatief.public_page_enabled}
+            onToggle={handlePublicToggle}
+            loading={settingsMutation.isPending}
+            disabled={!publicUrl}
+          />
+
+          <div
+            className={`space-y-1.5 ${
+              initiatief.public_page_enabled || !initiatief.slug
+                ? ''
+                : 'opacity-60'
+            }`}
+          >
             <label className="block text-sm font-medium text-text">
               Slug{' '}
               <span className="text-xs text-text-secondary">
@@ -623,20 +643,6 @@ function SettingsSection({ initiatief }: { initiatief: InitiatiefDetail }) {
               </div>
             )}
           </div>
-
-          <ToggleRow
-            icon={<Globe className="h-4 w-4" />}
-            label="Publieke pagina inschakelen"
-            description={
-              publicUrl
-                ? `Pagina bereikbaar via ${publicUrl} voor iedereen met de link.`
-                : 'Geen slug — pagina niet bereikbaar.'
-            }
-            enabled={initiatief.public_page_enabled}
-            onToggle={handlePublicToggle}
-            loading={settingsMutation.isPending}
-            disabled={!publicUrl}
-          />
         </div>
 
         {/* Funnel-afweging */}

--- a/frontend/src/components/initiatieven/InitiatiefDetailModal.tsx
+++ b/frontend/src/components/initiatieven/InitiatiefDetailModal.tsx
@@ -502,6 +502,8 @@ function SettingsSection({ initiatief }: { initiatief: InitiatiefDetail }) {
     score_politiek_label: initiatief.score_politiek_label ?? '',
     score_positie_label: initiatief.score_positie_label ?? '',
   });
+  const [slugDraft, setSlugDraft] = useState(initiatief.slug ?? '');
+  const [slugError, setSlugError] = useState<string | null>(null);
 
   const save = (data: InitiatiefSettingsUpdate) =>
     settingsMutation.mutateAsync({ id: initiatief.id, data });
@@ -558,9 +560,48 @@ function SettingsSection({ initiatief }: { initiatief: InitiatiefDetail }) {
               </span>
             </div>
           ) : (
-            <p className="text-sm text-text-secondary">
-              Geen slug. Naam te kort of geen geldige tekens.
-            </p>
+            <div className="space-y-1.5">
+              <p className="text-xs text-text-secondary">
+                Nog geen slug ingesteld. Kies kleine letters, cijfers en
+                streepjes (bv. <code>regelrecht</code>). Eenmalig instelbaar.
+              </p>
+              <div className="flex gap-2">
+                <span className="inline-flex items-center px-2 rounded-l-lg border border-r-0 border-border bg-gray-50 text-sm text-text-secondary">
+                  /c/
+                </span>
+                <input
+                  type="text"
+                  value={slugDraft}
+                  onChange={(e) => {
+                    setSlugDraft(e.target.value.toLowerCase());
+                    setSlugError(null);
+                  }}
+                  placeholder="regelrecht"
+                  className="flex-1 rounded-r-lg border border-border px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                />
+                <button
+                  type="button"
+                  onClick={async () => {
+                    const trimmed = slugDraft.trim();
+                    if (!trimmed) return;
+                    try {
+                      await save({ slug: trimmed });
+                    } catch (err) {
+                      const msg =
+                        err instanceof Error ? err.message : 'Onbekende fout';
+                      setSlugError(msg);
+                    }
+                  }}
+                  disabled={!slugDraft.trim() || settingsMutation.isPending}
+                  className="px-3 py-1 text-sm rounded-lg bg-primary-600 text-white disabled:opacity-50"
+                >
+                  Instellen
+                </button>
+              </div>
+              {slugError && (
+                <p className="text-xs text-red-600">{slugError}</p>
+              )}
+            </div>
           )}
         </div>
 

--- a/frontend/src/components/initiatieven/InitiatiefDetailModal.tsx
+++ b/frontend/src/components/initiatieven/InitiatiefDetailModal.tsx
@@ -1,5 +1,18 @@
 import { useState, useMemo } from 'react';
-import { Pencil, Trash2, X, UserPlus, Building2, Users } from 'lucide-react';
+import {
+  Pencil,
+  Trash2,
+  X,
+  UserPlus,
+  Building2,
+  Users,
+  Settings as SettingsIcon,
+  Megaphone,
+  UserCheck,
+  Globe,
+  Eye,
+  EyeOff,
+} from 'lucide-react';
 import { Modal } from '@/components/common/Modal';
 import { Button } from '@/components/common/Button';
 import { Badge } from '@/components/common/Badge';
@@ -11,6 +24,7 @@ import { RichTextDisplay } from '@/components/common/RichTextDisplay';
 import {
   useInitiatief,
   useUpdateInitiatief,
+  useUpdateInitiatiefSettings,
   useDeleteInitiatief,
   useAddInitiatiefMember,
   useRemoveInitiatiefMember,
@@ -18,11 +32,24 @@ import {
   useAddInitiatiefEenheid,
   useRemoveInitiatiefEenheid,
   useUpdateInitiatiefEenheidRol,
+  useInitiatiefUpdates,
+  useCreateInitiatiefUpdate,
+  useEditInitiatiefUpdate,
+  usePublishInitiatiefUpdate,
+  useUnpublishInitiatiefUpdate,
+  useDeleteInitiatiefUpdate,
 } from '@/hooks/useInitiatieven';
 import { usePeople } from '@/hooks/usePeople';
 import { useOrganisatieFlat } from '@/hooks/useOrganisatie';
 import { INITIATIEF_COLORS, INITIATIEF_ROL_LABELS } from '@/types';
-import type { InitiatiefUpdate } from '@/types';
+import type {
+  Initiatief,
+  InitiatiefDetail,
+  InitiatiefSettingsUpdate,
+  InitiatiefUpdate,
+  InitiatiefUpdatePost,
+} from '@/types';
+import { StakeholderTab } from '@/components/stakeholders/StakeholderTab';
 
 interface InitiatiefDetailModalProps {
   initiatiefId: string;
@@ -424,6 +451,27 @@ export function InitiatiefDetailModal({
                 </div>
               )}
             </div>
+
+            {/* Stakeholders */}
+            <div>
+              <div className="flex items-center justify-between mb-2">
+                <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider flex items-center gap-1.5">
+                  <UserCheck className="h-3.5 w-3.5" />
+                  Stakeholders
+                </h4>
+              </div>
+              <StakeholderTab
+                scopeType="initiatief"
+                scopeId={detail.id}
+                readOnly={!canEdit}
+              />
+            </div>
+
+            {/* Updates (publication posts) */}
+            <UpdatesSection initiatief={detail} canEdit={canEdit} />
+
+            {/* Settings — eigenaar only */}
+            {isEigenaar && <SettingsSection initiatief={detail} />}
           </div>
         )}
       </Modal>
@@ -441,6 +489,484 @@ export function InitiatiefDetailModal({
         niet ongedaan gemaakt worden.
       </ConfirmDialog>
     </>
+  );
+}
+
+// ---------- Settings section (eigenaar only) ----------
+
+function SettingsSection({ initiatief }: { initiatief: InitiatiefDetail }) {
+  const settingsMutation = useUpdateInitiatiefSettings();
+  const [pendingPublic, setPendingPublic] = useState(false);
+  const [scoreLabels, setScoreLabels] = useState({
+    score_strategisch_label: initiatief.score_strategisch_label ?? '',
+    score_politiek_label: initiatief.score_politiek_label ?? '',
+    score_positie_label: initiatief.score_positie_label ?? '',
+  });
+
+  const save = (data: InitiatiefSettingsUpdate) =>
+    settingsMutation.mutateAsync({ id: initiatief.id, data });
+
+  const handlePublicToggle = () => {
+    if (initiatief.public_page_enabled) {
+      // Turning off — no confirmation needed.
+      save({ public_page_enabled: false });
+    } else {
+      setPendingPublic(true);
+    }
+  };
+
+  const confirmPublicEnable = async () => {
+    await save({ public_page_enabled: true });
+    setPendingPublic(false);
+  };
+
+  const persistLabels = () => {
+    save({
+      score_strategisch_label: scoreLabels.score_strategisch_label || null,
+      score_politiek_label: scoreLabels.score_politiek_label || null,
+      score_positie_label: scoreLabels.score_positie_label || null,
+    });
+  };
+
+  const publicUrl = initiatief.slug ? `/c/${initiatief.slug}` : null;
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-2">
+        <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider flex items-center gap-1.5">
+          <SettingsIcon className="h-3.5 w-3.5" />
+          Instellingen
+        </h4>
+      </div>
+
+      <div className="space-y-4 rounded-xl border border-border p-4">
+        {/* Slug */}
+        <div className="space-y-1.5">
+          <label className="block text-sm font-medium text-text">
+            Slug{' '}
+            <span className="text-xs text-text-secondary">
+              (publieke URL-segment)
+            </span>
+          </label>
+          {initiatief.slug ? (
+            <div className="flex items-center gap-2">
+              <code className="text-sm bg-gray-50 px-2 py-1 rounded">
+                /c/{initiatief.slug}
+              </code>
+              <span className="text-xs text-text-secondary">
+                (kan niet meer gewijzigd worden)
+              </span>
+            </div>
+          ) : (
+            <p className="text-sm text-text-secondary">
+              Geen slug. Naam te kort of geen geldige tekens.
+            </p>
+          )}
+        </div>
+
+        {/* Funnel toggle */}
+        <ToggleRow
+          icon={<UserPlus className="h-4 w-4" />}
+          label="Funnel-velden op leads tonen"
+          description="Engagement type + drie scores (strategisch/politiek/positie) op leads in dit initiatief."
+          enabled={initiatief.funnel_enabled}
+          onToggle={() =>
+            save({ funnel_enabled: !initiatief.funnel_enabled })
+          }
+          loading={settingsMutation.isPending}
+        />
+
+        {/* Public page toggle */}
+        <ToggleRow
+          icon={<Globe className="h-4 w-4" />}
+          label="Publieke pagina inschakelen"
+          description={
+            publicUrl
+              ? `Pagina bereikbaar via ${publicUrl} voor iedereen met de link.`
+              : 'Geen slug — pagina niet bereikbaar.'
+          }
+          enabled={initiatief.public_page_enabled}
+          onToggle={handlePublicToggle}
+          loading={settingsMutation.isPending}
+          disabled={!publicUrl}
+        />
+
+        {/* Score labels (only when funnel enabled) */}
+        {initiatief.funnel_enabled && (
+          <div className="space-y-2 pt-2 border-t border-border">
+            <p className="text-xs text-text-secondary">
+              Optionele eigen labels voor de drie funnel-scores. Leeg laten
+              gebruikt de standaard.
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+              {(
+                [
+                  ['score_strategisch_label', 'Strategisch belang'],
+                  ['score_politiek_label', 'Politiek belang'],
+                  ['score_positie_label', 'Positie / omgeving'],
+                ] as const
+              ).map(([key, fallback]) => (
+                <label key={key} className="flex flex-col gap-0.5">
+                  <span className="text-xs text-text-secondary">
+                    {fallback}
+                  </span>
+                  <input
+                    type="text"
+                    value={scoreLabels[key]}
+                    onChange={(e) =>
+                      setScoreLabels({ ...scoreLabels, [key]: e.target.value })
+                    }
+                    onBlur={persistLabels}
+                    placeholder={fallback}
+                    className="text-sm rounded-lg border border-border px-2 py-1 focus:outline-none focus:ring-2 focus:ring-primary"
+                  />
+                </label>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <ConfirmDialog
+        open={pendingPublic}
+        onClose={() => setPendingPublic(false)}
+        onConfirm={confirmPublicEnable}
+        title="Publieke pagina inschakelen"
+        confirmLabel="Inschakelen"
+        loading={settingsMutation.isPending}
+      >
+        Iedereen met de link <code>/c/{initiatief.slug}</code> kan straks de
+        naam, beschrijving en gepubliceerde updates van dit initiatief zien.
+        Leads, scores en stakeholders blijven privé. Doorgaan?
+      </ConfirmDialog>
+    </div>
+  );
+}
+
+function ToggleRow({
+  icon,
+  label,
+  description,
+  enabled,
+  onToggle,
+  loading,
+  disabled,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  description: string;
+  enabled: boolean;
+  onToggle: () => void;
+  loading?: boolean;
+  disabled?: boolean;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-3">
+      <div className="flex items-start gap-2 min-w-0">
+        <div className="text-text-secondary mt-0.5">{icon}</div>
+        <div className="min-w-0">
+          <div className="text-sm font-medium text-text">{label}</div>
+          <div className="text-xs text-text-secondary">{description}</div>
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={onToggle}
+        disabled={loading || disabled}
+        className={`shrink-0 inline-flex h-6 w-11 items-center rounded-full transition-colors disabled:opacity-50 ${
+          enabled ? 'bg-primary-600' : 'bg-gray-300'
+        }`}
+        aria-pressed={enabled}
+      >
+        <span
+          className={`inline-block h-5 w-5 rounded-full bg-white transition-transform ${
+            enabled ? 'translate-x-5' : 'translate-x-0.5'
+          }`}
+        />
+      </button>
+    </div>
+  );
+}
+
+// ---------- Updates section (publication posts) ----------
+
+function UpdatesSection({
+  initiatief,
+  canEdit,
+}: {
+  initiatief: Initiatief;
+  canEdit: boolean;
+}) {
+  const { data: posts = [] } = useInitiatiefUpdates(initiatief.id);
+  const createMutation = useCreateInitiatiefUpdate();
+  const editMutation = useEditInitiatiefUpdate();
+  const publishMutation = usePublishInitiatiefUpdate();
+  const unpublishMutation = useUnpublishInitiatiefUpdate();
+  const deleteMutation = useDeleteInitiatiefUpdate();
+
+  const [composing, setComposing] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [draft, setDraft] = useState({ titel: '', body: '' });
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+
+  const concepts = posts.filter((p) => !p.published_at);
+  const published = posts.filter((p) => p.published_at);
+
+  const startCompose = () => {
+    setDraft({ titel: '', body: '' });
+    setEditingId(null);
+    setComposing(true);
+  };
+
+  const startEdit = (post: InitiatiefUpdatePost) => {
+    setDraft({ titel: post.titel, body: post.body ?? '' });
+    setEditingId(post.id);
+    setComposing(true);
+  };
+
+  const handleSave = async (publish: boolean) => {
+    if (!draft.titel.trim()) return;
+    if (editingId) {
+      await editMutation.mutateAsync({
+        initiatiefId: initiatief.id,
+        postId: editingId,
+        data: { titel: draft.titel, body: draft.body || null },
+      });
+      if (publish) {
+        await publishMutation.mutateAsync({
+          initiatiefId: initiatief.id,
+          postId: editingId,
+        });
+      }
+    } else {
+      await createMutation.mutateAsync({
+        initiatiefId: initiatief.id,
+        data: { titel: draft.titel, body: draft.body || null, publish },
+      });
+    }
+    setComposing(false);
+    setEditingId(null);
+  };
+
+  const handlePublish = (post: InitiatiefUpdatePost) =>
+    publishMutation.mutate({
+      initiatiefId: initiatief.id,
+      postId: post.id,
+    });
+
+  const handleUnpublish = (post: InitiatiefUpdatePost) =>
+    unpublishMutation.mutate({
+      initiatiefId: initiatief.id,
+      postId: post.id,
+    });
+
+  const handleDelete = async () => {
+    if (!confirmDelete) return;
+    await deleteMutation.mutateAsync({
+      initiatiefId: initiatief.id,
+      postId: confirmDelete,
+    });
+    setConfirmDelete(null);
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-2">
+        <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider flex items-center gap-1.5">
+          <Megaphone className="h-3.5 w-3.5" />
+          Updates ({posts.length})
+        </h4>
+        {canEdit && !composing && (
+          <Button variant="secondary" size="sm" onClick={startCompose}>
+            Nieuwe update
+          </Button>
+        )}
+      </div>
+
+      {composing && (
+        <div className="rounded-xl border border-border p-3 mb-3 space-y-2">
+          <input
+            type="text"
+            value={draft.titel}
+            onChange={(e) => setDraft({ ...draft, titel: e.target.value })}
+            placeholder="Titel"
+            className="w-full text-sm rounded-lg border border-border px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary"
+            autoFocus
+          />
+          <RichTextFormField
+            value={draft.body}
+            onChange={(value) => setDraft({ ...draft, body: value })}
+            rows={4}
+          />
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => {
+                setComposing(false);
+                setEditingId(null);
+              }}
+            >
+              Annuleren
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => handleSave(false)}
+              disabled={!draft.titel.trim()}
+            >
+              Opslaan als concept
+            </Button>
+            <Button
+              size="sm"
+              onClick={() => handleSave(true)}
+              disabled={!draft.titel.trim()}
+            >
+              {editingId ? 'Opslaan + publiceren' : 'Direct publiceren'}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {concepts.length > 0 && (
+        <div className="mb-3">
+          <div className="text-xs text-text-secondary mb-1">Concepten</div>
+          <ul className="divide-y divide-border rounded-xl border border-border">
+            {concepts.map((post) => (
+              <PostRow
+                key={post.id}
+                post={post}
+                canEdit={canEdit}
+                onEdit={() => startEdit(post)}
+                onPublish={() => handlePublish(post)}
+                onUnpublish={() => handleUnpublish(post)}
+                onDelete={() => setConfirmDelete(post.id)}
+              />
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {published.length > 0 ? (
+        <div>
+          <div className="text-xs text-text-secondary mb-1">Gepubliceerd</div>
+          <ul className="divide-y divide-border rounded-xl border border-border">
+            {published.map((post) => (
+              <PostRow
+                key={post.id}
+                post={post}
+                canEdit={canEdit}
+                onEdit={() => startEdit(post)}
+                onPublish={() => handlePublish(post)}
+                onUnpublish={() => handleUnpublish(post)}
+                onDelete={() => setConfirmDelete(post.id)}
+              />
+            ))}
+          </ul>
+        </div>
+      ) : (
+        concepts.length === 0 &&
+        !composing && (
+          <p className="text-sm text-text-secondary">
+            Nog geen updates. Klik op "Nieuwe update" om iets te publiceren.
+          </p>
+        )
+      )}
+
+      <ConfirmDialog
+        open={!!confirmDelete}
+        onClose={() => setConfirmDelete(null)}
+        onConfirm={handleDelete}
+        title="Update verwijderen"
+        confirmLabel="Verwijderen"
+        variant="danger"
+        loading={deleteMutation.isPending}
+      >
+        Weet je zeker dat je deze update wilt verwijderen?
+      </ConfirmDialog>
+    </div>
+  );
+}
+
+function PostRow({
+  post,
+  canEdit,
+  onEdit,
+  onPublish,
+  onUnpublish,
+  onDelete,
+}: {
+  post: InitiatiefUpdatePost;
+  canEdit: boolean;
+  onEdit: () => void;
+  onPublish: () => void;
+  onUnpublish: () => void;
+  onDelete: () => void;
+}) {
+  const isPublished = !!post.published_at;
+  return (
+    <li className="px-3 py-2">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium text-text truncate">
+              {post.titel}
+            </span>
+            {isPublished ? (
+              <Badge variant="green">Gepubliceerd</Badge>
+            ) : (
+              <Badge variant="gray">Concept</Badge>
+            )}
+          </div>
+          {post.body && (
+            <div className="mt-1 text-sm text-text-secondary line-clamp-2">
+              <RichTextDisplay content={post.body} />
+            </div>
+          )}
+          {isPublished && post.published_at && (
+            <div className="mt-1 text-xs text-text-secondary">
+              {new Date(post.published_at).toLocaleString('nl-NL')}
+              {post.published_by_naam && ` · ${post.published_by_naam}`}
+            </div>
+          )}
+        </div>
+        {canEdit && (
+          <div className="flex items-center gap-1 shrink-0">
+            <button
+              onClick={onEdit}
+              className="p-1 rounded hover:bg-gray-100 text-text-secondary hover:text-text transition-colors"
+              title="Bewerken"
+            >
+              <Pencil className="h-3.5 w-3.5" />
+            </button>
+            {isPublished ? (
+              <button
+                onClick={onUnpublish}
+                className="p-1 rounded hover:bg-gray-100 text-text-secondary hover:text-text transition-colors"
+                title="Terugtrekken naar concept"
+              >
+                <EyeOff className="h-3.5 w-3.5" />
+              </button>
+            ) : (
+              <button
+                onClick={onPublish}
+                className="p-1 rounded hover:bg-gray-100 text-text-secondary hover:text-emerald-600 transition-colors"
+                title="Publiceren"
+              >
+                <Eye className="h-3.5 w-3.5" />
+              </button>
+            )}
+            <button
+              onClick={onDelete}
+              className="p-1 rounded hover:bg-gray-100 text-text-secondary hover:text-red-500 transition-colors"
+              title="Verwijderen"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        )}
+      </div>
+    </li>
   );
 }
 

--- a/frontend/src/components/initiatieven/InitiatiefDetailModal.tsx
+++ b/frontend/src/components/initiatieven/InitiatiefDetailModal.tsx
@@ -12,6 +12,7 @@ import {
   Globe,
   Eye,
   EyeOff,
+  ExternalLink,
 } from 'lucide-react';
 import { Modal } from '@/components/common/Modal';
 import { Button } from '@/components/common/Button';
@@ -551,10 +552,22 @@ function SettingsSection({ initiatief }: { initiatief: InitiatiefDetail }) {
             </span>
           </label>
           {initiatief.slug ? (
-            <div className="flex items-center gap-2">
-              <code className="text-sm bg-gray-50 px-2 py-1 rounded">
-                /c/{initiatief.slug}
-              </code>
+            <div className="flex items-center gap-2 flex-wrap">
+              {initiatief.public_page_enabled ? (
+                <a
+                  href={`/c/${initiatief.slug}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-sm bg-emerald-50 hover:bg-emerald-100 text-emerald-900 px-2 py-1 rounded border border-emerald-200 transition-colors"
+                >
+                  <code>/c/{initiatief.slug}</code>
+                  <ExternalLink className="h-3 w-3" />
+                </a>
+              ) : (
+                <code className="text-sm bg-gray-50 px-2 py-1 rounded">
+                  /c/{initiatief.slug}
+                </code>
+              )}
               <span className="text-xs text-text-secondary">
                 (kan niet meer gewijzigd worden)
               </span>

--- a/frontend/src/components/initiatieven/InitiatiefDetailModal.tsx
+++ b/frontend/src/components/initiatieven/InitiatiefDetailModal.tsx
@@ -835,6 +835,7 @@ function UpdatesSection({
             autoFocus
           />
           <RichTextFormField
+            label="Inhoud"
             value={draft.body}
             onChange={(value) => setDraft({ ...draft, body: value })}
             rows={4}

--- a/frontend/src/components/leads/LeadCard.tsx
+++ b/frontend/src/components/leads/LeadCard.tsx
@@ -12,6 +12,10 @@ export function LeadCard({ lead, onClick }: LeadCardProps) {
   const overdue = lead.next_action_date && isOverdue(lead.next_action_date);
   const isInbox = lead.stage === LeadStage.INBOX;
   const contacts = lead.contact_names ?? [];
+  const hasFunnelScores =
+    lead.score_strategisch != null &&
+    lead.score_politiek != null &&
+    lead.score_positie != null;
 
   return (
     <button
@@ -79,6 +83,15 @@ export function LeadCard({ lead, onClick }: LeadCardProps) {
           <span className="inline-flex items-center gap-0.5 ml-auto">
             <Paperclip className="h-3 w-3" />
             {lead.attachment_count}
+          </span>
+        )}
+
+        {hasFunnelScores && (
+          <span
+            className={`tabular-nums text-[10px] text-text-secondary ${lead.attachment_count > 0 ? '' : 'ml-auto'}`}
+            title={`Strategisch ${lead.score_strategisch} · Politiek ${lead.score_politiek} · Positie ${lead.score_positie}`}
+          >
+            {lead.score_strategisch}·{lead.score_politiek}·{lead.score_positie}
           </span>
         )}
       </div>

--- a/frontend/src/components/leads/LeadDetailPanel.tsx
+++ b/frontend/src/components/leads/LeadDetailPanel.tsx
@@ -9,6 +9,7 @@ import {
   X,
   Plus,
   Link as LinkIcon,
+  ExternalLink,
   MessageSquare,
   Phone,
   Mail,
@@ -771,9 +772,19 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
                 <div className="space-y-2">
                   <div className="flex items-center gap-2 flex-wrap">
                     {status.visible ? (
-                      <Badge variant="green">
-                        Zichtbaar op /c/{linkedInit.slug}
-                      </Badge>
+                      <a
+                        href={`/c/${linkedInit.slug}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 group"
+                      >
+                        <Badge variant="green">
+                          <span className="inline-flex items-center gap-1 group-hover:underline">
+                            Zichtbaar op /c/{linkedInit.slug}
+                            <ExternalLink className="h-3 w-3" />
+                          </span>
+                        </Badge>
+                      </a>
                     ) : (
                       <Badge variant="gray">Niet zichtbaar</Badge>
                     )}

--- a/frontend/src/components/leads/LeadDetailPanel.tsx
+++ b/frontend/src/components/leads/LeadDetailPanel.tsx
@@ -57,8 +57,9 @@ import {
   LEAD_ACTIVITY_TYPE_LABELS,
   INITIATIEF_COLORS,
   LEAD_CONTACT_ROL_LABELS,
+  ENGAGEMENT_TYPE_LABELS,
 } from '@/types';
-import type { LeadUpdate, LeadActivityCreate } from '@/types';
+import type { LeadUpdate, LeadActivityCreate, EngagementType } from '@/types';
 
 interface LeadDetailPanelProps {
   leadId: string | null;
@@ -73,6 +74,7 @@ const ACTIVITY_ICONS: Record<LeadActivityType, React.ReactNode> = {
   [LeadActivityType.MEETING]: <User className="h-3.5 w-3.5" />,
   [LeadActivityType.CALL]: <Phone className="h-3.5 w-3.5" />,
   [LeadActivityType.EMAIL]: <Mail className="h-3.5 w-3.5" />,
+  [LeadActivityType.EVALUATIE]: <FileText className="h-3.5 w-3.5" />,
 };
 
 export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPanelProps) {
@@ -111,10 +113,16 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
   const [editNextActionDate, setEditNextActionDate] = useState('');
   const [editInitiatiefId, setEditInitiatiefId] = useState('');
   const [editTags, setEditTags] = useState('');
+  const [editEngagementType, setEditEngagementType] = useState<EngagementType | ''>('');
+  const [editScoreStrategisch, setEditScoreStrategisch] = useState<number | ''>('');
+  const [editScorePolitiek, setEditScorePolitiek] = useState<number | ''>('');
+  const [editScorePositie, setEditScorePositie] = useState<number | ''>('');
 
   // Activity form
   const [activityContent, setActivityContent] = useState('');
   const [activityType, setActivityType] = useState<LeadActivityType>(LeadActivityType.NOTE);
+  const [activityUitkomst, setActivityUitkomst] = useState('');
+  const [activityVervolgacties, setActivityVervolgacties] = useState('');
 
   // Contact add form
   const [showAddContact, setShowAddContact] = useState(false);
@@ -150,6 +158,10 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
     setEditNextActionDate(lead.next_action_date ?? '');
     setEditInitiatiefId(lead.initiatief_id ?? '');
     setEditTags((leadTags ?? []).map((lt) => lt.tag.name).join(', '));
+    setEditEngagementType(lead.engagement_type ?? '');
+    setEditScoreStrategisch(lead.score_strategisch ?? '');
+    setEditScorePolitiek(lead.score_politiek ?? '');
+    setEditScorePositie(lead.score_positie ?? '');
     setEditing(true);
   };
 
@@ -169,6 +181,10 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
       next_action: editNextAction.trim() || null,
       next_action_date: editNextActionDate || null,
       initiatief_id: editInitiatiefId || null,
+      engagement_type: editEngagementType || null,
+      score_strategisch: editScoreStrategisch === '' ? null : editScoreStrategisch,
+      score_politiek: editScorePolitiek === '' ? null : editScorePolitiek,
+      score_positie: editScorePositie === '' ? null : editScorePositie,
     };
 
     // Update lead fields
@@ -225,6 +241,14 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
     const data: LeadActivityCreate = {
       content: activityContent,
       activity_type: activityType,
+      uitkomst:
+        activityType === LeadActivityType.EVALUATIE
+          ? activityUitkomst.trim() || null
+          : null,
+      vervolgacties:
+        activityType === LeadActivityType.EVALUATIE
+          ? activityVervolgacties.trim() || null
+          : null,
     };
     createActivity.mutate(
       { leadId: lead.id, data },
@@ -232,6 +256,8 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
         onSuccess: () => {
           setActivityContent('');
           setActivityType(LeadActivityType.NOTE);
+          setActivityUitkomst('');
+          setActivityVervolgacties('');
         },
       },
     );
@@ -416,6 +442,75 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
               placeholder="Komma-gescheiden tags"
             />
           </div>
+          {(() => {
+            const selectedInit = initiatieven?.find((i) => i.id === editInitiatiefId);
+            if (!selectedInit?.funnel_enabled) return null;
+            const labelStrategisch =
+              selectedInit.score_strategisch_label || 'Strategisch belang';
+            const labelPolitiek =
+              selectedInit.score_politiek_label || 'Politiek belang';
+            const labelPositie =
+              selectedInit.score_positie_label || 'Positie / omgeving';
+            return (
+              <div className="space-y-3 rounded-lg border border-border p-3 bg-gray-50/50">
+                <div className="text-xs text-text-secondary uppercase tracking-wider font-semibold">
+                  Funnel-afweging
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-text mb-1">
+                    Engagement type
+                  </label>
+                  <select
+                    value={editEngagementType}
+                    onChange={(e) =>
+                      setEditEngagementType(
+                        (e.target.value || '') as EngagementType | '',
+                      )
+                    }
+                    className="w-full rounded-lg border border-border px-3 py-2 text-sm bg-white focus:outline-none focus:border-primary-400"
+                  >
+                    <option value="">—</option>
+                    {(
+                      Object.keys(ENGAGEMENT_TYPE_LABELS) as EngagementType[]
+                    ).map((k) => (
+                      <option key={k} value={k}>
+                        {ENGAGEMENT_TYPE_LABELS[k]}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="grid grid-cols-3 gap-2">
+                  {(
+                    [
+                      [labelStrategisch, editScoreStrategisch, setEditScoreStrategisch],
+                      [labelPolitiek, editScorePolitiek, setEditScorePolitiek],
+                      [labelPositie, editScorePositie, setEditScorePositie],
+                    ] as const
+                  ).map(([label, value, setter], idx) => (
+                    <label key={idx} className="flex flex-col gap-0.5">
+                      <span className="text-xs text-text-secondary">{label}</span>
+                      <select
+                        value={value}
+                        onChange={(e) =>
+                          setter(
+                            e.target.value === '' ? '' : Number(e.target.value),
+                          )
+                        }
+                        className="text-sm rounded-lg border border-border px-2 py-1 bg-white"
+                      >
+                        <option value="">—</option>
+                        {[1, 2, 3, 4, 5].map((n) => (
+                          <option key={n} value={n}>
+                            {n}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  ))}
+                </div>
+              </div>
+            );
+          })()}
           <RichTextFormField
             label="Beschrijving"
             value={editDescription}
@@ -501,6 +596,49 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
               },
             ]}
           />
+
+          {/* Funnel-afweging (only when initiatief has funnel_enabled) */}
+          {(() => {
+            const linkedInit = initiatieven?.find(
+              (i) => i.id === lead.initiatief_id,
+            );
+            if (!linkedInit?.funnel_enabled) return null;
+            const hasAny =
+              lead.engagement_type ||
+              lead.score_strategisch != null ||
+              lead.score_politiek != null ||
+              lead.score_positie != null;
+            if (!hasAny) return null;
+            const labels = [
+              [linkedInit.score_strategisch_label || 'Strategisch belang', lead.score_strategisch],
+              [linkedInit.score_politiek_label || 'Politiek belang', lead.score_politiek],
+              [linkedInit.score_positie_label || 'Positie / omgeving', lead.score_positie],
+            ] as const;
+            return (
+              <DetailSection title="Funnel-afweging">
+                <div className="space-y-2">
+                  {lead.engagement_type && (
+                    <div className="text-sm">
+                      <span className="text-text-secondary">Engagement: </span>
+                      <span className="text-text font-medium">
+                        {ENGAGEMENT_TYPE_LABELS[lead.engagement_type]}
+                      </span>
+                    </div>
+                  )}
+                  <div className="grid grid-cols-3 gap-2 text-sm">
+                    {labels.map(([label, value], idx) => (
+                      <div key={idx} className="text-text">
+                        <div className="text-xs text-text-secondary">{label}</div>
+                        <div className="font-medium">
+                          {value != null ? `${value}/5` : '—'}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </DetailSection>
+            );
+          })()}
 
           {/* Tags */}
           {(leadTags ?? []).length > 0 && (
@@ -722,6 +860,24 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
                 placeholder="Voeg een notitie of activiteit toe... Gebruik @ voor personen, # voor nodes/taken"
                 rows={2}
               />
+              {activityType === LeadActivityType.EVALUATIE && (
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                  <textarea
+                    value={activityUitkomst}
+                    onChange={(e) => setActivityUitkomst(e.target.value)}
+                    placeholder="Uitkomst van de evaluatie..."
+                    rows={2}
+                    className="text-sm rounded-lg border border-border px-2 py-1 focus:outline-none focus:ring-2 focus:ring-primary"
+                  />
+                  <textarea
+                    value={activityVervolgacties}
+                    onChange={(e) => setActivityVervolgacties(e.target.value)}
+                    placeholder="Vervolgacties / wat moet er nu gebeuren..."
+                    rows={2}
+                    className="text-sm rounded-lg border border-border px-2 py-1 focus:outline-none focus:ring-2 focus:ring-primary"
+                  />
+                </div>
+              )}
               <div className="flex items-center gap-2">
                 <div className="w-36">
                   <CreatableSelect
@@ -766,6 +922,30 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
                       <div className="mt-0.5">
                         <RichTextDisplay content={activity.content} fallback="" />
                       </div>
+                      {(activity.uitkomst || activity.vervolgacties) && (
+                        <div className="mt-1.5 grid grid-cols-1 sm:grid-cols-2 gap-2">
+                          {activity.uitkomst && (
+                            <div className="rounded-md bg-emerald-50 border border-emerald-200 px-2 py-1.5 text-xs">
+                              <div className="font-semibold text-emerald-800 mb-0.5">
+                                Uitkomst
+                              </div>
+                              <div className="text-text whitespace-pre-wrap">
+                                {activity.uitkomst}
+                              </div>
+                            </div>
+                          )}
+                          {activity.vervolgacties && (
+                            <div className="rounded-md bg-amber-50 border border-amber-200 px-2 py-1.5 text-xs">
+                              <div className="font-semibold text-amber-800 mb-0.5">
+                                Vervolgacties
+                              </div>
+                              <div className="text-text whitespace-pre-wrap">
+                                {activity.vervolgacties}
+                              </div>
+                            </div>
+                          )}
+                        </div>
+                      )}
                     </div>
                   </div>
                 ))}

--- a/frontend/src/components/leads/LeadDetailPanel.tsx
+++ b/frontend/src/components/leads/LeadDetailPanel.tsx
@@ -118,6 +118,9 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
   const [editScoreStrategisch, setEditScoreStrategisch] = useState<number | ''>('');
   const [editScorePolitiek, setEditScorePolitiek] = useState<number | ''>('');
   const [editScorePositie, setEditScorePositie] = useState<number | ''>('');
+  const [editPublicVisible, setEditPublicVisible] = useState(false);
+  const [editPublicTitle, setEditPublicTitle] = useState('');
+  const [editPublicSummary, setEditPublicSummary] = useState('');
 
   // Activity form
   const [activityContent, setActivityContent] = useState('');
@@ -163,6 +166,9 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
     setEditScoreStrategisch(lead.score_strategisch ?? '');
     setEditScorePolitiek(lead.score_politiek ?? '');
     setEditScorePositie(lead.score_positie ?? '');
+    setEditPublicVisible(lead.public_visible);
+    setEditPublicTitle(lead.public_title ?? '');
+    setEditPublicSummary(lead.public_summary ?? '');
     setEditing(true);
   };
 
@@ -186,6 +192,9 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
       score_strategisch: editScoreStrategisch === '' ? null : editScoreStrategisch,
       score_politiek: editScorePolitiek === '' ? null : editScorePolitiek,
       score_positie: editScorePositie === '' ? null : editScorePositie,
+      public_visible: editPublicVisible,
+      public_title: editPublicTitle.trim() || null,
+      public_summary: editPublicSummary.trim() || null,
     };
 
     // Update lead fields
@@ -512,6 +521,62 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
               </div>
             );
           })()}
+          {(() => {
+            const linkedInit = initiatieven?.find((i) => i.id === editInitiatiefId);
+            if (!linkedInit?.public_page_enabled) return null;
+            return (
+              <div className="space-y-3 rounded-lg border border-emerald-200 bg-emerald-50/40 p-3">
+                <div className="flex items-center justify-between gap-2">
+                  <div className="text-xs text-emerald-900 uppercase tracking-wider font-semibold">
+                    Publicatie op /c/{linkedInit.slug}
+                  </div>
+                  <label className="flex items-center gap-2 text-sm text-emerald-900 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={editPublicVisible}
+                      onChange={(e) => setEditPublicVisible(e.target.checked)}
+                      className="h-4 w-4 rounded border-emerald-300 text-emerald-600 focus:ring-emerald-500"
+                    />
+                    Publiek tonen
+                  </label>
+                </div>
+                <p className="text-xs text-emerald-800/80">
+                  Schrijf een externe titel en samenvatting. Alleen die tekst
+                  verschijnt op de publieke pagina, nooit het interne titel- of
+                  beschrijvingsveld.
+                </p>
+                <div>
+                  <label className="block text-sm font-medium text-text mb-1">
+                    Publieke titel
+                  </label>
+                  <input
+                    type="text"
+                    value={editPublicTitle}
+                    onChange={(e) => setEditPublicTitle(e.target.value)}
+                    placeholder="Bijv. 'Pilot bij Gemeente Utrecht'"
+                    className="w-full rounded-lg border border-border px-3 py-2 text-sm bg-white focus:outline-none focus:border-emerald-400"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-text mb-1">
+                    Publieke samenvatting
+                  </label>
+                  <textarea
+                    value={editPublicSummary}
+                    onChange={(e) => setEditPublicSummary(e.target.value)}
+                    placeholder="Korte tekst voor buitenstaanders. Geen interne details, geen namen van conflicten."
+                    rows={3}
+                    className="w-full rounded-lg border border-border px-3 py-2 text-sm bg-white focus:outline-none focus:border-emerald-400"
+                  />
+                </div>
+                <p className="text-xs text-text-secondary">
+                  Verschijnt alleen als de stage actief is (eerste gesprek, interne
+                  check, follow-up of in the pocket) én "Publiek tonen" aan staat én
+                  de titel ingevuld is.
+                </p>
+              </div>
+            );
+          })()}
           <RichTextFormField
             label="Beschrijving"
             value={editDescription}
@@ -638,6 +703,43 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
                       </div>
                     ))}
                   </div>
+                </div>
+              </DetailSection>
+            );
+          })()}
+
+          {/* Publicatie-status */}
+          {(() => {
+            const linkedInit = initiatieven?.find(
+              (i) => i.id === lead.initiatief_id,
+            );
+            if (!linkedInit?.public_page_enabled) return null;
+            if (!lead.public_visible && !lead.public_title) return null;
+            return (
+              <DetailSection title="Publicatie">
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    {lead.public_visible && lead.public_title ? (
+                      <Badge variant="green">
+                        Zichtbaar op /c/{linkedInit.slug}
+                      </Badge>
+                    ) : (
+                      <Badge variant="gray">Niet zichtbaar</Badge>
+                    )}
+                  </div>
+                  {lead.public_title && (
+                    <div className="text-sm">
+                      <span className="text-text-secondary">Publieke titel: </span>
+                      <span className="text-text font-medium">
+                        {lead.public_title}
+                      </span>
+                    </div>
+                  )}
+                  {lead.public_summary && (
+                    <div className="text-sm text-text-secondary whitespace-pre-wrap">
+                      {lead.public_summary}
+                    </div>
+                  )}
                 </div>
               </DetailSection>
             );

--- a/frontend/src/components/leads/LeadDetailPanel.tsx
+++ b/frontend/src/components/leads/LeadDetailPanel.tsx
@@ -58,6 +58,7 @@ import {
   INITIATIEF_COLORS,
   LEAD_CONTACT_ROL_LABELS,
   ENGAGEMENT_TYPE_LABELS,
+  ENGAGEMENT_TYPE_COLORS,
 } from '@/types';
 import type { LeadUpdate, LeadActivityCreate, EngagementType } from '@/types';
 
@@ -620,7 +621,9 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
                   {lead.engagement_type && (
                     <div className="text-sm">
                       <span className="text-text-secondary">Engagement: </span>
-                      <span className="text-text font-medium">
+                      <span
+                        className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${ENGAGEMENT_TYPE_COLORS[lead.engagement_type]}`}
+                      >
                         {ENGAGEMENT_TYPE_LABELS[lead.engagement_type]}
                       </span>
                     </div>

--- a/frontend/src/components/leads/LeadDetailPanel.tsx
+++ b/frontend/src/components/leads/LeadDetailPanel.tsx
@@ -62,6 +62,42 @@ import {
 } from '@/types';
 import type { LeadUpdate, LeadActivityCreate, EngagementType } from '@/types';
 
+/** Stages where a lead can publicly appear; mirrors the backend filter in
+ *  public_initiatief.py — keep in sync. */
+const PUBLIC_VISIBLE_STAGES: LeadStage[] = [
+  LeadStage.EERSTE_GESPREK,
+  LeadStage.INTERNE_CHECK,
+  LeadStage.FOLLOW_UP,
+  LeadStage.IN_THE_POCKET,
+];
+
+interface PublicationStatus {
+  /** Will this lead actually appear on the public page right now? */
+  visible: boolean;
+  /** Human-readable reason when not visible. Null when visible. */
+  reason: string | null;
+}
+
+function publicationStatus(args: {
+  publicVisible: boolean;
+  publicTitle: string | null;
+  stage: LeadStage;
+}): PublicationStatus {
+  if (!args.publicVisible) {
+    return { visible: false, reason: 'Toggle "Publiek tonen" staat uit.' };
+  }
+  if (!args.publicTitle?.trim()) {
+    return { visible: false, reason: 'Publieke titel is leeg.' };
+  }
+  if (!PUBLIC_VISIBLE_STAGES.includes(args.stage)) {
+    return {
+      visible: false,
+      reason: `Lead in stage "${LEAD_STAGE_LABELS[args.stage]}" — alleen actieve stages worden publiek.`,
+    };
+  }
+  return { visible: true, reason: null };
+}
+
 interface LeadDetailPanelProps {
   leadId: string | null;
   open: boolean;
@@ -524,6 +560,11 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
           {(() => {
             const linkedInit = initiatieven?.find((i) => i.id === editInitiatiefId);
             if (!linkedInit?.public_page_enabled) return null;
+            const status = publicationStatus({
+              publicVisible: editPublicVisible,
+              publicTitle: editPublicTitle,
+              stage: editStage,
+            });
             return (
               <div className="space-y-3 rounded-lg border border-emerald-200 bg-emerald-50/40 p-3">
                 <div className="flex items-center justify-between gap-2">
@@ -540,6 +581,11 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
                     Publiek tonen
                   </label>
                 </div>
+                {editPublicVisible && !status.visible && (
+                  <div className="rounded-md bg-amber-50 border border-amber-200 px-2 py-1.5 text-xs text-amber-900">
+                    <strong>Nog niet zichtbaar:</strong> {status.reason}
+                  </div>
+                )}
                 <p className="text-xs text-emerald-800/80">
                   Schrijf een externe titel en samenvatting. Alleen die tekst
                   verschijnt op de publieke pagina, nooit het interne titel- of
@@ -715,11 +761,16 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
             );
             if (!linkedInit?.public_page_enabled) return null;
             if (!lead.public_visible && !lead.public_title) return null;
+            const status = publicationStatus({
+              publicVisible: lead.public_visible,
+              publicTitle: lead.public_title,
+              stage: lead.stage,
+            });
             return (
               <DetailSection title="Publicatie">
                 <div className="space-y-2">
-                  <div className="flex items-center gap-2">
-                    {lead.public_visible && lead.public_title ? (
+                  <div className="flex items-center gap-2 flex-wrap">
+                    {status.visible ? (
                       <Badge variant="green">
                         Zichtbaar op /c/{linkedInit.slug}
                       </Badge>
@@ -727,6 +778,11 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
                       <Badge variant="gray">Niet zichtbaar</Badge>
                     )}
                   </div>
+                  {!status.visible && status.reason && (
+                    <p className="text-xs text-text-secondary">
+                      {status.reason}
+                    </p>
+                  )}
                   {lead.public_title && (
                     <div className="text-sm">
                       <span className="text-text-secondary">Publieke titel: </span>

--- a/frontend/src/components/nodes/NodeDetail.tsx
+++ b/frontend/src/components/nodes/NodeDetail.tsx
@@ -28,6 +28,7 @@ import { uploadBijlage, deleteBijlage, getBijlageDownloadUrl, updateNodeBronDeta
 import { useVocabulary } from '@/contexts/VocabularyContext';
 import { useToast } from '@/contexts/ToastContext';
 import { formatDate } from '@/utils/dates';
+import { StakeholderTab } from '@/components/stakeholders/StakeholderTab';
 
 type TabId = 'overview' | 'connections' | 'stakeholders' | 'tasks' | 'activity';
 
@@ -805,6 +806,17 @@ export function NodeDetail({ nodeId }: NodeDetailProps) {
                 description="Er zijn nog geen personen gekoppeld aan deze node."
               />
             )}
+
+            <div className="pt-4 mt-4 border-t border-border">
+              <h4 className="text-sm font-medium text-text mb-2">
+                Belang, houding & invloed
+              </h4>
+              <p className="text-xs text-text-secondary mb-3">
+                Inschatting per stakeholder, los van rol. Aparte assessment voor
+                analyse-doeleinden.
+              </p>
+              <StakeholderTab scopeType="corpus_node" scopeId={nodeId} />
+            </div>
           </div>
         )}
 

--- a/frontend/src/components/stakeholders/StakeholderTab.tsx
+++ b/frontend/src/components/stakeholders/StakeholderTab.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Trash2 } from 'lucide-react';
 import { Badge } from '@/components/common/Badge';
 import { CreatableSelect } from '@/components/common/CreatableSelect';
@@ -130,14 +130,9 @@ export function StakeholderTab({
                 />
               </div>
               {!readOnly && (
-                <textarea
-                  value={a.notitie ?? ''}
-                  onChange={(e) =>
-                    handleUpdate(a, { notitie: e.target.value || null })
-                  }
-                  placeholder="Notitie (optioneel)"
-                  rows={2}
-                  className="w-full text-sm rounded-lg border border-border px-2 py-1 focus:outline-none focus:ring-2 focus:ring-primary"
+                <NoteEditor
+                  value={a.notitie}
+                  onPersist={(value) => handleUpdate(a, { notitie: value })}
                 />
               )}
               {readOnly && a.notitie && (
@@ -247,5 +242,42 @@ function HoudingSelect({
         ))}
       </select>
     </label>
+  );
+}
+
+function NoteEditor({
+  value,
+  onPersist,
+}: {
+  value: string | null;
+  onPersist: (v: string | null) => void;
+}) {
+  // Local draft so typing doesn't fire a PUT per keystroke. Persist on blur.
+  // Sync from server only when not actively editing.
+  const [draft, setDraft] = useState(value ?? '');
+  const [focused, setFocused] = useState(false);
+
+  useEffect(() => {
+    if (!focused) {
+      setDraft(value ?? '');
+    }
+  }, [value, focused]);
+
+  return (
+    <textarea
+      value={draft}
+      onChange={(e) => setDraft(e.target.value)}
+      onFocus={() => setFocused(true)}
+      onBlur={() => {
+        setFocused(false);
+        const next = draft.trim() ? draft : null;
+        if (next !== (value ?? null)) {
+          onPersist(next);
+        }
+      }}
+      placeholder="Notitie (optioneel)"
+      rows={2}
+      className="w-full text-sm rounded-lg border border-border px-2 py-1 focus:outline-none focus:ring-2 focus:ring-primary"
+    />
   );
 }

--- a/frontend/src/components/stakeholders/StakeholderTab.tsx
+++ b/frontend/src/components/stakeholders/StakeholderTab.tsx
@@ -1,0 +1,251 @@
+import { useMemo, useState } from 'react';
+import { Trash2 } from 'lucide-react';
+import { Badge } from '@/components/common/Badge';
+import { CreatableSelect } from '@/components/common/CreatableSelect';
+import { LoadingSpinner } from '@/components/common/LoadingSpinner';
+import {
+  useStakeholderAssessments,
+  useCreateStakeholderAssessment,
+  useUpdateStakeholderAssessment,
+  useDeleteStakeholderAssessment,
+} from '@/hooks/useStakeholderAssessments';
+import { usePeople } from '@/hooks/usePeople';
+import {
+  STAKEHOLDER_HOUDING_LABELS,
+  STAKEHOLDER_HOUDING_COLORS,
+} from '@/types';
+import type {
+  StakeholderAssessment,
+  StakeholderHouding,
+  StakeholderScopeType,
+} from '@/types';
+
+interface StakeholderTabProps {
+  scopeType: StakeholderScopeType;
+  scopeId: string;
+  readOnly?: boolean;
+}
+
+const HOUDING_OPTIONS: StakeholderHouding[] = [
+  'tegen',
+  'kritisch',
+  'neutraal',
+  'welwillend',
+  'voorstander',
+];
+
+const SCORE_OPTIONS = [1, 2, 3, 4, 5];
+
+export function StakeholderTab({
+  scopeType,
+  scopeId,
+  readOnly = false,
+}: StakeholderTabProps) {
+  const { data: assessments = [], isLoading } = useStakeholderAssessments(
+    scopeType,
+    scopeId,
+  );
+  const { data: allPeople = [] } = usePeople();
+  const createMutation = useCreateStakeholderAssessment();
+  const updateMutation = useUpdateStakeholderAssessment();
+  const deleteMutation = useDeleteStakeholderAssessment();
+  const [addValue, setAddValue] = useState('');
+
+  const availableOptions = useMemo(() => {
+    const linkedIds = new Set(assessments.map((a) => a.person_id));
+    return allPeople
+      .filter((p) => !linkedIds.has(p.id) && !p.is_agent)
+      .map((p) => ({ value: p.id, label: p.naam }));
+  }, [allPeople, assessments]);
+
+  const handleAdd = async (personId: string) => {
+    if (!personId) return;
+    await createMutation.mutateAsync({
+      person_id: personId,
+      scope_type: scopeType,
+      scope_id: scopeId,
+    });
+    setAddValue('');
+  };
+
+  const handleUpdate = (
+    a: StakeholderAssessment,
+    patch: Partial<StakeholderAssessment>,
+  ) => {
+    updateMutation.mutate({
+      id: a.id,
+      data: patch,
+      scopeType,
+      scopeId,
+    });
+  };
+
+  const handleDelete = (a: StakeholderAssessment) => {
+    deleteMutation.mutate({ id: a.id, scopeType, scopeId });
+  };
+
+  if (isLoading) return <LoadingSpinner className="py-6" />;
+
+  return (
+    <div className="space-y-3">
+      {assessments.length === 0 ? (
+        <p className="text-sm text-text-secondary">
+          Nog geen stakeholders geregistreerd.
+        </p>
+      ) : (
+        <ul className="divide-y divide-border rounded-xl border border-border">
+          {assessments.map((a) => (
+            <li key={a.id} className="px-3 py-3 space-y-2">
+              <div className="flex items-center justify-between gap-2">
+                <div className="font-medium text-sm text-text">
+                  {a.person_naam}
+                </div>
+                {!readOnly && (
+                  <button
+                    onClick={() => handleDelete(a)}
+                    className="p-1 rounded hover:bg-gray-100 text-text-secondary hover:text-red-500 transition-colors"
+                    title="Verwijderen"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                )}
+              </div>
+              <div className="grid grid-cols-3 gap-2">
+                <ScoreSelect
+                  label="Belang"
+                  value={a.belang}
+                  onChange={(v) => handleUpdate(a, { belang: v })}
+                  disabled={readOnly}
+                />
+                <HoudingSelect
+                  value={a.houding}
+                  onChange={(v) => handleUpdate(a, { houding: v })}
+                  disabled={readOnly}
+                />
+                <ScoreSelect
+                  label="Invloed"
+                  value={a.invloed}
+                  onChange={(v) => handleUpdate(a, { invloed: v })}
+                  disabled={readOnly}
+                />
+              </div>
+              {!readOnly && (
+                <textarea
+                  value={a.notitie ?? ''}
+                  onChange={(e) =>
+                    handleUpdate(a, { notitie: e.target.value || null })
+                  }
+                  placeholder="Notitie (optioneel)"
+                  rows={2}
+                  className="w-full text-sm rounded-lg border border-border px-2 py-1 focus:outline-none focus:ring-2 focus:ring-primary"
+                />
+              )}
+              {readOnly && a.notitie && (
+                <p className="text-sm text-text-secondary whitespace-pre-wrap">
+                  {a.notitie}
+                </p>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {!readOnly && (
+        <div className="flex items-start gap-2">
+          <div className="flex-1">
+            <CreatableSelect
+              value={addValue}
+              onChange={(v) => {
+                setAddValue(v);
+                if (v) handleAdd(v);
+              }}
+              options={availableOptions}
+              placeholder="Persoon toevoegen..."
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ScoreSelect({
+  label,
+  value,
+  onChange,
+  disabled,
+}: {
+  label: string;
+  value: number | null;
+  onChange: (v: number | null) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <label className="flex flex-col gap-0.5">
+      <span className="text-xs text-text-secondary">{label}</span>
+      <select
+        value={value ?? ''}
+        onChange={(e) =>
+          onChange(e.target.value === '' ? null : Number(e.target.value))
+        }
+        disabled={disabled}
+        className="text-sm rounded-lg border border-border px-2 py-1 focus:outline-none focus:ring-2 focus:ring-primary disabled:bg-gray-50"
+      >
+        <option value="">—</option>
+        {SCORE_OPTIONS.map((n) => (
+          <option key={n} value={n}>
+            {n}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+function HoudingSelect({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: StakeholderHouding | null;
+  onChange: (v: StakeholderHouding | null) => void;
+  disabled?: boolean;
+}) {
+  if (disabled) {
+    return (
+      <div className="flex flex-col gap-0.5">
+        <span className="text-xs text-text-secondary">Houding</span>
+        {value ? (
+          <Badge className={STAKEHOLDER_HOUDING_COLORS[value]}>
+            {STAKEHOLDER_HOUDING_LABELS[value]}
+          </Badge>
+        ) : (
+          <span className="text-sm text-text-secondary">—</span>
+        )}
+      </div>
+    );
+  }
+  return (
+    <label className="flex flex-col gap-0.5">
+      <span className="text-xs text-text-secondary">Houding</span>
+      <select
+        value={value ?? ''}
+        onChange={(e) =>
+          onChange(
+            e.target.value === ''
+              ? null
+              : (e.target.value as StakeholderHouding),
+          )
+        }
+        className="text-sm rounded-lg border border-border px-2 py-1 focus:outline-none focus:ring-2 focus:ring-primary"
+      >
+        <option value="">—</option>
+        {HOUDING_OPTIONS.map((h) => (
+          <option key={h} value={h}>
+            {STAKEHOLDER_HOUDING_LABELS[h]}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/frontend/src/contexts/NodeDetailContext.tsx
+++ b/frontend/src/contexts/NodeDetailContext.tsx
@@ -13,10 +13,19 @@ interface NodeDetailContextValue {
 
 const NodeDetailContext = createContext<NodeDetailContextValue | null>(null);
 
+/** No-op fallback for read-only / public contexts (e.g. /c/:slug page) where
+ *  the provider isn't mounted but a child component (RichTextDisplay) still
+ *  calls the hook. Mention buttons become harmless click-throughs. */
+const NOOP_NODE_DETAIL: NodeDetailContextValue = {
+  openNodeDetail: () => {},
+  nodeDetailId: null,
+  nodeParentLabel: null,
+  closeNodeDetail: () => {},
+  nodeOpenSeq: 0,
+};
+
 export function useNodeDetail() {
-  const ctx = useContext(NodeDetailContext);
-  if (!ctx) throw new Error('useNodeDetail must be used within NodeDetailProvider');
-  return ctx;
+  return useContext(NodeDetailContext) ?? NOOP_NODE_DETAIL;
 }
 
 export function NodeDetailProvider({ children }: { children: React.ReactNode }) {

--- a/frontend/src/contexts/TaskDetailContext.tsx
+++ b/frontend/src/contexts/TaskDetailContext.tsx
@@ -13,10 +13,19 @@ interface TaskDetailContextValue {
 
 const TaskDetailContext = createContext<TaskDetailContextValue | null>(null);
 
+/** No-op fallback for read-only / public contexts (e.g. /c/:slug page) where
+ *  the provider isn't mounted but a child component (RichTextDisplay) still
+ *  calls the hook. */
+const NOOP_TASK_DETAIL: TaskDetailContextValue = {
+  openTaskDetail: () => {},
+  taskDetailId: null,
+  taskParentLabel: null,
+  closeTaskDetail: () => {},
+  taskOpenSeq: 0,
+};
+
 export function useTaskDetail() {
-  const ctx = useContext(TaskDetailContext);
-  if (!ctx) throw new Error('useTaskDetail must be used within TaskDetailProvider');
-  return ctx;
+  return useContext(TaskDetailContext) ?? NOOP_TASK_DETAIL;
 }
 
 export function TaskDetailProvider({ children }: { children: React.ReactNode }) {

--- a/frontend/src/hooks/useInitiatieven.ts
+++ b/frontend/src/hooks/useInitiatieven.ts
@@ -4,6 +4,7 @@ import {
   getInitiatief,
   createInitiatief,
   updateInitiatief,
+  updateInitiatiefSettings,
   deleteInitiatief,
   addInitiatiefMember,
   removeInitiatiefMember,
@@ -12,9 +13,21 @@ import {
   removeInitiatiefEenheid,
   updateInitiatiefEenheidRol,
   getInitiatievenForEenheid,
+  getInitiatiefUpdates,
+  createInitiatiefUpdate,
+  editInitiatiefUpdate,
+  publishInitiatiefUpdate,
+  unpublishInitiatiefUpdate,
+  deleteInitiatiefUpdate,
 } from '@/api/initiatieven';
 import { queryKeys } from '@/hooks/queryKeys';
-import type { InitiatiefCreate, InitiatiefUpdate } from '@/types';
+import type {
+  InitiatiefCreate,
+  InitiatiefSettingsUpdate,
+  InitiatiefUpdate,
+  InitiatiefUpdatePostCreate,
+  InitiatiefUpdatePostEdit,
+} from '@/types';
 
 export function useInitiatieven(params?: { search?: string }) {
   return useQuery({
@@ -172,5 +185,113 @@ export function useInitiatievenForEenheid(eenheidId: string | null) {
     queryKey: ['initiatieven-for-eenheid', eenheidId],
     queryFn: () => getInitiatievenForEenheid(eenheidId!),
     enabled: !!eenheidId,
+  });
+}
+
+export function useUpdateInitiatiefSettings() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: InitiatiefSettingsUpdate }) =>
+      updateInitiatiefSettings(id, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.initiatieven.all });
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// InitiatiefUpdatePost hooks
+// ---------------------------------------------------------------------------
+
+const initiatiefUpdatesKey = (initiatiefId: string | undefined) =>
+  ['initiatief-updates', initiatiefId] as const;
+
+export function useInitiatiefUpdates(initiatiefId: string | undefined) {
+  return useQuery({
+    queryKey: initiatiefUpdatesKey(initiatiefId),
+    queryFn: () => getInitiatiefUpdates(initiatiefId!),
+    enabled: !!initiatiefId,
+  });
+}
+
+export function useCreateInitiatiefUpdate() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      initiatiefId,
+      data,
+    }: {
+      initiatiefId: string;
+      data: InitiatiefUpdatePostCreate;
+    }) => createInitiatiefUpdate(initiatiefId, data),
+    onSuccess: (_data, { initiatiefId }) => {
+      qc.invalidateQueries({ queryKey: initiatiefUpdatesKey(initiatiefId) });
+    },
+  });
+}
+
+export function useEditInitiatiefUpdate() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      initiatiefId,
+      postId,
+      data,
+    }: {
+      initiatiefId: string;
+      postId: string;
+      data: InitiatiefUpdatePostEdit;
+    }) => editInitiatiefUpdate(initiatiefId, postId, data),
+    onSuccess: (_data, { initiatiefId }) => {
+      qc.invalidateQueries({ queryKey: initiatiefUpdatesKey(initiatiefId) });
+    },
+  });
+}
+
+export function usePublishInitiatiefUpdate() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      initiatiefId,
+      postId,
+    }: {
+      initiatiefId: string;
+      postId: string;
+    }) => publishInitiatiefUpdate(initiatiefId, postId),
+    onSuccess: (_data, { initiatiefId }) => {
+      qc.invalidateQueries({ queryKey: initiatiefUpdatesKey(initiatiefId) });
+    },
+  });
+}
+
+export function useUnpublishInitiatiefUpdate() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      initiatiefId,
+      postId,
+    }: {
+      initiatiefId: string;
+      postId: string;
+    }) => unpublishInitiatiefUpdate(initiatiefId, postId),
+    onSuccess: (_data, { initiatiefId }) => {
+      qc.invalidateQueries({ queryKey: initiatiefUpdatesKey(initiatiefId) });
+    },
+  });
+}
+
+export function useDeleteInitiatiefUpdate() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      initiatiefId,
+      postId,
+    }: {
+      initiatiefId: string;
+      postId: string;
+    }) => deleteInitiatiefUpdate(initiatiefId, postId),
+    onSuccess: (_data, { initiatiefId }) => {
+      qc.invalidateQueries({ queryKey: initiatiefUpdatesKey(initiatiefId) });
+    },
   });
 }

--- a/frontend/src/hooks/useLeads.ts
+++ b/frontend/src/hooks/useLeads.ts
@@ -105,9 +105,12 @@ export function useMoveLead() {
       console.error('Fout bij verplaatsen lead:', error);
       showError('Fout bij verplaatsen lead');
     },
-    onSettled: () => {
+    onSettled: (_data, _error, { id }) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.leads.lists() });
       queryClient.invalidateQueries({ queryKey: queryKeys.leads.metrics() });
+      // Detail-cache moet ook ververst zodat zichtbaarheidsstatus en andere
+      // afgeleide UI (bv. publicatie-badge) klopt met nieuwe stage.
+      queryClient.invalidateQueries({ queryKey: queryKeys.leads.detail(id) });
     },
   });
 }
@@ -153,8 +156,13 @@ export function useReorderLeads() {
       console.error('Fout bij herordenen leads:', error);
       showError('Fout bij herordenen leads');
     },
-    onSettled: () => {
+    onSettled: (_data, _error, { leadIds }) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.leads.lists() });
+      // Invalideer details van alle verplaatste leads zodat afgeleide UI
+      // (publicatie-status, stage-badge) klopt.
+      for (const id of leadIds) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.leads.detail(id) });
+      }
     },
   });
 }

--- a/frontend/src/hooks/useStakeholderAssessments.ts
+++ b/frontend/src/hooks/useStakeholderAssessments.ts
@@ -1,0 +1,71 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  getStakeholderAssessments,
+  createStakeholderAssessment,
+  updateStakeholderAssessment,
+  deleteStakeholderAssessment,
+} from '@/api/stakeholderAssessments';
+import type {
+  StakeholderAssessmentCreate,
+  StakeholderAssessmentUpdate,
+  StakeholderScopeType,
+} from '@/types';
+
+const key = (scopeType: StakeholderScopeType, scopeId: string) =>
+  ['stakeholder-assessments', scopeType, scopeId] as const;
+
+export function useStakeholderAssessments(
+  scopeType: StakeholderScopeType,
+  scopeId: string | undefined,
+) {
+  return useQuery({
+    queryKey: key(scopeType, scopeId ?? ''),
+    queryFn: () => getStakeholderAssessments(scopeType, scopeId!),
+    enabled: !!scopeId,
+  });
+}
+
+export function useCreateStakeholderAssessment() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: StakeholderAssessmentCreate) =>
+      createStakeholderAssessment(data),
+    onSuccess: (_d, vars) => {
+      qc.invalidateQueries({ queryKey: key(vars.scope_type, vars.scope_id) });
+    },
+  });
+}
+
+export function useUpdateStakeholderAssessment() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      id,
+      data,
+    }: {
+      id: string;
+      data: StakeholderAssessmentUpdate;
+      scopeType: StakeholderScopeType;
+      scopeId: string;
+    }) => updateStakeholderAssessment(id, data),
+    onSuccess: (_d, vars) => {
+      qc.invalidateQueries({ queryKey: key(vars.scopeType, vars.scopeId) });
+    },
+  });
+}
+
+export function useDeleteStakeholderAssessment() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      id,
+    }: {
+      id: string;
+      scopeType: StakeholderScopeType;
+      scopeId: string;
+    }) => deleteStakeholderAssessment(id),
+    onSuccess: (_d, vars) => {
+      qc.invalidateQueries({ queryKey: key(vars.scopeType, vars.scopeId) });
+    },
+  });
+}

--- a/frontend/src/pages/LeadsPage.tsx
+++ b/frontend/src/pages/LeadsPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { Plus, Columns3, LayoutGrid, GitFork, Clock, Search, X, Settings, Inbox } from 'lucide-react';
+import { Plus, Columns3, LayoutGrid, GitFork, Clock, Search, X, Settings, Inbox, Globe } from 'lucide-react';
 import { Button } from '@/components/common/Button';
 import { Input } from '@/components/common/Input';
 import { Modal } from '@/components/common/Modal';
@@ -202,6 +202,22 @@ export function LeadsPage() {
               <Settings className="h-3.5 w-3.5" />
             </button>
           )}
+          {(() => {
+            if (!selectedInitiatiefId) return null;
+            const sel = initiatieven?.find((i) => i.id === selectedInitiatiefId);
+            if (!sel?.public_page_enabled || !sel.slug) return null;
+            return (
+              <a
+                href={`/c/${sel.slug}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="rounded-full w-7 h-7 flex items-center justify-center text-emerald-700 hover:text-emerald-900 hover:bg-emerald-50 transition-colors"
+                title={`Open publieke pagina /c/${sel.slug}`}
+              >
+                <Globe className="h-3.5 w-3.5" />
+              </a>
+            );
+          })()}
         </div>
         <div className="flex items-center gap-2 sm:gap-3 shrink-0">
           <ViewToggle value={viewMode} onChange={setViewMode} options={VIEW_OPTIONS} />

--- a/frontend/src/pages/PublicInitiatiefPage.tsx
+++ b/frontend/src/pages/PublicInitiatiefPage.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { getPublicInitiatief } from '@/api/publicInitiatief';
+import { ApiError } from '@/api/client';
+import { LoadingSpinner } from '@/components/common/LoadingSpinner';
+import { RichTextDisplay } from '@/components/common/RichTextDisplay';
+import type { PublicInitiatief } from '@/types';
+
+type Status = 'loading' | 'ok' | 'not-found' | 'error';
+
+export function PublicInitiatiefPage() {
+  const { slug } = useParams<{ slug: string }>();
+  const [status, setStatus] = useState<Status>('loading');
+  const [data, setData] = useState<PublicInitiatief | null>(null);
+
+  useEffect(() => {
+    if (!slug) {
+      setStatus('not-found');
+      return;
+    }
+    let cancelled = false;
+    setStatus('loading');
+    getPublicInitiatief(slug)
+      .then((d) => {
+        if (cancelled) return;
+        setData(d);
+        setStatus('ok');
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        if (err instanceof ApiError && err.status === 404) {
+          setStatus('not-found');
+        } else {
+          setStatus('error');
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [slug]);
+
+  if (status === 'loading') {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (status === 'not-found') {
+    return (
+      <div className="min-h-screen flex items-center justify-center px-4 bg-gray-50">
+        <div className="max-w-md text-center space-y-3">
+          <h1 className="text-2xl font-semibold text-text">Pagina niet gevonden</h1>
+          <p className="text-text-secondary">
+            Deze pagina bestaat niet of is niet (meer) publiek toegankelijk.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === 'error' || !data) {
+    return (
+      <div className="min-h-screen flex items-center justify-center px-4 bg-gray-50">
+        <div className="max-w-md text-center space-y-3">
+          <h1 className="text-2xl font-semibold text-text">Er ging iets mis</h1>
+          <p className="text-text-secondary">
+            Probeer het later opnieuw.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header
+        className="px-6 py-10 border-b"
+        style={{
+          borderColor: data.kleur ?? '#e5e7eb',
+          background: data.kleur
+            ? `linear-gradient(180deg, ${data.kleur}10 0%, transparent 100%)`
+            : undefined,
+        }}
+      >
+        <div className="max-w-3xl mx-auto">
+          <div className="flex items-center gap-3 mb-2">
+            {data.kleur && (
+              <span
+                className="inline-block h-4 w-4 rounded-full"
+                style={{ backgroundColor: data.kleur }}
+              />
+            )}
+            <h1 className="text-3xl font-semibold text-text">{data.naam}</h1>
+          </div>
+          {data.beschrijving && (
+            <div className="mt-4 text-text-secondary max-w-prose">
+              <RichTextDisplay content={data.beschrijving} />
+            </div>
+          )}
+        </div>
+      </header>
+
+      <main className="max-w-3xl mx-auto px-6 py-8">
+        <h2 className="text-lg font-semibold text-text mb-4">Updates</h2>
+        {data.updates.length === 0 ? (
+          <p className="text-text-secondary">Nog geen updates gepubliceerd.</p>
+        ) : (
+          <ul className="space-y-6">
+            {data.updates.map((u, idx) => (
+              <li
+                key={idx}
+                className="bg-white rounded-xl border border-border p-5 shadow-sm"
+              >
+                <h3 className="text-base font-semibold text-text">{u.titel}</h3>
+                <div className="text-xs text-text-secondary mt-1">
+                  {new Date(u.published_at).toLocaleDateString('nl-NL', {
+                    day: 'numeric',
+                    month: 'long',
+                    year: 'numeric',
+                  })}
+                  {u.published_by_naam && ` · ${u.published_by_naam}`}
+                </div>
+                {u.body && (
+                  <div className="mt-3 text-text">
+                    <RichTextDisplay content={u.body} />
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/pages/PublicInitiatiefPage.tsx
+++ b/frontend/src/pages/PublicInitiatiefPage.tsx
@@ -14,6 +14,19 @@ export function PublicInitiatiefPage() {
   const [data, setData] = useState<PublicInitiatief | null>(null);
 
   useEffect(() => {
+    // Voorkom indexering door zoekmachines: een initiatief kan ooit publiek
+    // hebben gestaan en daarna weer worden gedimd; cached search-results
+    // mogen geen interne info blijven serveren.
+    const meta = document.createElement('meta');
+    meta.name = 'robots';
+    meta.content = 'noindex, nofollow, noarchive';
+    document.head.appendChild(meta);
+    return () => {
+      document.head.removeChild(meta);
+    };
+  }, []);
+
+  useEffect(() => {
     if (!slug) {
       setStatus('not-found');
       return;

--- a/frontend/src/pages/PublicInitiatiefPage.tsx
+++ b/frontend/src/pages/PublicInitiatiefPage.tsx
@@ -4,9 +4,15 @@ import { getPublicInitiatief } from '@/api/publicInitiatief';
 import { ApiError } from '@/api/client';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
 import { RichTextDisplay } from '@/components/common/RichTextDisplay';
-import type { PublicInitiatief } from '@/types';
+import type {
+  PublicCasus,
+  PublicInitiatief,
+  PublicInitiatiefUpdate,
+} from '@/types';
 
 type Status = 'loading' | 'ok' | 'not-found' | 'error';
+
+const DEFAULT_ACCENT = '#3B82F6';
 
 export function PublicInitiatiefPage() {
   const { slug } = useParams<{ slug: string }>();
@@ -25,6 +31,10 @@ export function PublicInitiatiefPage() {
       document.head.removeChild(meta);
     };
   }, []);
+
+  useEffect(() => {
+    if (data?.naam) document.title = `${data.naam} · Bouwmeester`;
+  }, [data?.naam]);
 
   useEffect(() => {
     if (!slug) {
@@ -54,97 +64,225 @@ export function PublicInitiatiefPage() {
 
   if (status === 'loading') {
     return (
-      <div className="min-h-screen flex items-center justify-center">
+      <div className="min-h-screen flex items-center justify-center bg-slate-50">
         <LoadingSpinner />
       </div>
     );
   }
 
   if (status === 'not-found') {
-    return (
-      <div className="min-h-screen flex items-center justify-center px-4 bg-gray-50">
-        <div className="max-w-md text-center space-y-3">
-          <h1 className="text-2xl font-semibold text-text">Pagina niet gevonden</h1>
-          <p className="text-text-secondary">
-            Deze pagina bestaat niet of is niet (meer) publiek toegankelijk.
-          </p>
-        </div>
-      </div>
-    );
+    return <PublicMessage title="Pagina niet gevonden" body="Deze pagina bestaat niet of is niet (meer) publiek toegankelijk." />;
   }
 
   if (status === 'error' || !data) {
-    return (
-      <div className="min-h-screen flex items-center justify-center px-4 bg-gray-50">
-        <div className="max-w-md text-center space-y-3">
-          <h1 className="text-2xl font-semibold text-text">Er ging iets mis</h1>
-          <p className="text-text-secondary">
-            Probeer het later opnieuw.
-          </p>
-        </div>
-      </div>
-    );
+    return <PublicMessage title="Er ging iets mis" body="Probeer het later opnieuw." />;
   }
 
+  const accent = data.kleur || DEFAULT_ACCENT;
+
   return (
-    <div className="min-h-screen bg-gray-50">
-      <header
-        className="px-6 py-10 border-b"
-        style={{
-          borderColor: data.kleur ?? '#e5e7eb',
-          background: data.kleur
-            ? `linear-gradient(180deg, ${data.kleur}10 0%, transparent 100%)`
-            : undefined,
-        }}
-      >
-        <div className="max-w-3xl mx-auto">
-          <div className="flex items-center gap-3 mb-2">
-            {data.kleur && (
-              <span
-                className="inline-block h-4 w-4 rounded-full"
-                style={{ backgroundColor: data.kleur }}
-              />
-            )}
-            <h1 className="text-3xl font-semibold text-text">{data.naam}</h1>
+    <div className="min-h-screen bg-slate-50 flex flex-col">
+      {/* Top accent stripe — subtiele kleur-identiteit per initiatief */}
+      <div className="h-1.5 w-full" style={{ backgroundColor: accent }} />
+
+      <header className="relative overflow-hidden">
+        {/* Heel zachte color-wash op de achtergrond, gradient naar wit */}
+        <div
+          aria-hidden
+          className="absolute inset-0"
+          style={{
+            background: `linear-gradient(180deg, ${accent}14 0%, ${accent}06 35%, transparent 100%)`,
+          }}
+        />
+        <div className="relative max-w-3xl mx-auto px-6 pt-16 pb-12">
+          <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wider text-slate-500 mb-4">
+            <span
+              className="inline-block h-2 w-2 rounded-full"
+              style={{ backgroundColor: accent }}
+            />
+            Community
           </div>
+          <h1 className="text-4xl sm:text-5xl font-semibold text-slate-900 tracking-tight">
+            {data.naam}
+          </h1>
           {data.beschrijving && (
-            <div className="mt-4 text-text-secondary max-w-prose">
+            <div className="mt-6 text-lg text-slate-600 leading-relaxed max-w-2xl">
               <RichTextDisplay content={data.beschrijving} />
             </div>
           )}
         </div>
       </header>
 
-      <main className="max-w-3xl mx-auto px-6 py-8">
-        <h2 className="text-lg font-semibold text-text mb-4">Updates</h2>
-        {data.updates.length === 0 ? (
-          <p className="text-text-secondary">Nog geen updates gepubliceerd.</p>
-        ) : (
-          <ul className="space-y-6">
-            {data.updates.map((u, idx) => (
-              <li
-                key={idx}
-                className="bg-white rounded-xl border border-border p-5 shadow-sm"
-              >
-                <h3 className="text-base font-semibold text-text">{u.titel}</h3>
-                <div className="text-xs text-text-secondary mt-1">
-                  {new Date(u.published_at).toLocaleDateString('nl-NL', {
-                    day: 'numeric',
-                    month: 'long',
-                    year: 'numeric',
-                  })}
-                  {u.published_by_naam && ` · ${u.published_by_naam}`}
-                </div>
-                {u.body && (
-                  <div className="mt-3 text-text">
-                    <RichTextDisplay content={u.body} />
-                  </div>
-                )}
-              </li>
-            ))}
-          </ul>
+      <main className="flex-1 max-w-3xl mx-auto w-full px-6 pb-20 space-y-12">
+        {data.casussen.length > 0 && (
+          <section>
+            <div className="flex items-baseline justify-between mt-4 mb-6">
+              <h2 className="text-xl font-semibold text-slate-900">
+                Lopende casussen
+              </h2>
+              <span className="text-sm text-slate-500">
+                {data.casussen.length}{' '}
+                {data.casussen.length === 1 ? 'casus' : 'casussen'}
+              </span>
+            </div>
+            <ul className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {data.casussen.map((c, idx) => (
+                <CasusCard key={idx} casus={c} accent={accent} />
+              ))}
+            </ul>
+          </section>
         )}
+
+        <section>
+          <div className="flex items-baseline justify-between mt-4 mb-6">
+            <h2 className="text-xl font-semibold text-slate-900">Updates</h2>
+            {data.updates.length > 0 && (
+              <span className="text-sm text-slate-500">
+                {data.updates.length}{' '}
+                {data.updates.length === 1 ? 'bericht' : 'berichten'}
+              </span>
+            )}
+          </div>
+
+          {data.updates.length === 0 ? (
+            <EmptyState accent={accent} naam={data.naam} />
+          ) : (
+            <ol className="space-y-8">
+              {data.updates.map((u, idx) => (
+                <UpdateCard key={idx} update={u} accent={accent} />
+              ))}
+            </ol>
+          )}
+        </section>
       </main>
+
+      <footer className="border-t border-slate-200 bg-white">
+        <div className="max-w-3xl mx-auto px-6 py-6 text-sm text-slate-500 flex flex-wrap items-center justify-between gap-2">
+          <span>
+            Publieke pagina van <span className="font-medium text-slate-700">{data.naam}</span>
+          </span>
+          <span className="text-xs text-slate-400">
+            Gepubliceerd via Bouwmeester
+          </span>
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+function UpdateCard({
+  update,
+  accent,
+}: {
+  update: PublicInitiatiefUpdate;
+  accent: string;
+}) {
+  const date = new Date(update.published_at);
+  const formattedDate = date.toLocaleDateString('nl-NL', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  });
+
+  return (
+    <li className="bg-white rounded-2xl border border-slate-200 shadow-sm hover:shadow-md transition-shadow overflow-hidden">
+      <article className="relative px-6 py-6 sm:px-8 sm:py-7">
+        {/* Kleur-streepje links als verticale accent */}
+        <div
+          aria-hidden
+          className="absolute left-0 top-6 bottom-6 w-1 rounded-r-full"
+          style={{ backgroundColor: accent }}
+        />
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-slate-500 mb-3">
+          <time dateTime={update.published_at} className="font-medium">
+            {formattedDate}
+          </time>
+          {update.published_by_naam && (
+            <>
+              <span className="text-slate-300">·</span>
+              <span>{update.published_by_naam}</span>
+            </>
+          )}
+        </div>
+        <h3 className="text-xl sm:text-2xl font-semibold text-slate-900 leading-snug">
+          {update.titel}
+        </h3>
+        {update.body && (
+          <div className="mt-4 text-slate-700 leading-relaxed prose-public">
+            <RichTextDisplay content={update.body} />
+          </div>
+        )}
+      </article>
+    </li>
+  );
+}
+
+function CasusCard({ casus, accent }: { casus: PublicCasus; accent: string }) {
+  return (
+    <li className="bg-white rounded-xl border border-slate-200 shadow-sm p-5 hover:shadow-md transition-shadow">
+      <div className="flex items-center gap-2 mb-2">
+        <span
+          className="inline-block h-2 w-2 rounded-full"
+          style={{ backgroundColor: accent }}
+        />
+        <span className="text-xs font-medium uppercase tracking-wider text-slate-500">
+          Casus
+        </span>
+      </div>
+      <h3 className="text-base font-semibold text-slate-900 leading-snug">
+        {casus.titel}
+      </h3>
+      {casus.samenvatting && (
+        <p className="mt-2 text-sm text-slate-600 leading-relaxed whitespace-pre-wrap">
+          {casus.samenvatting}
+        </p>
+      )}
+    </li>
+  );
+}
+
+function EmptyState({ accent, naam }: { accent: string; naam: string }) {
+  return (
+    <div
+      className="rounded-2xl border-2 border-dashed border-slate-200 bg-white px-6 py-12 text-center"
+    >
+      <div
+        className="inline-flex items-center justify-center h-12 w-12 rounded-full mb-4"
+        style={{ backgroundColor: `${accent}1a` }}
+      >
+        <svg
+          className="h-6 w-6"
+          fill="none"
+          stroke={accent}
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          aria-hidden
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z"
+          />
+        </svg>
+      </div>
+      <h3 className="text-base font-semibold text-slate-900">
+        Nog geen updates
+      </h3>
+      <p className="mt-2 text-sm text-slate-500 max-w-sm mx-auto">
+        Hier verschijnen updates die het team van {naam} publiceert. Kom later
+        terug, of bookmark deze pagina.
+      </p>
+    </div>
+  );
+}
+
+function PublicMessage({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="min-h-screen flex items-center justify-center px-4 bg-slate-50">
+      <div className="max-w-md text-center space-y-3">
+        <h1 className="text-2xl font-semibold text-slate-900">{title}</h1>
+        <p className="text-slate-500">{body}</p>
+      </div>
     </div>
   );
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1737,6 +1737,9 @@ export interface Lead {
   score_strategisch: number | null;
   score_politiek: number | null;
   score_positie: number | null;
+  public_visible: boolean;
+  public_title: string | null;
+  public_summary: string | null;
   attachment_count: number;
   contact_names: string[];
   created_at: string;
@@ -1766,6 +1769,9 @@ export interface LeadCreate {
   score_strategisch?: number | null;
   score_politiek?: number | null;
   score_positie?: number | null;
+  public_visible?: boolean | null;
+  public_title?: string | null;
+  public_summary?: string | null;
   created_at?: string | null;
 }
 
@@ -1785,6 +1791,9 @@ export interface LeadUpdate {
   score_strategisch?: number | null;
   score_politiek?: number | null;
   score_positie?: number | null;
+  public_visible?: boolean | null;
+  public_title?: string | null;
+  public_summary?: string | null;
 }
 
 export interface LeadActivityCreate {
@@ -1904,12 +1913,18 @@ export interface PublicInitiatiefUpdate {
   published_by_naam: string | null;
 }
 
+export interface PublicCasus {
+  titel: string;
+  samenvatting: string | null;
+}
+
 export interface PublicInitiatief {
   naam: string;
   slug: string;
   beschrijving: string | null;
   kleur: string | null;
   updates: PublicInitiatiefUpdate[];
+  casussen: PublicCasus[];
 }
 
 export type EngagementType =

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1646,6 +1646,7 @@ export enum LeadActivityType {
   MEETING = 'meeting',
   CALL = 'call',
   EMAIL = 'email',
+  EVALUATIE = 'evaluatie',
 }
 
 export const LEAD_ACTIVITY_TYPE_LABELS: Record<LeadActivityType, string> = {
@@ -1654,6 +1655,7 @@ export const LEAD_ACTIVITY_TYPE_LABELS: Record<LeadActivityType, string> = {
   [LeadActivityType.MEETING]: 'Meeting',
   [LeadActivityType.CALL]: 'Telefoongesprek',
   [LeadActivityType.EMAIL]: 'E-mail',
+  [LeadActivityType.EVALUATIE]: 'Evaluatie',
 };
 
 export interface LeadAssigneeSummary {
@@ -1707,6 +1709,8 @@ export interface LeadActivity {
   content: string;
   activity_type: LeadActivityType;
   metadata_: Record<string, unknown>;
+  uitkomst: string | null;
+  vervolgacties: string | null;
   created_at: string;
 }
 
@@ -1729,6 +1733,10 @@ export interface Lead {
   tags: string[];
   sort_order: number;
   raw_intake_text: string | null;
+  engagement_type: EngagementType | null;
+  score_strategisch: number | null;
+  score_politiek: number | null;
+  score_positie: number | null;
   attachment_count: number;
   contact_names: string[];
   created_at: string;
@@ -1754,6 +1762,10 @@ export interface LeadCreate {
   next_action_date?: string | null;
   raw_intake_text?: string | null;
   initiatief_id?: string | null;
+  engagement_type?: EngagementType | null;
+  score_strategisch?: number | null;
+  score_politiek?: number | null;
+  score_positie?: number | null;
   created_at?: string | null;
 }
 
@@ -1769,11 +1781,17 @@ export interface LeadUpdate {
   next_action_date?: string | null;
   raw_intake_text?: string | null;
   initiatief_id?: string | null;
+  engagement_type?: EngagementType | null;
+  score_strategisch?: number | null;
+  score_politiek?: number | null;
+  score_positie?: number | null;
 }
 
 export interface LeadActivityCreate {
   content: string;
   activity_type?: LeadActivityType;
+  uitkomst?: string | null;
+  vervolgacties?: string | null;
 }
 
 export interface LeadMetrics {
@@ -1822,8 +1840,14 @@ export interface LeadTimelineResponse {
 export interface Initiatief {
   id: string;
   naam: string;
+  slug: string | null;
   beschrijving: string | null;
   kleur: string | null;
+  funnel_enabled: boolean;
+  public_page_enabled: boolean;
+  score_strategisch_label: string | null;
+  score_politiek_label: string | null;
+  score_positie_label: string | null;
   created_by_id: string | null;
   created_at: string;
   updated_at: string | null;
@@ -1839,6 +1863,135 @@ export interface InitiatiefUpdate {
   naam?: string;
   beschrijving?: string | null;
   kleur?: string | null;
+}
+
+export interface InitiatiefSettingsUpdate {
+  slug?: string | null;
+  funnel_enabled?: boolean;
+  public_page_enabled?: boolean;
+  score_strategisch_label?: string | null;
+  score_politiek_label?: string | null;
+  score_positie_label?: string | null;
+}
+
+export interface InitiatiefUpdatePost {
+  id: string;
+  initiatief_id: string;
+  titel: string;
+  body: string | null;
+  published_at: string | null;
+  published_by_id: string | null;
+  published_by_naam: string | null;
+  created_at: string;
+  updated_at: string | null;
+}
+
+export interface InitiatiefUpdatePostCreate {
+  titel: string;
+  body?: string | null;
+  publish?: boolean;
+}
+
+export interface InitiatiefUpdatePostEdit {
+  titel?: string;
+  body?: string | null;
+}
+
+export interface PublicInitiatiefUpdate {
+  titel: string;
+  body: string | null;
+  published_at: string;
+  published_by_naam: string | null;
+}
+
+export interface PublicInitiatief {
+  naam: string;
+  slug: string;
+  beschrijving: string | null;
+  kleur: string | null;
+  updates: PublicInitiatiefUpdate[];
+}
+
+export type EngagementType =
+  | 'intern_oppakken'
+  | 'voorbereiden_eigen_team'
+  | 'betrokken_houden'
+  | 'verkenning'
+  | 'nog_te_bepalen';
+
+export const ENGAGEMENT_TYPE_LABELS: Record<EngagementType, string> = {
+  intern_oppakken: 'Intern oppakken',
+  voorbereiden_eigen_team: 'Voorbereiden eigen team',
+  betrokken_houden: 'Betrokken houden',
+  verkenning: 'Verkenning (spike)',
+  nog_te_bepalen: 'Nog te bepalen',
+};
+
+export const ENGAGEMENT_TYPE_COLORS: Record<EngagementType, string> = {
+  intern_oppakken: 'bg-emerald-100 text-emerald-800',
+  voorbereiden_eigen_team: 'bg-indigo-100 text-indigo-800',
+  betrokken_houden: 'bg-sky-100 text-sky-800',
+  verkenning: 'bg-amber-100 text-amber-800',
+  nog_te_bepalen: 'bg-slate-100 text-slate-800',
+};
+
+export type StakeholderHouding =
+  | 'tegen'
+  | 'kritisch'
+  | 'neutraal'
+  | 'welwillend'
+  | 'voorstander';
+
+export const STAKEHOLDER_HOUDING_LABELS: Record<StakeholderHouding, string> = {
+  tegen: 'Tegen',
+  kritisch: 'Kritisch',
+  neutraal: 'Neutraal',
+  welwillend: 'Welwillend',
+  voorstander: 'Voorstander',
+};
+
+export const STAKEHOLDER_HOUDING_COLORS: Record<StakeholderHouding, string> = {
+  tegen: 'bg-red-100 text-red-800',
+  kritisch: 'bg-orange-100 text-orange-800',
+  neutraal: 'bg-slate-100 text-slate-800',
+  welwillend: 'bg-emerald-100 text-emerald-800',
+  voorstander: 'bg-green-100 text-green-800',
+};
+
+export type StakeholderScopeType = 'corpus_node' | 'initiatief';
+
+export interface StakeholderAssessment {
+  id: string;
+  person_id: string;
+  person_naam: string;
+  scope_type: StakeholderScopeType;
+  scope_id: string;
+  belang: number | null;
+  houding: StakeholderHouding | null;
+  invloed: number | null;
+  notitie: string | null;
+  assessed_by_id: string | null;
+  assessed_by_naam: string | null;
+  assessed_at: string | null;
+  created_at: string;
+  updated_at: string | null;
+}
+
+export interface StakeholderAssessmentCreate {
+  person_id: string;
+  scope_type: StakeholderScopeType;
+  scope_id: string;
+  belang?: number | null;
+  houding?: StakeholderHouding | null;
+  invloed?: number | null;
+  notitie?: string | null;
+}
+
+export interface StakeholderAssessmentUpdate {
+  belang?: number | null;
+  houding?: StakeholderHouding | null;
+  invloed?: number | null;
+  notitie?: string | null;
 }
 
 export interface InitiatiefMember {


### PR DESCRIPTION
## Summary

Vertaling van Abrams Mattermost-thread (drie processen die Bouwmeester moet ondersteunen) naar code:

- **Funnel op leads** — `engagement_type` + drie scores (strategisch / politiek / positie) op leads, conditioneel zichtbaar als gekoppeld initiatief `funnel_enabled` heeft
- **Evaluatie-activity** — nieuw activity-type met `uitkomst` + `vervolgacties` velden, voor de validatie-bottleneck die Eelco signaleerde
- **Stakeholder-assessment** — nieuw model voor belang × houding × invloed per persoon op een corpus-node of initiatief, met UI op beide
- **Publieke community-pagina per initiatief** op `/c/:slug` — opt-in via `public_page_enabled`, toont alleen expliciet gepubliceerde updates (`InitiatiefUpdatePost`), nooit leads of scores
- **Per-initiatief instellingen** (eigenaar-only): slug, funnel-toggle, publieke-pagina-toggle (met bevestigingsdialoog), drie label-overrides voor de scores

Generieke veldnamen + per-initiatief toggles zorgen dat dit niet RR-only is. Andere initiatieven kunnen de funnel uit laten staan en de UI is dan onveranderd.

Vijf Alembic-migraties; veldnamen zo gekozen dat ze later eenvoudig uit te breiden zijn.

## Test plan

- [ ] `just reset-db` op een verse DB, alle migraties draaien zonder fout
- [ ] Lead aan een initiatief met `funnel_enabled=true`: engagement-type + drie scores zichtbaar in form, opslaan, view-mode toont waardes
- [ ] Lead aan initiatief zonder funnel: geen funnel-velden zichtbaar
- [ ] Evaluatie-activity toevoegen op lead met uitkomst + vervolgacties; verschijnt in timeline met badges
- [ ] Stakeholder-tab op corpus-node-detail: persoon koppelen, belang/houding/invloed invullen, opslaan
- [ ] Stakeholder-sectie op InitiatiefDetailModal: idem
- [ ] Updates-sectie op InitiatiefDetailModal: concept-update opslaan, publiceren, terugtrekken naar concept, verwijderen
- [ ] Settings-sectie alleen zichtbaar voor eigenaar; bevestigingsdialoog bij publiek-aan
- [ ] `/c/<slug>` in incognito (geen login): toont initiatief + gepubliceerde updates, geen leads/scores/stakeholders
- [ ] `/c/<slug>` met `public_page_enabled=false` → 404
- [ ] `/c/onbestaand` → 404
- [ ] Concept-update niet zichtbaar op publieke pagina