### PR TITLE
Dicht resterende _KNOWN_DEBT routes (één PR voor alle clusters)

### DIFF
--- a/backend/bouwmeester/api/routes/bijlage.py
+++ b/backend/bouwmeester/api/routes/bijlage.py
@@ -10,6 +10,12 @@ from sqlalchemy.orm import selectinload
 
 from bouwmeester.core.auth import OptionalUser
 from bouwmeester.core.database import get_db
+from bouwmeester.core.org_context import (
+    OrgContext,
+    check_resource_org_scope,
+    get_org_context,
+)
+from bouwmeester.core.permissions import require_permission
 from bouwmeester.core.storage import (
     BRON_ALLOWED_CONTENT_TYPES,
     ensure_bijlagen_dir,
@@ -54,8 +60,11 @@ async def upload_bijlage(
     file: UploadFile,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("node:update")),
+    org_ctx: OrgContext = Depends(get_org_context),
 ) -> BronBijlageResponse:
     """Upload a file attachment to a bron node. Replaces existing attachment."""
+    await check_resource_org_scope(db, "corpus_node", node_id, org_ctx)
     bron = await _get_bron(node_id, db, load_bijlage=True)
 
     content_type = file.content_type or ""
@@ -104,8 +113,10 @@ async def get_bijlage_info(
     node_id: uuid.UUID,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    org_ctx: OrgContext = Depends(get_org_context),
 ) -> BronBijlageResponse | None:
     """Get metadata about a bron node's attachment (filename, size, type)."""
+    await check_resource_org_scope(db, "corpus_node", node_id, org_ctx)
     bron = await _get_bron(node_id, db)
 
     result = await db.execute(select(BronBijlage).where(BronBijlage.bron_id == bron.id))
@@ -122,8 +133,10 @@ async def download_bijlage(
     node_id: uuid.UUID,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    org_ctx: OrgContext = Depends(get_org_context),
 ) -> FileResponse:
     """Download the file attachment of a bron node."""
+    await check_resource_org_scope(db, "corpus_node", node_id, org_ctx)
     bron = await _get_bron(node_id, db)
 
     result = await db.execute(select(BronBijlage).where(BronBijlage.bron_id == bron.id))
@@ -147,8 +160,11 @@ async def delete_bijlage(
     node_id: uuid.UUID,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("node:update")),
+    org_ctx: OrgContext = Depends(get_org_context),
 ) -> None:
     """Delete a bron node's file attachment (DB record and file on disk)."""
+    await check_resource_org_scope(db, "corpus_node", node_id, org_ctx)
     bron = await _get_bron(node_id, db)
 
     result = await db.execute(select(BronBijlage).where(BronBijlage.bron_id == bron.id))

--- a/backend/bouwmeester/api/routes/import_export.py
+++ b/backend/bouwmeester/api/routes/import_export.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from bouwmeester.api.deps import validate_csv_upload
 from bouwmeester.core.auth import OptionalUser
 from bouwmeester.core.database import get_db
+from bouwmeester.core.permissions import require_permission
 from bouwmeester.schema.import_export import ImportResult
 from bouwmeester.services.activity_service import log_activity
 from bouwmeester.services.archimate_export_service import (
@@ -28,6 +29,7 @@ async def import_politieke_inputs(
     file: UploadFile,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("import_export:import")),
 ) -> ImportResult:
     """Upload a CSV to bulk-import politieke inputs."""
     content = await validate_csv_upload(file)
@@ -50,6 +52,7 @@ async def import_nodes(
     file: UploadFile,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("import_export:import")),
 ) -> ImportResult:
     """Upload a CSV to bulk-import generic nodes."""
     content = await validate_csv_upload(file)
@@ -72,6 +75,7 @@ async def import_edges(
     file: UploadFile,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("import_export:import")),
 ) -> ImportResult:
     """Upload a CSV to bulk-import edges."""
     content = await validate_csv_upload(file)
@@ -97,6 +101,7 @@ async def export_nodes(
     current_user: OptionalUser,
     node_type: str | None = Query(None),
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("import_export:export")),
 ) -> StreamingResponse:
     """Export all nodes as CSV (optionally filtered by node_type)."""
     service = ExportService(db)
@@ -112,6 +117,7 @@ async def export_nodes(
 async def export_edges(
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("import_export:export")),
 ) -> StreamingResponse:
     """Export all edges as CSV."""
     service = ExportService(db)
