### PR TITLE
Fix: e-mail-drop op leads sluit modal niet meer direct

### DIFF
--- a/frontend/src/components/common/Modal.test.tsx
+++ b/frontend/src/components/common/Modal.test.tsx
@@ -70,9 +70,27 @@ describe('Modal', () => {
       </Modal>,
     );
 
-    // The overlay is the backdrop div
+    // Wait past the 250ms suppression window applied at mount
+    await new Promise((r) => setTimeout(r, 300));
+
     const overlay = container.querySelector('.backdrop-blur-sm');
     if (overlay) await user.click(overlay);
     expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('ignores overlay clicks within 250ms of opening (drag-and-drop guard)', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const { container } = render(
+      <Modal open={true} onClose={onClose} title="Drop">
+        Content
+      </Modal>,
+    );
+
+    // Click immediately, simulating the synthetic post-drop click from
+    // Outlook on Windows/Citrix.
+    const overlay = container.querySelector('.backdrop-blur-sm');
+    if (overlay) await user.click(overlay);
+    expect(onClose).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/common/Modal.tsx
+++ b/frontend/src/components/common/Modal.tsx
@@ -62,10 +62,12 @@ export function Modal({
   onBack,
 }: ModalProps) {
   const wasOpen = useRef(false);
+  const openedAtRef = useRef(0);
   useEffect(() => {
     if (open && !wasOpen.current) {
       openModalCount++;
       document.body.style.overflow = 'hidden';
+      openedAtRef.current = Date.now();
       wasOpen.current = true;
     } else if (!open && wasOpen.current) {
       openModalCount = Math.max(0, openModalCount - 1);
@@ -99,12 +101,22 @@ export function Modal({
 
   const borderClass = accentColor ? `border-t-[3px] ${ACCENT_BORDER[accentColor]}` : '';
 
+  // Suppress overlay-click for the first 250ms after opening. Without this,
+  // a synthetic mouseup/click that follows a drag-and-drop (notably Outlook
+  // on Windows/Citrix) lands on the freshly-mounted overlay and closes the
+  // modal before the user sees it.
+  const handleOverlayClick = () => {
+    if (!closeable) return;
+    if (Date.now() - openedAtRef.current < 250) return;
+    onClose();
+  };
+
   return (
     <div className="fixed inset-0 flex items-center justify-center" style={{ zIndex }}>
       {/* Overlay */}
       <div
         className="fixed inset-0 bg-black/40 backdrop-blur-sm transition-opacity"
-        onClick={closeable ? onClose : undefined}
+        onClick={handleOverlayClick}
       />
 
       {/* Dialog */}


### PR DESCRIPTION
## Probleem

Op Citrix-Windows met klassiek Outlook faalde het slepen van een e-mail naar Bouwmeester zonder error: de Lead-intake-modal verscheen heel kort en verdween dan zonder feedback.

## Oorzaak

Klassiek Outlook op Windows synthesizet na een drag-and-drop een muisclick op de drop-positie. Die click landde op de zojuist gemounte modal-overlay (`<div onClick={onClose} />`) en sloot de modal direct weer.

Dit raakt elke drop-naar-modal-flow, niet alleen Outlook — Citrix maakt het zichtbaarder doordat events daar net iets later binnenkomen dan het mounten van de modal.

## Fix

`Modal.tsx` negeert overlay-clicks gedurende 250 ms na het openen. Daarna gedraagt de overlay zich zoals voorheen (klikken-buiten sluit de modal). Esc en de close-knop zijn onaangetast.

## Test plan

- [ ] Citrix-Windows + klassiek Outlook: e-mail naar /leads slepen, modal blijft open
- [ ] Mac/Linux: bestaand gedrag (klik buiten sluit modal) ongewijzigd
- [ ] Andere modals openen en direct buiten klikken: sluit zoals verwacht (na 250 ms)