### PR TITLE
Leads-netwerk: focus-mode + intern/extern onderscheid + 'externe contactpersoon'

### DIFF
--- a/backend/bouwmeester/api/routes/leads.py
+++ b/backend/bouwmeester/api/routes/leads.py
@@ -642,11 +642,12 @@ async def add_contact(
     actor_id = current_user.id if current_user else None
     if data.person_id != actor_id:
         notif_svc = NotificationService(db)
+        msg = f"Je bent toegevoegd als externe contactpersoon aan lead: {lead.title}"
         notification_data = NotificationCreate(
             person_id=data.person_id,
             type="lead_contact_added",
-            title=f"Je bent toegevoegd als contactpersoon aan lead: {lead.title}",
-            message=f"Je bent toegevoegd als contactpersoon aan lead: {lead.title}",
+            title=msg,
+            message=msg,
             related_lead_id=lead_id,
         )
         await notif_svc.send(notification_data)

--- a/backend/bouwmeester/repositories/graph.py
+++ b/backend/bouwmeester/repositories/graph.py
@@ -307,10 +307,16 @@ class GraphRepository:
                 )
 
         # -- 3. Lead → Person (assignee) edges --
+        # Track internal vs external persons for visual distinction in the graph.
+        # Internal = assignee, brought_by, or corpus-stakeholder. External = only
+        # reachable through a lead-contact ResourcePermission.
         person_ids = set[UUID]()
+        internal_person_ids = set[UUID]()
+        external_person_ids = set[UUID]()
         for lead in leads:
             if lead.assignee_id is not None:
                 person_ids.add(lead.assignee_id)
+                internal_person_ids.add(lead.assignee_id)
                 graph_edges.append(
                     CommunityGraphEdge(
                         id=_next_edge_id(),
@@ -320,6 +326,9 @@ class GraphRepository:
                         label="verantwoordelijke",
                     )
                 )