@@ -127,6 +133,7 @@ async def export_edges(
 async def export_corpus(
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("import_export:export")),
 ) -> JSONResponse:
     """Export full corpus as JSON (nodes + edges + types)."""
     service = ExportService(db)
@@ -141,6 +148,7 @@ async def export_corpus(
 async def export_archimate(
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("import_export:export")),
 ) -> StreamingResponse:
     """Export corpus as ArchiMate Exchange Format XML."""
     service = ArchiMateExportService(db)

--- a/backend/bouwmeester/api/routes/mentions.py
+++ b/backend/bouwmeester/api/routes/mentions.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from bouwmeester.core.auth import OptionalUser
 from bouwmeester.core.database import get_db
+from bouwmeester.core.org_context import OrgContext, get_org_context
 from bouwmeester.schema.mention import MentionReference, MentionSearchResult
 from bouwmeester.services.mention_service import MentionService
 
@@ -20,13 +21,16 @@ async def search_mentionables(
     types: str = Query("node,task,tag"),
     limit: int = Query(10, ge=1, le=50),
     db: AsyncSession = Depends(get_db),
+    org_ctx: OrgContext = Depends(get_org_context),
 ) -> list[MentionSearchResult]:
     """Search nodes, tasks, and tags for # mention suggestions."""
     service = MentionService(db)
     type_list = [t.strip() for t in types.split(",") if t.strip()]
     if not q.strip():
         return []
-    return await service.search_mentionables(q.strip(), type_list, limit)
+    return await service.search_mentionables(
+        q.strip(), type_list, limit, org_ctx=org_ctx
+    )
 
 
 @router.get("/references/{target_id}", response_model=list[MentionReference])
@@ -34,7 +38,8 @@ async def get_references(
     target_id: UUID,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    org_ctx: OrgContext = Depends(get_org_context),
 ) -> list[MentionReference]:
     """Get all places where target_id is mentioned."""
     service = MentionService(db)
-    return await service.get_references(target_id)
+    return await service.get_references(target_id, org_ctx=org_ctx)

--- a/backend/bouwmeester/api/routes/nodes.py
+++ b/backend/bouwmeester/api/routes/nodes.py
@@ -295,8 +295,10 @@ async def get_neighbors(
     id: UUID,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    org_ctx: OrgContext = Depends(get_org_context),
 ) -> GraphNeighborsResponse:
     """Get direct neighbors of a node (one hop) with their connecting edges."""
+    await check_resource_org_scope(db, "corpus_node", id, org_ctx)
     service = NodeService(db)
     result = await service.get_neighbors(id)
     require_found(result["node"], "Node")
@@ -318,8 +320,10 @@ async def get_graph(
     current_user: OptionalUser,
     depth: int = Query(2, ge=1, le=5),
     db: AsyncSession = Depends(get_db),
+    org_ctx: OrgContext = Depends(get_org_context),
 ) -> GraphViewResponse:
     """Get a multi-hop subgraph around a node (configurable depth 1-5)."""
+    await check_resource_org_scope(db, "corpus_node", id, org_ctx)
     service = NodeService(db)
     result = await service.get_graph(id, depth=depth)
     return GraphViewResponse(
@@ -335,14 +339,15 @@ async def get_node_tasks(
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=500),
     db: AsyncSession = Depends(get_db),
+    org_ctx: OrgContext = Depends(get_org_context),
 ) -> list[TaskResponse]:
     """List all tasks linked to a specific node."""
-    # Verify node exists
+    await check_resource_org_scope(db, "corpus_node", id, org_ctx)
     service = NodeService(db)
     require_found(await service.get(id), "Node")
 
     task_repo = TaskRepository(db)
-    tasks = await task_repo.get_by_node(id, skip=skip, limit=limit)
+    tasks = await task_repo.get_by_node(id, skip=skip, limit=limit, org_ctx=org_ctx)
     return validate_list(TaskResponse, tasks)
 
 
@@ -351,8 +356,10 @@ async def get_node_stakeholders(
     id: UUID,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    org_ctx: OrgContext = Depends(get_org_context),
 ) -> list[NodeStakeholderResponse]:
     """List stakeholders (eigenaar/betrokken/adviseur) of a node."""
+    await check_resource_org_scope(db, "corpus_node", id, org_ctx)
     service = NodeService(db)
     require_found(await service.get(id), "Node")
 
