### PR TITLE
Lead-contactpersoon aanmaken: people:create permissie + zichtbare error

### DIFF
--- a/backend/bouwmeester/api/routes/people.py
+++ b/backend/bouwmeester/api/routes/people.py
@@ -106,7 +106,7 @@ async def create_person(
     actor_id: UUID | None = Query(None),
     force: bool = Query(False),
     db: AsyncSession = Depends(get_db),
-    _perm=Depends(require_permission("people:manage")),
+    _perm=Depends(require_permission("people:create")),
 ) -> PersonCreateResponse:
     """Create a person.
 

--- a/backend/bouwmeester/migrations/versions/a1f3c8e7d402_add_people_create_permission.py
+++ b/backend/bouwmeester/migrations/versions/a1f3c8e7d402_add_people_create_permission.py
@@ -1,0 +1,69 @@
+"""add people:create permission
+
+Revision ID: a1f3c8e7d402
+Revises: d9f0a1b2c345
+Create Date: 2026-05-06
+
+Splits ``people:manage`` verder zodat editors / unit_managers / viewers
+zelf nieuwe personen kunnen aanmaken (typisch via de CreatableSelect bij
+het toevoegen van contactpersonen aan een lead). Voor verwijderen,
+agent-toggle en API-key rotate blijft ``people:manage`` vereist.
+
+Granted to viewer, editor, unit_manager, ministry_admin, super_admin —
+identiek aan de ``people:update`` rolset.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a1f3c8e7d402"
+down_revision: str | None = "d9f0a1b2c345"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_NEW_PERMISSION = ("people:create", "people")
+
+_ROLE_GRANTS = [
+    "viewer",
+    "editor",
+    "unit_manager",
+    "ministry_admin",
+    "super_admin",
+]
+
+
+def upgrade() -> None:
+    permission_table = sa.table(
+        "permission",
+        sa.column("id", sa.String()),
+        sa.column("category", sa.String()),
+    )
+    op.bulk_insert(
+        permission_table,
+        [{"id": _NEW_PERMISSION[0], "category": _NEW_PERMISSION[1]}],
+    )
+
+    role_permission_table = sa.table(
+        "role_permission",
+        sa.column("role_id", sa.String()),
+        sa.column("permission_id", sa.String()),
+    )
+    op.bulk_insert(
+        role_permission_table,
+        [{"role_id": rid, "permission_id": _NEW_PERMISSION[0]} for rid in _ROLE_GRANTS],
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    bind.execute(
+        sa.text("DELETE FROM role_permission WHERE permission_id = :pid"),
+        {"pid": _NEW_PERMISSION[0]},
+    )
+    bind.execute(
+        sa.text("DELETE FROM permission WHERE id = :pid"),
+        {"pid": _NEW_PERMISSION[0]},
+    )

--- a/backend/tests/test_people_authz.py
+++ b/backend/tests/test_people_authz.py
@@ -116,13 +116,31 @@ async def test_get_person_summary_requires_people_read(
     assert resp.status_code == 403
 
 
-async def test_create_person_requires_people_manage(
+async def test_create_person_requires_people_create(
     people_authz_setup, db_session: AsyncSession
 ):
     s = people_authz_setup
     async with _make_client(s["app"], db_session, s["person"], {"people:read"}) as ac:
         resp = await ac.post("/api/people", json={"naam": "Nieuwe Persoon"})
     assert resp.status_code == 403
+
+
+async def test_create_person_allowed_with_people_create(
+    people_authz_setup, db_session: AsyncSession
+):
+    """Editors / unit_managers met people:create kunnen contactpersonen aanmaken."""
+    s = people_authz_setup
+    async with _make_client(
+        s["app"], db_session, s["person"], {"people:read", "people:create"}
+    ) as ac:
+        resp = await ac.post(
+            "/api/people",
+            json={"naam": f"Nieuwe Persoon {uuid.uuid4().hex[:6]}"},
+        )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["naam"].startswith("Nieuwe Persoon")
+    assert "id" in body
 
 
 async def test_update_person_requires_people_update(

--- a/frontend/src/components/common/CreatableSelect.tsx
+++ b/frontend/src/components/common/CreatableSelect.tsx
@@ -1,5 +1,19 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { ChevronDown, Plus, Search, X } from 'lucide-react';
+import { ApiError } from '@/api/client';
+
+function extractCreateErrorMessage(err: unknown): string {
+  if (err instanceof ApiError) {
+    if (err.status === 403) {
+      return 'Geen rechten om dit aan te maken.';
+    }
+    const body = err.body as Record<string, unknown> | undefined;
+    if (body && typeof body.detail === 'string') return body.detail;
+    return `Aanmaken niet gelukt (${err.status})`;
+  }
+  if (err instanceof Error && err.message) return err.message;
+  return 'Aanmaken niet gelukt';
+}
 
 export interface SelectOption {
   value: string;
@@ -59,6 +73,7 @@ export function CreatableSelect({
   const [highlightedIndex, setHighlightedIndex] = useState(0);
   const [isCreating, setIsCreating] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
@@ -94,6 +109,7 @@ export function CreatableSelect({
   // Reset highlight when filtered list changes
   useEffect(() => {
     setHighlightedIndex(0);
+    setCreateError(null);
   }, [query]);
 
   // Scroll highlighted item into view
@@ -116,15 +132,24 @@ export function CreatableSelect({
   const handleCreate = useCallback(async () => {
     if (!onCreate || !query.trim() || isCreating) return;
     setIsCreating(true);
+    setCreateError(null);
     try {
       const newId = await onCreate(query.trim());
       if (newId) {
         onChange(newId);
+        setIsOpen(false);
+        setQuery('');
+      } else {
+        // onCreate returned null without throwing — treat as soft success
+        // (e.g. when the parent wants to keep the typed text without saving yet)
+        setIsOpen(false);
+        setQuery('');
       }
+    } catch (err) {
+      setCreateError(extractCreateErrorMessage(err));
+      // Keep dropdown open and query intact so the user can retry or correct
     } finally {
       setIsCreating(false);
-      setIsOpen(false);
-      setQuery('');
     }
   }, [onCreate, query, onChange, isCreating]);
 
@@ -301,10 +326,19 @@ export function CreatableSelect({
                 </span>
               </li>
             )}
+
+            {createError && (
+              <li className="px-3.5 py-2 text-xs text-red-600 border-t border-border bg-red-50">
+                {createError}
+              </li>
+            )}
           </ul>
         )}
       </div>
       {error && <p className="text-xs text-red-600">{error}</p>}
+      {!error && createError && !isOpen && (
+        <p className="text-xs text-red-600">{createError}</p>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/common/CreatableSelect.tsx
+++ b/frontend/src/components/common/CreatableSelect.tsx
@@ -109,7 +109,6 @@ export function CreatableSelect({
   // Reset highlight when filtered list changes
   useEffect(() => {
     setHighlightedIndex(0);
-    setCreateError(null);
   }, [query]);
 
   // Scroll highlighted item into view
@@ -125,6 +124,7 @@ export function CreatableSelect({
       onChange(opt.value);
       setIsOpen(false);
       setQuery('');
+      setCreateError(null);
     },
     [onChange],
   );
@@ -189,6 +189,7 @@ export function CreatableSelect({
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setQuery(e.target.value);
+    setCreateError(null);
     onQueryChange?.(e.target.value);
     if (!isOpen) setIsOpen(true);
   };

--- a/frontend/src/components/leads/LeadDetailPanel.tsx
+++ b/frontend/src/components/leads/LeadDetailPanel.tsx
@@ -25,7 +25,6 @@ import { RichTextFormField } from '@/components/common/RichTextFormField';
 import { RichTextEditor } from '@/components/common/RichTextEditor';
 import { RichTextDisplay } from '@/components/common/RichTextDisplay';
 import { LinkLeadNodeModal } from './LinkLeadNodeModal';
-import { createPerson } from '@/api/people';
 import { Badge } from '@/components/common/Badge';
 import { DetailSection } from '@/components/common/DetailSection';
 import { DetailMetadataGrid } from '@/components/common/DetailMetadataGrid';
@@ -45,7 +44,7 @@ import {
   useAddTagToLead,
   useRemoveTagFromLead,
 } from '@/hooks/useLeads';
-import { usePeople } from '@/hooks/usePeople';
+import { usePeople, useCreatePerson } from '@/hooks/usePeople';
 import { useInitiatieven, useCreateInitiatief } from '@/hooks/useInitiatieven';
 import { getLeadAttachmentDownloadUrl } from '@/api/leads';
 import { isOverdue, formatDateLong, timeAgo } from '@/utils/dates';
@@ -120,6 +119,7 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
   const { data: people } = usePeople();
   const { data: initiatieven } = useInitiatieven();
   const createInitiatief = useCreateInitiatief();
+  const createPerson = useCreatePerson();
 
   const contactPersonOptions = useMemo(
     () => (people ?? [])
@@ -425,7 +425,7 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
                 ]}
                 placeholder="Zoek een persoon..."
                 onCreate={async (name) => {
-                  const result = await createPerson({ naam: name }, true);
+                  const result = await createPerson.mutateAsync({ naam: name, force: true });
                   return result?.id ?? null;
                 }}
                 createLabel="Nieuwe persoon aanmaken"
@@ -952,8 +952,8 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
                       options={contactPersonOptions}
                       placeholder="Zoek of typ een naam..."
                       onCreate={async (name) => {
-                        const newPerson = await createPerson({ naam: name }, true);
-                        return newPerson.id;
+                        const newPerson = await createPerson.mutateAsync({ naam: name, force: true });
+                        return newPerson?.id ?? null;
                       }}
                       createLabel="Nieuw contact"
                     />

--- a/frontend/src/components/leads/LeadIntakeDialog.tsx
+++ b/frontend/src/components/leads/LeadIntakeDialog.tsx
@@ -11,9 +11,8 @@ import { useTags } from '@/hooks/useTags';
 import { isEmailFile, parseEmailFile, emailToRawText } from '@/utils/emailParser';
 import type { ParsedEmail } from '@/utils/emailParser';
 import { useToast } from '@/contexts/ToastContext';
-import { usePeople } from '@/hooks/usePeople';
+import { usePeople, useCreatePerson } from '@/hooks/usePeople';
 import { useInitiatieven, useCreateInitiatief } from '@/hooks/useInitiatieven';
-import { createPerson } from '@/api/people';
 import { useCurrentPerson } from '@/contexts/CurrentPersonContext';
 import { useLeadDetail } from '@/contexts/LeadDetailContext';
 import { LeadStage, LEAD_STAGE_ORDER, LEAD_STAGE_LABELS, LEAD_STAGE_COLORS, INITIATIEF_COLORS, formatFunctie } from '@/types';
@@ -83,6 +82,7 @@ export function LeadIntakeDialog({ open, onClose, defaultInitiatiefId, sharedPar
   const { currentPerson } = useCurrentPerson();
   const { data: initiatieven } = useInitiatieven();
   const createInitiatiefMutation = useCreateInitiatief();
+  const createPersonMutation = useCreatePerson();
   const { data: people } = usePeople();
   const { data: allTags } = useTags();
   const { openLeadDetail } = useLeadDetail();
@@ -430,14 +430,13 @@ export function LeadIntakeDialog({ open, onClose, defaultInitiatiefId, sharedPar
               if (byEmail) personId = byEmail.id;
             }
             if (!personId) {
-              const newPerson = await createPerson(
-                {
-                  naam: contact.name.trim(),
-                  email: contact.email.trim() || undefined,
-                },
-                true,
-              );
-              personId = newPerson.id;
+              const newPerson = await createPersonMutation.mutateAsync({
+                naam: contact.name.trim(),
+                email: contact.email.trim() || undefined,
+                force: true,
+              });
+              personId = newPerson?.id ?? null;
+              if (!personId) continue;
             }
             await addLeadContactApi(lead.id, personId, contact.rol);
           } catch {


### PR DESCRIPTION
## Probleem

In de leads-flow kreeg iedereen behalve admins een 403 bij \`POST /api/people\`, en de UI gaf geen enkele feedback. \`CreatableSelect.handleCreate\` had een \`try { ... } finally { ... }\` zonder \`catch\`, en \`LeadDetailPanel\` / \`LeadIntakeDialog\` gebruikten de rauwe \`createPerson\` API in plaats van de \`useCreatePerson\` hook — dus zelfs de toast van \`useMutationWithError\` ging niet af.

## Aanpak

**Backend** — splits \`people:create\` af van \`people:manage\` (zelfde patroon als #265 voor \`people:update\`):

- Migratie \`a1f3c8e7d402\` voegt de permissie toe en grant aan viewer / editor / unit_manager / ministry_admin / super_admin
- \`POST /api/people\` vraagt nu \`people:create\`
- Sensitive mutaties (delete, agent toggle, API key rotate) blijven op \`people:manage\`

**Frontend**

- \`CreatableSelect\`: vangt \`onCreate\` errors, houdt dropdown open, toont rode error-regel inline (uit \`ApiError.body.detail\`, met expliciete 403-tekst). Reset bij volgende toetsaanslag.
- \`LeadDetailPanel\` + \`LeadIntakeDialog\`: switch naar \`useCreatePerson\` hook zodat 4xx errors ook toast tonen.

## Wie kan straks contactpersonen aanmaken?

Iedereen met een rol behalve \`platform_admin\` (en niet-ingelogd / niet-whitelisted users worden al door de middleware tegengehouden). \`viewer\` is bewust meegenomen om hetzelfde gedrag te krijgen als \`people:update\` in #265.

## Test plan

- [ ] CI: nieuwe authz-test \`test_create_person_allowed_with_people_create\` slaagt
- [ ] Lokaal: nieuwe contactpersoon via \`AddLeadContactModal\` werkt voor non-admin
- [ ] Lokaal: forceer 403 (bv. lege rolset) → rode error verschijnt onder de create-optie en het veld, dropdown blijft open
- [ ] Lokaal: \`LeadDetailPanel\` "Toegewezen aan" + "Nieuw contact" gebruiken nu de hook → toast verschijnt bij fout
- [ ] Lokaal: \`LeadIntakeDialog\` submit met nieuw contact werkt