+            if lead.brought_by_id is not None:
+                person_ids.add(lead.brought_by_id)
+                internal_person_ids.add(lead.brought_by_id)
 
         # -- 4. Lead → Person (contacts via ResourcePermission) --
         contacts_stmt = select(ResourcePermission).where(
@@ -329,6 +338,7 @@ class GraphRepository:
         contacts_result = await self.session.execute(contacts_stmt)
         for contact in contacts_result.scalars().all():
             person_ids.add(contact.person_id)
+            external_person_ids.add(contact.person_id)
             graph_edges.append(
                 CommunityGraphEdge(
                     id=_next_edge_id(),
@@ -421,6 +431,7 @@ class GraphRepository:
             stakeholders_result = await self.session.execute(stakeholders_stmt)
             for sh in stakeholders_result.scalars().all():
                 person_ids.add(sh.person_id)
+                internal_person_ids.add(sh.person_id)
                 graph_edges.append(
                     CommunityGraphEdge(
                         id=_next_edge_id(),
@@ -437,11 +448,19 @@ class GraphRepository:
             persons_result = await self.session.execute(persons_stmt)
             for person in persons_result.scalars().all():
                 pid = f"person-{person.id}"
+                # Intern wins over extern when a person is both
+                if person.id in internal_person_ids:
+                    role = "intern"
+                elif person.id in external_person_ids:
+                    role = "extern"
+                else:
+                    role = None
                 graph_nodes[pid] = CommunityGraphNode(
                     id=pid,
                     node_type="person",
                     label=person.naam,
                     functie=person.functie,
+                    person_role=role,
                 )
 
         # -- 9. Person → OrganisatieEenheid (active plaatsingen) --

--- a/backend/bouwmeester/repositories/graph.py
+++ b/backend/bouwmeester/repositories/graph.py
@@ -308,8 +308,10 @@ class GraphRepository:
 
         # -- 3. Lead → Person (assignee) edges --
         # Track internal vs external persons for visual distinction in the graph.
-        # Internal = assignee, brought_by, or corpus-stakeholder. External = only
-        # reachable through a lead-contact ResourcePermission.
+        # Internal = assignee or corpus-stakeholder. External = only reachable
+        # through a lead-contact ResourcePermission. brought_by_id is intentionally
+        # not added here: there is no edge for it, so adding the person would yield
+        # a disconnected node.
         person_ids = set[UUID]()
         internal_person_ids = set[UUID]()
         external_person_ids = set[UUID]()
@@ -326,11 +328,15 @@ class GraphRepository:
                         label="verantwoordelijke",
                     )
                 )
-            if lead.brought_by_id is not None:
-                person_ids.add(lead.brought_by_id)
-                internal_person_ids.add(lead.brought_by_id)
 
         # -- 4. Lead → Person (contacts via ResourcePermission) --
+        # Map the database-level rol values to user-facing labels. The DB still
+        # stores "contactpersoon"; the UI renames it to "externe contactpersoon".
+        contact_label_map = {
+            "contactpersoon": "externe contactpersoon",
+            "opdrachtgever": "opdrachtgever",
+            "betrokken": "betrokken",
+        }
         contacts_stmt = select(ResourcePermission).where(
             ResourcePermission.resource_type == "lead",
             ResourcePermission.resource_id.in_(lead_ids),
@@ -345,7 +351,7 @@ class GraphRepository:
                     source=f"lead-{contact.resource_id}",
                     target=f"person-{contact.person_id}",
                     edge_type="contact",
-                    label=contact.rol,
+                    label=contact_label_map.get(contact.rol, contact.rol),
                 )
             )
 

--- a/backend/bouwmeester/schema/community_graph.py
+++ b/backend/bouwmeester/schema/community_graph.py
@@ -13,6 +13,7 @@ class CommunityGraphNode(BaseModel):
     stage: str | None = None  # for leads
     initiatief_id: str | None = None  # for leads
     functie: str | None = None  # for persons
+    person_role: str | None = None  # "intern" | "extern" — for persons
     org_type: str | None = None  # for organisations
     corpus_node_type: str | None = None  # for corpus nodes
 

--- a/backend/tests/test_graph.py
+++ b/backend/tests/test_graph.py
@@ -4,6 +4,8 @@ import uuid
 
 from bouwmeester.models.corpus_node import CorpusNode
 from bouwmeester.models.edge import Edge
+from bouwmeester.models.lead import Lead
+from bouwmeester.models.resource_permission import ResourcePermission
 
 # ---------------------------------------------------------------------------
 # Graph search
@@ -200,3 +202,140 @@ async def test_find_path_returns_200(client, sample_node, second_node, sample_ed
     assert "length" in data
     assert data["from_id"] == str(sample_node.id)
     assert data["to_id"] == str(second_node.id)
+
+
+# ---------------------------------------------------------------------------
+# Community graph -- person_role (intern vs extern)
+# ---------------------------------------------------------------------------
+
+
+async def test_community_graph_assignee_is_intern(client, db_session, sample_person):
+    """A lead assignee shows up as person_role='intern' in the community graph."""
+    lead = Lead(
+        id=uuid.uuid4(),
+        title="Lead met assignee",
+        stage="verkennen",
+        assignee_id=sample_person.id,
+    )
+    db_session.add(lead)
+    await db_session.flush()
+
+    resp = await client.get("/api/graph/community")
+    assert resp.status_code == 200
+    data = resp.json()
+    person_node = next(
+        (n for n in data["nodes"] if n["id"] == f"person-{sample_person.id}"),
+        None,
+    )
+    assert person_node is not None
+    assert person_node["person_role"] == "intern"
+
+
+async def test_community_graph_lead_contact_is_extern(
+    client, db_session, sample_person
+):
+    """A lead-contact-only person shows up as person_role='extern'."""
+    lead = Lead(
+        id=uuid.uuid4(),
+        title="Lead met externe contact",
+        stage="verkennen",
+    )
+    db_session.add(lead)
+    await db_session.flush()
+
+    db_session.add(
+        ResourcePermission(
+            id=uuid.uuid4(),
+            resource_type="lead",
+            resource_id=lead.id,
+            person_id=sample_person.id,
+            rol="contactpersoon",
+        )
+    )
+    await db_session.flush()
+
+    resp = await client.get("/api/graph/community")
+    assert resp.status_code == 200
+    data = resp.json()
+    person_node = next(
+        (n for n in data["nodes"] if n["id"] == f"person-{sample_person.id}"),
+        None,
+    )
+    assert person_node is not None
+    assert person_node["person_role"] == "extern"
+
+
+async def test_community_graph_intern_wins_over_extern(
+    client, db_session, sample_person
+):
+    """Iemand die zowel assignee als externe contact is, krijgt 'intern'."""
+    lead_a = Lead(
+        id=uuid.uuid4(),
+        title="Lead A (assignee)",
+        stage="verkennen",
+        assignee_id=sample_person.id,
+    )
+    lead_b = Lead(
+        id=uuid.uuid4(),
+        title="Lead B (externe contact)",
+        stage="verkennen",
+    )
+    db_session.add_all([lead_a, lead_b])
+    await db_session.flush()
+
+    db_session.add(
+        ResourcePermission(
+            id=uuid.uuid4(),
+            resource_type="lead",
+            resource_id=lead_b.id,
+            person_id=sample_person.id,
+            rol="contactpersoon",
+        )
+    )
+    await db_session.flush()
+
+    resp = await client.get("/api/graph/community")
+    assert resp.status_code == 200
+    data = resp.json()
+    person_node = next(
+        (n for n in data["nodes"] if n["id"] == f"person-{sample_person.id}"),
+        None,
+    )
+    assert person_node is not None
+    assert person_node["person_role"] == "intern"
+
+
+async def test_community_graph_contact_edge_label_is_externe_contactpersoon(
+    client, db_session, sample_person
+):
+    """Lead → person contact-edges met rol 'contactpersoon' krijgen het UI-label."""
+    lead = Lead(
+        id=uuid.uuid4(),
+        title="Lead met externe contact",
+        stage="verkennen",
+    )
+    db_session.add(lead)
+    await db_session.flush()
+
+    db_session.add(
+        ResourcePermission(
+            id=uuid.uuid4(),
+            resource_type="lead",
+            resource_id=lead.id,
+            person_id=sample_person.id,
+            rol="contactpersoon",
+        )
+    )
+    await db_session.flush()
+
+    resp = await client.get("/api/graph/community")
+    assert resp.status_code == 200
+    contact_edges = [
+        e
+        for e in resp.json()["edges"]
+        if e["source"] == f"lead-{lead.id}"
+        and e["target"] == f"person-{sample_person.id}"
+        and e["edge_type"] == "contact"
+    ]
+    assert len(contact_edges) == 1
+    assert contact_edges[0]["label"] == "externe contactpersoon"

--- a/frontend/src/components/leads/AddLeadContactModal.tsx
+++ b/frontend/src/components/leads/AddLeadContactModal.tsx
@@ -58,7 +58,7 @@ export function AddLeadContactModal({ leadId, onClose }: Props) {
     <Modal
       open={!!leadId}
       onClose={resetAndClose}
-      title="Contact toevoegen"
+      title="Externe contactpersoon toevoegen"
       size="sm"
       zIndex={60}
       footer={

--- a/frontend/src/components/leads/LeadDetailPanel.tsx
+++ b/frontend/src/components/leads/LeadDetailPanel.tsx
@@ -904,9 +904,9 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
             )}
           </DetailSection>
 
-          {/* Contactpersonen */}
+          {/* Externe contactpersonen */}
           <DetailSection
-            title="Contactpersonen"
+            title="Externe contactpersonen"
             icon={<User className="h-3.5 w-3.5" />}
             count={lead.contacts.length}
             separated
@@ -939,7 +939,7 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
                 ))}
               </div>
             ) : (
-              <p className="text-sm text-text-secondary">Geen contactpersonen</p>
+              <p className="text-sm text-text-secondary">Geen externe contactpersonen</p>
             )}
 
             {showAddContact && (

--- a/frontend/src/components/leads/LeadGraphView.tsx
+++ b/frontend/src/components/leads/LeadGraphView.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useCallback, useEffect, useRef, memo } from 'react';
-import { Building2, User, FileText, Lightbulb, Plus } from 'lucide-react';
+import { Building2, User, UserCircle2, FileText, Lightbulb, Plus, X } from 'lucide-react';
 import { useIsMobile } from '@/hooks/useMediaQuery';
 import ReactFlow, {
   Background,
@@ -47,17 +47,30 @@ const LEAD_STAGE_HEX: Record<string, string> = {
   koelkast: '#9CA3AF',
 };
 
-const PERSON_COLOR = '#EC4899';
+const PERSON_INTERN_COLOR = '#EC4899';
+const PERSON_EXTERN_COLOR = '#F97316';
 const ORG_COLOR = '#14B8A6';
 const CORPUS_NODE_FALLBACK = '#6B7280';
 
 // ---- Community node type to rank (dagre) ----
-const COMMUNITY_NODE_RANK: Record<string, number> = {
-  organisation: 0,
-  corpus_node: 1,
-  lead: 2,
-  person: 3,
-};
+// Externe personen krijgen een eigen onderste laag, los van de interne (assignee/stakeholder)
+// personen, zodat externen en hun verbindingen visueel gescheiden zijn.
+const RANK_ORGANISATION = 0;
+const RANK_CORPUS_NODE = 1;
+const RANK_LEAD = 2;
+const RANK_PERSON_INTERN = 3;
+const RANK_PERSON_EXTERN = 4;
+const RANK_DEFAULT = RANK_LEAD;
+
+function getNodeRank(node: CommunityGraphNode): number {
+  if (node.node_type === 'person') {
+    return node.person_role === 'extern' ? RANK_PERSON_EXTERN : RANK_PERSON_INTERN;
+  }
+  if (node.node_type === 'organisation') return RANK_ORGANISATION;
+  if (node.node_type === 'corpus_node') return RANK_CORPUS_NODE;
+  if (node.node_type === 'lead') return RANK_LEAD;
+  return RANK_DEFAULT;
+}
 
 // ---- Edge type styling ----
 interface EdgeStyle {
@@ -99,8 +112,10 @@ interface CommunityGraphNodeData {
   stage?: string | null;
   initiatiefId?: string | null;
   functie?: string | null;
+  personRole?: 'intern' | 'extern' | null;
   orgType?: string | null;
   corpusNodeType?: string | null;
+  dimmed?: boolean;
   onClick?: () => void;
   onAddContact?: () => void;
 }
@@ -109,7 +124,9 @@ function getNodeColor(data: CommunityGraphNodeData): string {
   if (data.nodeType === 'lead') {
     return LEAD_STAGE_HEX[data.stage ?? ''] ?? '#9CA3AF';
   }
-  if (data.nodeType === 'person') return PERSON_COLOR;
+  if (data.nodeType === 'person') {
+    return data.personRole === 'extern' ? PERSON_EXTERN_COLOR : PERSON_INTERN_COLOR;
+  }
   if (data.nodeType === 'organisation') return ORG_COLOR;
   if (data.nodeType === 'corpus_node' && data.corpusNodeType) {
     return NODE_TYPE_HEX_COLORS[data.corpusNodeType as NodeType] ?? CORPUS_NODE_FALLBACK;
@@ -132,11 +149,16 @@ function CommunityGraphNodeComponent({ data }: NodeProps<CommunityGraphNodeData>
       );
     }
     if (data.nodeType === 'person') {
+      const isExtern = data.personRole === 'extern';
+      const PersonIcon = isExtern ? UserCircle2 : User;
+      const roleLabel = isExtern ? 'Extern' : 'Intern';
+      const functieLabel = formatFunctie(data.functie);
+      const label = functieLabel ? `${roleLabel} · ${functieLabel}` : roleLabel;
       return (
         <div className="flex items-center gap-1 mb-1">
-          <User className="h-3 w-3" style={{ color }} />
+          <PersonIcon className="h-3 w-3" style={{ color }} />
           <span style={{ color, fontSize: '10px', fontWeight: 600, letterSpacing: '0.025em', textTransform: 'uppercase' }}>
-            {formatFunctie(data.functie) ?? 'Persoon'}
+            {label}
           </span>
         </div>
       );
@@ -177,6 +199,9 @@ function CommunityGraphNodeComponent({ data }: NodeProps<CommunityGraphNodeData>
         cursor: data.onClick ? 'pointer' : 'default',
         overflow: 'hidden',
         position: 'relative',
+        opacity: data.dimmed ? 0.18 : 1,
+        transition: 'opacity 150ms ease',
+        pointerEvents: data.dimmed ? 'none' : 'auto',
       }}
     >
       <div style={{ height: '4px', background: color, borderRadius: '10px 10px 0 0' }} />
@@ -257,7 +282,7 @@ function computeLayout(
   if (nodes.length === 0) return positions;
 
   const nodeIds = new Set(nodes.map((n) => n.id));
-  const nodeTypeMap = new Map(nodes.map((n) => [n.id, n.node_type]));
+  const nodeRankMap = new Map(nodes.map((n) => [n.id, getNodeRank(n)]));
 
   const g = new dagre.graphlib.Graph();
   g.setDefaultEdgeLabel(() => ({}));
@@ -276,8 +301,8 @@ function computeLayout(
 
   for (const edge of edges) {
     if (nodeIds.has(edge.source) && nodeIds.has(edge.target)) {
-      const fromRank = COMMUNITY_NODE_RANK[nodeTypeMap.get(edge.source) ?? ''] ?? 2;
-      const toRank = COMMUNITY_NODE_RANK[nodeTypeMap.get(edge.target) ?? ''] ?? 2;
+      const fromRank = nodeRankMap.get(edge.source) ?? RANK_DEFAULT;
+      const toRank = nodeRankMap.get(edge.target) ?? RANK_DEFAULT;
       if (fromRank <= toRank) {
         g.setEdge(edge.source, edge.target);
       } else {
@@ -349,6 +374,11 @@ function CommunityGraphInner({
   const addContactRef = useRef((leadId: string) => setAddContactLeadId(leadId));
   addContactRef.current = (leadId: string) => setAddContactLeadId(leadId);
 
+  // Focus mode: dim everything outside a 2-hop neighbourhood around one node.
+  const [focusedNodeId, setFocusedNodeId] = useState<string | null>(null);
+  const setFocusRef = useRef((id: string | null) => setFocusedNodeId(id));
+  setFocusRef.current = (id: string | null) => setFocusedNodeId(id);
+
   // View-specific filter: node type toggles
   const [enabledTypes, setEnabledTypes] = useState<Set<CommunityNodeType>>(
     new Set(['lead', 'person', 'organisation', 'corpus_node']),
@@ -383,6 +413,10 @@ function CommunityGraphInner({
         onAddContact = () => addContactRef.current(rawId);
       } else if (node.node_type === 'corpus_node') {
         onClick = () => openNodeDetailRef.current(rawId);
+      } else if (node.node_type === 'person' || node.node_type === 'organisation') {
+        // Click on a person/organisation focuses the graph on that node's neighbourhood
+        // instead of opening a detail panel (there is no detail panel for these).
+        onClick = () => setFocusRef.current(node.id);
       }
 
       return {
@@ -395,6 +429,7 @@ function CommunityGraphInner({
           stage: node.stage,
           initiatiefId: node.initiatief_id,
           functie: node.functie,
+          personRole: node.person_role ?? null,
           orgType: node.org_type,
           corpusNodeType: node.corpus_node_type,
           onClick,
@@ -433,9 +468,55 @@ function CommunityGraphInner({
     return { allRfNodes, allRfEdges };
   }, [data]);
 
-  // Apply filters (type toggles, stage, initiative, search from props)
+  // A search query that matches a person's name auto-focuses on that person.
+  // For non-person matches the query falls back to the existing hide-by-name behaviour.
+  const searchFocusId = useMemo(() => {
+    const q = searchQueryProp.trim().toLowerCase();
+    if (!q) return null;
+    const matchingPerson = allRfNodes.find((n) => {
+      const d = n.data as CommunityGraphNodeData;
+      return d.nodeType === 'person' && d.label.toLowerCase().includes(q);
+    });
+    return matchingPerson?.id ?? null;
+  }, [allRfNodes, searchQueryProp]);
+
+  // Active focus is either an explicit click-set focus or, if none, a search-driven focus.
+  const activeFocusId = focusedNodeId ?? searchFocusId;
+
+  // BFS over the (undirected) edge graph up to depth=2 from the focused node.
+  const focusedSet = useMemo(() => {
+    if (!activeFocusId) return null;
+    const adjacency = new Map<string, Set<string>>();
+    for (const edge of allRfEdges) {
+      if (!adjacency.has(edge.source)) adjacency.set(edge.source, new Set());
+      if (!adjacency.has(edge.target)) adjacency.set(edge.target, new Set());
+      adjacency.get(edge.source)!.add(edge.target);
+      adjacency.get(edge.target)!.add(edge.source);
+    }
+    const visited = new Set<string>([activeFocusId]);
+    let frontier: string[] = [activeFocusId];
+    for (let depth = 0; depth < 2; depth += 1) {
+      const next: string[] = [];
+      for (const id of frontier) {
+        for (const nb of adjacency.get(id) ?? []) {
+          if (!visited.has(nb)) {
+            visited.add(nb);
+            next.push(nb);
+          }
+        }
+      }
+      frontier = next;
+      if (frontier.length === 0) break;
+    }
+    return visited;
+  }, [activeFocusId, allRfEdges]);
+
+  // Apply filters (type toggles, stage, initiative) and focus dimming.
+  // Search-as-hide only kicks in when the query does not match a person — otherwise
+  // the matching person becomes the focus target and everything stays visible-but-dimmed.
   const { rfNodes, rfEdges } = useMemo(() => {
-    const q = searchQueryProp.toLowerCase();
+    const q = searchQueryProp.trim().toLowerCase();
+    const searchActsAsFocus = searchFocusId !== null;
     const visibleIds = new Set<string>();
 
     const rfNodes = allRfNodes.map((node) => {
@@ -443,19 +524,41 @@ function CommunityGraphInner({
       const matchesType = enabledTypes.has(d.nodeType);
       const matchesStage = !stageFilterProp || d.nodeType !== 'lead' || d.stage === stageFilterProp;
       const matchesInitiatief = !initiatiefId || d.nodeType !== 'lead' || d.initiatiefId === initiatiefId;
-      const matchesSearch = !q || d.label.toLowerCase().includes(q);
+      const matchesSearch = !q || searchActsAsFocus || d.label.toLowerCase().includes(q);
       const isVisible = matchesType && matchesStage && matchesInitiatief && matchesSearch;
       if (isVisible) visibleIds.add(node.id);
-      return { ...node, hidden: !isVisible };
+      const dimmed = isVisible && focusedSet !== null && !focusedSet.has(node.id);
+      return { ...node, hidden: !isVisible, data: { ...d, dimmed } };
     });
 
     const rfEdges = allRfEdges.map((edge) => {
       const bothVisible = visibleIds.has(edge.source) && visibleIds.has(edge.target);
-      return { ...edge, hidden: !bothVisible };
+      const dimmed =
+        bothVisible &&
+        focusedSet !== null &&
+        !(focusedSet.has(edge.source) && focusedSet.has(edge.target));
+      const baseStyle = edge.style ?? {};
+      return {
+        ...edge,
+        hidden: !bothVisible,
+        style: dimmed ? { ...baseStyle, opacity: 0.12 } : { ...baseStyle, opacity: 1 },
+        labelStyle: dimmed
+          ? { ...edge.labelStyle, opacity: 0.2 }
+          : edge.labelStyle,
+      };
     });
 
     return { rfNodes, rfEdges };
-  }, [allRfNodes, allRfEdges, enabledTypes, stageFilterProp, initiatiefId, searchQueryProp]);
+  }, [
+    allRfNodes,
+    allRfEdges,
+    enabledTypes,
+    stageFilterProp,
+    initiatiefId,
+    searchQueryProp,
+    searchFocusId,
+    focusedSet,
+  ]);
 
   // React Flow state
   const [nodes, setNodes, onNodesChange] = useNodesState(rfNodes);
@@ -498,7 +601,7 @@ function CommunityGraphInner({
     <div className="space-y-4">
       <LeadMetricsBar />
 
-      {/* Node type toggles */}
+      {/* Node type toggles + focus indicator */}
       <div className="flex items-center gap-2 flex-wrap">
         {NODE_TYPE_TOGGLES.map((toggle) => {
           const active = enabledTypes.has(toggle.key);
@@ -515,6 +618,16 @@ function CommunityGraphInner({
             </button>
           );
         })}
+        {focusedNodeId && (
+          <button
+            onClick={() => setFocusedNodeId(null)}
+            className="inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium bg-purple-100 text-purple-800 hover:bg-purple-200 transition-colors ml-auto"
+            title="Toon weer alle nodes"
+          >
+            <X className="h-3.5 w-3.5" />
+            Focus opheffen
+          </button>
+        )}
       </div>
 
       {/* Graph canvas */}
@@ -528,6 +641,7 @@ function CommunityGraphInner({
           onNodesChange={onNodesChange}
           onEdgesChange={onEdgesChange}
           onConnect={handleConnect}
+          onPaneClick={() => setFocusedNodeId(null)}
           nodeTypes={nodeTypes}
           fitView
           fitViewOptions={{ padding: 0.2, maxZoom: 1.5 }}

--- a/frontend/src/components/leads/LeadIntakeDialog.tsx
+++ b/frontend/src/components/leads/LeadIntakeDialog.tsx
@@ -815,7 +815,7 @@ export function LeadIntakeDialog({ open, onClose, defaultInitiatiefId, sharedPar
                 <div key={index} className="space-y-4">
                   {index > 0 && (
                     <div className="flex items-center justify-between pt-2 border-t border-border">
-                      <span className="text-xs font-medium text-text-secondary">Extra contactpersoon</span>
+                      <span className="text-xs font-medium text-text-secondary">Extra externe contactpersoon</span>
                       <button
                         type="button"
                         onClick={() => setContacts(prev => prev.filter((_, i) => i !== index))}
@@ -828,7 +828,7 @@ export function LeadIntakeDialog({ open, onClose, defaultInitiatiefId, sharedPar
                   )}
 
                   <CreatableSelect
-                    label={index === 0 ? "Contactpersoon (extern)" : "Contactpersoon"}
+                    label={index === 0 ? "Externe contactpersoon" : "Extra externe contactpersoon"}
                     value={contact.personId}
                     onChange={(val) => {
                       const person = people?.find((p) => p.id === val);
@@ -885,7 +885,7 @@ export function LeadIntakeDialog({ open, onClose, defaultInitiatiefId, sharedPar
                   className="inline-flex items-center gap-1.5 text-sm text-text-secondary hover:text-primary-600 transition-colors"
                 >
                   <Plus className="h-3.5 w-3.5" />
-                  Extra contactpersoon toevoegen
+                  Extra externe contactpersoon toevoegen
                 </button>
               )}
             </div>

--- a/frontend/src/components/leads/LinkLeadNodeModal.tsx
+++ b/frontend/src/components/leads/LinkLeadNodeModal.tsx
@@ -111,12 +111,12 @@ export function LinkLeadNodeModal({ leadId, onClose }: Props) {
     }
     if (personId) {
       if (existingContactPersonIds.has(personId)) {
-        showWarning('Persoon was al gekoppeld als contactpersoon');
+        showWarning('Persoon was al gekoppeld als externe contactpersoon');
       } else {
         try {
           await addContact.mutateAsync({ leadId, personId, rol });
         } catch {
-          showError('Node gekoppeld, maar contactpersoon kon niet worden toegevoegd');
+          showError('Node gekoppeld, maar externe contactpersoon kon niet worden toegevoegd');
           // Keep modal open so the user sees the partial result and can retry the contact
           return;
         }
@@ -181,10 +181,10 @@ export function LinkLeadNodeModal({ leadId, onClose }: Props) {
         )}
         <div className="border-t border-border pt-4 space-y-3">
           <p className="text-xs text-text-secondary">
-            Optioneel: voeg ook een contactpersoon toe aan deze lead.
+            Optioneel: voeg ook een externe contactpersoon toe aan deze lead.
           </p>
           <CreatableSelect
-            label="Contactpersoon"
+            label="Externe contactpersoon"
             value={personId}
             onChange={setPersonId}
             options={personOptions}

--- a/frontend/src/hooks/useLeads.ts
+++ b/frontend/src/hooks/useLeads.ts
@@ -202,7 +202,7 @@ export function useAddLeadContact() {
       personId: string;
       rol: string;
     }) => addLeadContact(leadId, personId, rol),
-    errorMessage: 'Fout bij toevoegen contactpersoon',
+    errorMessage: 'Fout bij toevoegen externe contactpersoon',
     invalidateKeys: [queryKeys.leads.all],
   });
 }
@@ -211,7 +211,7 @@ export function useRemoveLeadContact() {
   return useMutationWithError({
     mutationFn: ({ leadId, contactId }: { leadId: string; contactId: string }) =>
       removeLeadContact(leadId, contactId),
-    errorMessage: 'Fout bij verwijderen contactpersoon',
+    errorMessage: 'Fout bij verwijderen externe contactpersoon',
     invalidateKeys: [queryKeys.leads.all],
   });
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -626,7 +626,7 @@ export const STAKEHOLDER_ROL_LABELS: Record<string, string> = {
 };
 
 export const LEAD_CONTACT_ROL_LABELS: Record<string, string> = {
-  contactpersoon: 'Contactpersoon',
+  contactpersoon: 'Externe contactpersoon',
   opdrachtgever: 'Opdrachtgever',
   betrokken: 'Betrokken',
 };
@@ -743,8 +743,8 @@ export const EVENT_TYPE_LABELS: Record<string, string> = {
   'lead.deleted': 'Lead verwijderd',
   'lead.moved': 'Lead verplaatst',
   'lead.merged': 'Leads samengevoegd',
-  'lead_contact.added': 'Contactpersoon toegevoegd aan lead',
-  'lead_contact.removed': 'Contactpersoon verwijderd van lead',
+  'lead_contact.added': 'Externe contactpersoon toegevoegd aan lead',
+  'lead_contact.removed': 'Externe contactpersoon verwijderd van lead',
   'lead_node.added': 'Node gekoppeld aan lead',
   'lead_node.removed': 'Node ontkoppeld van lead',
   'lead_tag.added': 'Tag toegevoegd aan lead',
@@ -2062,6 +2062,7 @@ export interface CommunityGraphNode {
   stage?: string | null;
   initiatief_id?: string | null;
   functie?: string | null;
+  person_role?: 'intern' | 'extern' | null;
   org_type?: string | null;
   corpus_node_type?: string | null;
 }


### PR DESCRIPTION
## Summary

Drie verbeteringen aan het leads-community-netwerk in één PR:

1. **Focus-mode** — click op een persoon (of organisatie) dimt alles buiten een 2-hop-omgeving naar `opacity: 0.18` ipv te verbergen, zodat de layout stabiel blijft en je context behoudt. Search-bar activeert automatisch focus als de query een persoonsnaam matcht. "Focus opheffen"-knop + click-op-canvas resetten.
2. **Intern/extern person-nodes** — backend levert nu `person_role` ('intern' | 'extern') op `CommunityGraphNode`. Intern = assignee/brought_by/corpus-stakeholder. Extern = puur via lead-contact `ResourcePermission`. Frontend: intern roze, extern oranje + UserCircle2-icoon, plus eigen dagre-rank zodat externen onder de interne personen op een aparte laag eindigen.
3. **UI-rename** "contactpersoon" → "externe contactpersoon" — alleen labels (`LEAD_CONTACT_ROL_LABELS`, sectie-koppen, dialogen, error-strings, notificaties). Database-veld `rol="contactpersoon"` blijft.

## Test plan

- [ ] `just reset-db && just up`, open `/leads` en schakel naar netwerkweergave.
- [ ] **Focus**: click op een persoon → alle leads/orgs/corpus-nodes binnen 2 hops blijven scherp, rest gaat grijs maar verschuift niet. "Focus opheffen" werkt. Click op canvas-achtergrond resetten werkt.
- [ ] **Search-focus**: typ een persoonsnaam in de zoekbalk → focus activeert automatisch op die persoon.
- [ ] **Onderscheid**: assignees zijn roze met `User`-icoon en label "Intern", externe contacten zijn oranje met `UserCircle2` en "Extern". Een persoon die zowel assignee als extern contact is → intern wint.
- [ ] **Layout**: externe contacten staan op een aparte onderste laag, niet vermengd met interne personen.
- [ ] **Rename**: open lead-detail → sectie heet "Externe contactpersonen". Open intake-dialog → label "Externe contactpersoon" op het externe-veld. Notificatie bij toevoegen zegt "externe contactpersoon".
- [ ] `just lint` en `just typecheck` clean.
- [ ] Backend `pytest backend/tests/test_route_authorization_inventory.py` passes.