@@ -530,10 +537,12 @@ async def get_node_tags(
     id: UUID,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    org_ctx: OrgContext = Depends(get_org_context),
 ) -> list[NodeTagResponse]:
     """List all tags applied to a node."""
     from bouwmeester.repositories.tag import TagRepository
 
+    await check_resource_org_scope(db, "corpus_node", id, org_ctx)
     service = NodeService(db)
     require_found(await service.get(id), "Node")
 
@@ -631,8 +640,10 @@ async def get_node_title_history(
     id: UUID,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    org_ctx: OrgContext = Depends(get_org_context),
 ) -> list[NodeTitleRecord]:
     """Get temporal history of title changes for a node."""
+    await check_resource_org_scope(db, "corpus_node", id, org_ctx)
     service = NodeService(db)
     require_found(await service.get(id), "Node")
     records = await service.get_title_history(id)
@@ -644,8 +655,10 @@ async def get_node_status_history(
     id: UUID,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    org_ctx: OrgContext = Depends(get_org_context),
 ) -> list[NodeStatusRecord]:
     """Get temporal history of status changes for a node."""
+    await check_resource_org_scope(db, "corpus_node", id, org_ctx)
     service = NodeService(db)
     require_found(await service.get(id), "Node")
     records = await service.get_status_history(id)
@@ -657,12 +670,14 @@ async def get_node_bron_detail(
     id: UUID,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    org_ctx: OrgContext = Depends(get_org_context),
 ) -> BronResponse | None:
     """Get bron-specific detail fields for a bron node."""
     from sqlalchemy import select
 
     from bouwmeester.models.bron import Bron
 
+    await check_resource_org_scope(db, "corpus_node", id, org_ctx)
     stmt = select(Bron).where(Bron.id == id)
     result = await db.execute(stmt)
     bron = result.scalar_one_or_none()
@@ -740,6 +755,7 @@ async def get_node_parlementair_item(
     id: UUID,
     current_user: OptionalUser,
     db: AsyncSession = Depends(get_db),
+    org_ctx: OrgContext = Depends(get_org_context),
 ) -> dict | None:
     """Get linked parliamentary item data for a politieke_input node.
 
@@ -750,6 +766,7 @@ async def get_node_parlementair_item(
 
     from bouwmeester.models.parlementair_item import ParlementairItem
 
+    await check_resource_org_scope(db, "corpus_node", id, org_ctx)
     stmt = (
         select(ParlementairItem)
         .where(ParlementairItem.corpus_node_id == id)

--- a/backend/bouwmeester/services/mention_service.py
+++ b/backend/bouwmeester/services/mention_service.py
@@ -6,6 +6,7 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from bouwmeester.core.org_context import OrgContext, apply_org_filter
 from bouwmeester.models.corpus_node import CorpusNode
 from bouwmeester.models.mention import Mention
 from bouwmeester.models.task import Task
@@ -98,17 +99,30 @@ class MentionService:
     # DMs, org descriptions, and any future private source types are excluded.
     _PUBLIC_SOURCE_TYPES = ["node", "task"]
 
-    async def get_references(self, target_id: UUID) -> list[MentionReference]:
+    async def get_references(
+        self,
+        target_id: UUID,
+        *,
+        org_ctx: OrgContext | None = None,
+    ) -> list[MentionReference]:
         """Get all places where target_id is mentioned, with source titles.
 
         Only includes public source types (nodes, tasks) — private content
         like DMs and org descriptions should not leak as back-references.
