### PR TITLE
Fix afgekapte beschrijving op leads-inbox kaartjes

### DIFF
--- a/frontend/src/components/leads/LeadInboxView.tsx
+++ b/frontend/src/components/leads/LeadInboxView.tsx
@@ -256,7 +256,7 @@ export function LeadInboxView({
                       </div>
 
                       {lead.description && (
-                        <div className="text-xs text-text-secondary mt-0.5 max-h-8 overflow-hidden break-words">
+                        <div className="text-xs text-text-secondary mt-1 line-clamp-2 break-words [&_p]:m-0 [&_p]:leading-snug">
                           <RichTextDisplay content={lead.description} fallback="" />
                         </div>
                       )}


### PR DESCRIPTION
## Wat
`max-h-8` (32px) op de description-container sneed de tweede regel halverwege af in de inbox-kaartjes (zie screenshot in issue/Slack). Vervangen door `line-clamp-2`, plus margin-reset op `<p>` en `leading-snug` zodat `RichTextDisplay`/`MarkdownRenderer`-output netjes binnen twee regels past en eindigt op een ellipsis.

## Test plan
- [ ] `/inbox` openen, leads met lange beschrijving tonen 2 volle regels + `…`
- [ ] Korte beschrijving toont 1 regel zonder extra whitespace
- [ ] Markdown-beschrijvingen (bold, links) renderen nog correct