+        Filters node/task sources cross-org via ``org_ctx``.
         """
         mentions = await self.repo.get_by_target(
             target_id, allowed_source_types=self._PUBLIC_SOURCE_TYPES
         )
         if not mentions:
             return []
+
+        # Filter mentions to only those whose source node/task is visible
+        # to the caller (cross-org leak prevention).
+        if org_ctx is not None and not org_ctx.is_admin:
+            mentions = await self._filter_mentions_by_org(mentions, org_ctx)
+            if not mentions:
+                return []
 
         # Batch-fetch titles by source type to avoid N+1 queries
         titles = await self._get_source_titles_batch(mentions)
@@ -169,8 +183,50 @@ class MentionService:
 
         return titles
 
+    async def _filter_mentions_by_org(
+        self, mentions: list[Mention], org_ctx: OrgContext
+    ) -> list[Mention]:
+        """Drop mentions whose source node/task is outside the caller's org-scope."""
+        node_ids = {m.source_id for m in mentions if m.source_type == "node"}
+        task_ids = {m.source_id for m in mentions if m.source_type == "task"}
+
+        visible_node_ids: set[UUID] = set()
+        visible_task_ids: set[UUID] = set()
+
+        if node_ids:
+            stmt = apply_org_filter(
+                select(CorpusNode.id).where(CorpusNode.id.in_(node_ids)),
+                CorpusNode.organisatie_eenheid_id,
+                org_ctx,
+            )
+            visible_node_ids = {
+                row[0] for row in (await self.session.execute(stmt)).all()
+            }
+
+        if task_ids:
+            stmt = apply_org_filter(
+                select(Task.id).where(Task.id.in_(task_ids)),
+                Task.organisatie_eenheid_id,
+                org_ctx,
+            )
+            visible_task_ids = {
+                row[0] for row in (await self.session.execute(stmt)).all()
+            }
+
+        return [
+            m
+            for m in mentions
+            if (m.source_type == "node" and m.source_id in visible_node_ids)
+            or (m.source_type == "task" and m.source_id in visible_task_ids)
+        ]
+
     async def search_mentionables(
-        self, query: str, types: list[str] | None = None, limit: int = 10
+        self,
+        query: str,
+        types: list[str] | None = None,
+        limit: int = 10,
+        *,
+        org_ctx: OrgContext | None = None,
     ) -> list[MentionSearchResult]:
         """Search across nodes, tasks, and tags for # mention suggestions."""
         results: list[MentionSearchResult] = []
@@ -178,12 +234,9 @@ class MentionService:
         pattern = f"%{query}%"
 
         if "node" in allowed:
-            stmt = (
-                select(CorpusNode)
-                .where(CorpusNode.title.ilike(pattern))
-                .order_by(CorpusNode.title)
-                .limit(limit)
-            )
+            stmt = select(CorpusNode).where(CorpusNode.title.ilike(pattern))
+            stmt = apply_org_filter(stmt, CorpusNode.organisatie_eenheid_id, org_ctx)
+            stmt = stmt.order_by(CorpusNode.title).limit(limit)
             rows = await self.session.execute(stmt)
             for n in rows.scalars().all():
                 results.append(
@@ -196,12 +249,9 @@ class MentionService:
                 )
 
         if "task" in allowed:
-            stmt = (
-                select(Task)
-                .where(Task.title.ilike(pattern))
-                .order_by(Task.title)
-                .limit(limit)
-            )
+            stmt = select(Task).where(Task.title.ilike(pattern))
+            stmt = apply_org_filter(stmt, Task.organisatie_eenheid_id, org_ctx)
+            stmt = stmt.order_by(Task.title).limit(limit)
             rows = await self.session.execute(stmt)
             for t in rows.scalars().all():
                 results.append(

--- a/backend/tests/test_bron.py
+++ b/backend/tests/test_bron.py
@@ -88,11 +88,15 @@ async def test_get_bron_detail_not_found(client, sample_node):
 
 
 async def test_get_bron_detail_nonexistent(client):
-    """GET /api/nodes/{id}/bron-detail returns null for nonexistent node."""
+    """GET /api/nodes/{id}/bron-detail returns 404 for nonexistent node.
+
+    The org-scope check resolves the parent node first; missing nodes
+    surface as 404 rather than null (consistent with other node detail
+    routes since the authz hardening in #270).
+    """
     fake_id = uuid.uuid4()
     resp = await client.get(f"/api/nodes/{fake_id}/bron-detail")
-    assert resp.status_code == 200
-    assert resp.json() is None
+    assert resp.status_code == 404
 
 
 async def test_update_bron_detail(client, bron_node):

--- a/backend/tests/test_route_authorization_inventory.py
+++ b/backend/tests/test_route_authorization_inventory.py
@@ -33,6 +33,11 @@ _AUTHZ_WHITELIST: dict[str, str] = {
     # Self-scoped endpoints (effective_person_id ensures caller-only data)
     "/api/tasks/my": "self-scoped via effective_person_id",
     "/api/tasks/inbox": "self-scoped via effective_person_id",
+    "/api/activity/inbox": "self-scoped via effective_person_id in handler",
+    "/api/roles/my-permissions": "self-scoped (caller's own roles + perms)",
+    "/api/org-placements/my-requests": "self-scoped via current_user.id filter",
+    "/api/chat/{conversation_id}": "self-scoped via current_user.id in handler",
+    "/api/chat/attachments/{attachment_id}/preview": "owner-check in handler",
     # Mattermost webhook endpoints (authenticated via shared secret)
     "/api/mattermost/slash": "authenticated via shared secret in body",
     "/api/mattermost/action": "authenticated via shared secret in body",
@@ -51,6 +56,31 @@ _AUTHZ_WHITELIST: dict[str, str] = {
     "/api/edge-types/valid": "schema-data, ministerie-breed",
     "/api/edge-schema-rules": "schema-data, ministerie-breed",
     "/api/skill.md": "skill markdown bundle, no PII",
+    "/api/roles": "globale rol-definitielijst, ministerie-breed referentiedata",
+    # Org-chart is bewust ministerie-breed leesbaar binnen de tenant.
+    # Mutaties hebben wel require_permission("org:manage") + check_org_scope.
+    "/api/organisatie": "org-chart is ministerie-breed by design",
+    "/api/organisatie/search": "org-chart, ministerie-breed",
+    "/api/organisatie/managed-by/{person_id}": "org-chart, ministerie-breed",
+    "/api/organisatie/{id}": "org-chart, ministerie-breed",
+    "/api/organisatie/{id}/history/managers": "org-chart history, ministerie-breed",
+    "/api/organisatie/{id}/history/namen": "org-chart history, ministerie-breed",
+    "/api/organisatie/{id}/history/parents": "org-chart history, ministerie-breed",
+    "/api/organisatie/{id}/personen": (
+        "team-member lijst, ministerie-breed (publiek profiel: naam, "
+        "functie, default email — geen private nummers)"
+    ),
+    # Externe organisaties zijn als KvK-nummers publieke NL-data, geen
+    # gevoelige interne contactdata.
+    "/api/externe-organisaties": "externe org-referentie, publieke NL-data",
+    "/api/externe-organisaties/{id}": "externe org-referentie, publieke NL-data",
+    # LLM corpus-gaps geeft ministerie-brede dossier-overview voor
+    # planningsdoeleinden; geen gevoelige PII.
+    "/api/llm/corpus-gaps": "ministerie-brede planningsdata, geen PII",
+    # Graph endpoints bouwen op CorpusNode dat al via apply_org_filter
+    # gescopeerd is (zie nodes/list_nodes en repository).
+    "/api/graph/search": "bouwt op CorpusNode (al gefilterd via PR #263)",
+    "/api/graph/path": "bouwt op CorpusNode (al gefilterd via PR #263)",
     # Notifications: handlers filter on effective_person_id explicitly
     # in the route body (zie notifications.py — list/count/dashboard-stats
     # roepen effective_person_id aan; detail/replies gaan door
@@ -72,55 +102,8 @@ _AUTHZ_PREFIX_WHITELIST: tuple[str, ...] = (
 )
 
 # Known-debt: GET routes that still lack authz but are scheduled for a
-# follow-up PR.  Keeping them in this list:
-#   1. lets CI stay green on main while the cleanup is in flight, and
-#   2. catches any *new* authz regressions on routes outside this set.
-# Once a route here grows an authz dependency, the second test below
-# will demand it be removed from the list — preventing accidental
-# re-introduction of the gap.
-#
-# Routes covered by in-flight PRs (#263 opdrachten, #264 parlementair,
-# #265 people, #266 tasks) are still listed here because this PR is based
-# on plain main; once those PR's merge their entries will be flagged by
-# test_known_debt_is_still_unauthorized and cleaned up.
-_KNOWN_DEBT: set[str] = {
-    "/api/activity/inbox",
-    "/api/chat/{conversation_id}",
-    "/api/chat/attachments/{attachment_id}/preview",
-    "/api/export/archimate",
-    "/api/export/corpus",
-    "/api/export/edges",
-    "/api/export/nodes",
-    "/api/externe-organisaties",
-    "/api/externe-organisaties/{id}",
-    "/api/graph/path",
-    "/api/graph/search",
-    "/api/llm/corpus-gaps",
-    "/api/mentions/references/{target_id}",
-    "/api/mentions/search",
-    "/api/nodes/{id}/bron-detail",
-    "/api/nodes/{id}/graph",
-    "/api/nodes/{id}/history/statuses",
-    "/api/nodes/{id}/history/titles",
-    "/api/nodes/{id}/neighbors",
-    "/api/nodes/{id}/parlementair-item",
-    "/api/nodes/{id}/stakeholders",
-    "/api/nodes/{id}/tags",
-    "/api/nodes/{id}/tasks",
-    "/api/nodes/{node_id}/bijlage",
-    "/api/nodes/{node_id}/bijlage/download",
-    "/api/org-placements/my-requests",
-    "/api/organisatie",
-    "/api/organisatie/managed-by/{person_id}",
-    "/api/organisatie/search",
-    "/api/organisatie/{id}",
-    "/api/organisatie/{id}/history/managers",
-    "/api/organisatie/{id}/history/namen",
-    "/api/organisatie/{id}/history/parents",
-    "/api/organisatie/{id}/personen",
-    "/api/roles",
-    "/api/roles/my-permissions",
-}
+# follow-up PR.  Once empty, this guard is fully active.
+_KNOWN_DEBT: set[str] = set()
 
 # Recognised dependency-callable names that satisfy the authz requirement.
 _AUTHZ_DEP_NAMES = {


### PR DESCRIPTION
Volgt op #263-#269. Dicht alle 36 paths die nog in \`_KNOWN_DEBT\` stonden, zodat \`_KNOWN_DEBT = set()\` en de regressietest volledig actief is.

## Wat erin zit

### Echt beschermd (15 endpoints)

**\`backend/bouwmeester/api/routes/nodes.py\` — 9 GET-subroutes** krijgen \`check_resource_org_scope(db, \"corpus_node\", id, org_ctx)\`:
- \`/neighbors\`, \`/graph\`, \`/tasks\`, \`/stakeholders\`, \`/tags\`
- \`/history/titles\`, \`/history/statuses\`
- \`/bron-detail\`, \`/parlementair-item\`

**\`backend/bouwmeester/api/routes/bijlage.py\` — alle 4 routes** (upload, get-info, download, delete) krijgen \`check_resource_org_scope\`. Upload en delete krijgen daarnaast \`require_permission(\"node:update\")\`.

**\`backend/bouwmeester/services/mention_service.py\`** — \`search_mentionables\` en \`get_references\` filteren nu via \`apply_org_filter\` op source-nodes en source-tasks. Voorkomt dat een non-admin via mention-search content uit een andere eenheid kan ontdekken.

**\`backend/bouwmeester/api/routes/import_export.py\` — alle 7 routes** krijgen \`require_permission(\"import_export:import\")\` of \`import_export:export\`. Permissies bestaan al in \`c44e4533e993\`; alleen platform_admin heeft ze.

### Bewust gewhitelist (21 endpoints met justificatie-comment)

- **Org-chart** (8): ministerie-breed by design — \`/api/organisatie*\`
- **Referentiedata** (3): \`/api/roles\`, \`/api/roles/my-permissions\` (self-scoped), \`/api/org-placements/my-requests\` (self-scoped)
- **Self-scoped via handler** (3): \`/api/activity/inbox\`, \`/api/chat/{conversation_id}\`, \`/api/chat/attachments/{attachment_id}/preview\`
- **Externe organisaties** (2): publieke NL-data
- **LLM corpus-gaps** (1): ministerie-brede planningsdata
- **Graph** (2): bouwt op CorpusNode dat al gefilterd is in #263

### Test-update

\`test_bron.py::test_get_bron_detail_nonexistent\`: verwacht nu 404 in plaats van 200+null. Consistent met overige node-detail-routes — \`check_resource_org_scope\` resolve de node eerst.

## Resultaat

\`_KNOWN_DEBT = set()\`. De regressietest is daarmee volledig actief: élke nieuwe GET \`/api/*\` route moet ofwel een authz-dependency declareren ofwel een whitelist-entry met justificatie krijgen.

## Test plan

- [x] \`uv run pytest -q\` — 833 passed
- [x] \`uv run pytest tests/test_route_authorization_inventory.py -v\` — 2 pass, geen offenders, geen stale debt
- [x] \`ruff format\` + \`ruff check\` clean
- [ ] Staging: viewer probeert \`GET /api/nodes/{andere-eenheid}/tasks\` → 403
- [ ] Staging: viewer doet \`GET /api/mentions/search?q=...\` → resultaten alleen uit eigen scope
- [ ] Staging: niet-admin probeert \`GET /api/export/corpus\` → 403