### PR TITLE
Lead-activiteiten verwijderen door auteur of admin

### DIFF
--- a/backend/bouwmeester/api/routes/leads.py
+++ b/backend/bouwmeester/api/routes/leads.py
@@ -26,6 +26,7 @@ from bouwmeester.core.storage import (
     write_upload_to_disk,
 )
 from bouwmeester.models.lead import Lead
+from bouwmeester.models.lead_activity import LeadActivity
 from bouwmeester.models.lead_attachment import LeadAttachment
 from bouwmeester.models.lead_node import LeadNode
 from bouwmeester.repositories.lead import LeadRepository
@@ -602,6 +603,51 @@ async def list_activities(
     repo = LeadActivityRepository(db)
     activities = await repo.get_by_lead(lead_id)
     return validate_list(LeadActivityResponse, activities)
+
+
+@router.delete(
+    "/{lead_id}/activities/{activity_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_activity(
+    lead_id: UUID,
+    activity_id: UUID,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    init_ctx: InitiatiefContext = Depends(get_initiatief_context),
+) -> None:
+    """Delete a lead activity. Only the author or an admin may delete."""
+    lead = await db.get(Lead, lead_id)
+    if lead is None:
+        raise HTTPException(status_code=404, detail="Lead niet gevonden")
+    _check_lead_access(lead, init_ctx)
+
+    activity = await db.get(LeadActivity, activity_id)
+    if activity is None or activity.lead_id != lead_id:
+        raise HTTPException(status_code=404, detail="Activiteit niet gevonden")
+
+    actor_id = current_user.id if current_user else None
+    if not init_ctx.is_admin and (actor_id is None or activity.author_id != actor_id):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Alleen de auteur of een beheerder kan deze activiteit verwijderen",
+        )
+
+    activity_type = activity.activity_type
+    await db.delete(activity)
+
+    await log_activity(
+        db,
+        current_user,
+        None,
+        "lead_activity.deleted",
+        details={
+            "lead_id": str(lead_id),
+            "lead_title": lead.title,
+            "activity_id": str(activity_id),
+            "activity_type": activity_type,
+        },
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_lead_activity.py
+++ b/backend/tests/test_lead_activity.py
@@ -97,6 +97,44 @@ async def test_add_activity_with_mention_notifies_target(
     assert "Test lead" in notifs[0].title
 
 
+async def test_delete_activity_returns_204_and_removes_row(
+    client, db_session, sample_lead
+):
+    """Admin (default in test/dev mode) can delete; row is gone afterwards."""
+    from bouwmeester.models.lead_activity import LeadActivity
+
+    create_resp = await client.post(
+        f"/api/leads/{sample_lead.id}/activities",
+        json={"content": "Te verwijderen", "activity_type": "note"},
+    )
+    assert create_resp.status_code == 201
+    activity_id = create_resp.json()["id"]
+
+    del_resp = await client.delete(
+        f"/api/leads/{sample_lead.id}/activities/{activity_id}"
+    )
+    assert del_resp.status_code == 204
+
+    refreshed = await db_session.get(LeadActivity, uuid.UUID(activity_id))
+    assert refreshed is None
+
+
+async def test_delete_activity_wrong_lead_returns_404(client, sample_lead):
+    """Activity that does not belong to the given lead returns 404."""
+    create_resp = await client.post(
+        f"/api/leads/{sample_lead.id}/activities",
+        json={"content": "Notitie", "activity_type": "note"},
+    )
+    assert create_resp.status_code == 201
+    activity_id = create_resp.json()["id"]
+
+    other_lead_id = uuid.uuid4()
+    del_resp = await client.delete(
+        f"/api/leads/{other_lead_id}/activities/{activity_id}"
+    )
+    assert del_resp.status_code == 404
+
+
 async def test_mentioned_assignee_only_gets_one_notification(
     client, db_session, assigned_lead, sample_person
 ):

--- a/frontend/src/api/leads.ts
+++ b/frontend/src/api/leads.ts
@@ -81,6 +81,13 @@ export async function createLeadActivity(
   return apiPost<LeadActivity>(`/api/leads/${leadId}/activities`, data);
 }
 
+export async function deleteLeadActivity(
+  leadId: string,
+  activityId: string,
+): Promise<void> {
+  return apiDelete(`/api/leads/${leadId}/activities/${activityId}`);
+}
+
 export async function addLeadContact(
   leadId: string,
   personId: string,

--- a/frontend/src/components/leads/LeadDetailPanel.tsx
+++ b/frontend/src/components/leads/LeadDetailPanel.tsx
@@ -1104,7 +1104,7 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
                           <button
                             type="button"
                             onClick={() => setActivityToDelete(activity.id)}
-                            className="ml-auto text-text-secondary opacity-0 group-hover:opacity-100 hover:text-red-600 focus:opacity-100 focus:outline-none"
+                            className="ml-auto text-text-secondary sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 hover:text-red-600 focus:outline-none transition-opacity"
                             aria-label="Activiteit verwijderen"
                             title="Verwijderen"
                           >

--- a/frontend/src/components/leads/LeadDetailPanel.tsx
+++ b/frontend/src/components/leads/LeadDetailPanel.tsx
@@ -35,6 +35,7 @@ import {
   useUpdateLead,
   useDeleteLead,
   useCreateLeadActivity,
+  useDeleteLeadActivity,
   useAddLeadContact,
   useRemoveLeadContact,
   useUnlinkLeadNode,
@@ -44,6 +45,7 @@ import {
   useAddTagToLead,
   useRemoveTagFromLead,
 } from '@/hooks/useLeads';
+import { useAuth } from '@/contexts/AuthContext';
 import { usePeople, useCreatePerson } from '@/hooks/usePeople';
 import { useInitiatieven, useCreateInitiatief } from '@/hooks/useInitiatieven';
 import { getLeadAttachmentDownloadUrl } from '@/api/leads';
@@ -132,6 +134,8 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
   const updateLead = useUpdateLead();
   const deleteLead = useDeleteLead();
   const createActivity = useCreateLeadActivity();
+  const deleteActivity = useDeleteLeadActivity();
+  const { person } = useAuth();
   const addContact = useAddLeadContact();
   const removeContact = useRemoveLeadContact();
   const unlinkNode = useUnlinkLeadNode();
@@ -176,6 +180,7 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [lightboxSrc, setLightboxSrc] = useState<{ src: string; alt: string } | null>(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [activityToDelete, setActivityToDelete] = useState<string | null>(null);
 
   useEffect(() => {
     if (!lightboxSrc) return;
@@ -1076,8 +1081,13 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
             {/* Activity list */}
             {lead.activities.length > 0 ? (
               <div className="space-y-3">
-                {[...lead.activities].reverse().map((activity) => (
-                  <div key={activity.id} className="flex gap-2.5">
+                {[...lead.activities].reverse().map((activity) => {
+                  const canDelete =
+                    !!person &&
+                    (person.is_admin ||
+                      (person.id !== null && activity.author_id === person.id));
+                  return (
+                  <div key={activity.id} className="group flex gap-2.5">
                     <div className="mt-0.5 flex items-center justify-center h-6 w-6 rounded-full bg-gray-100 text-text-secondary shrink-0">
                       {ACTIVITY_ICONS[activity.activity_type]}
                     </div>
@@ -1090,6 +1100,17 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
                           {LEAD_ACTIVITY_TYPE_LABELS[activity.activity_type]}
                         </Badge>
                         <span>{timeAgo(activity.created_at)}</span>
+                        {canDelete && (
+                          <button
+                            type="button"
+                            onClick={() => setActivityToDelete(activity.id)}
+                            className="ml-auto text-text-secondary opacity-0 group-hover:opacity-100 hover:text-red-600 focus:opacity-100 focus:outline-none"
+                            aria-label="Activiteit verwijderen"
+                            title="Verwijderen"
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </button>
+                        )}
                       </div>
                       <div className="mt-0.5">
                         <RichTextDisplay content={activity.content} fallback="" />
@@ -1120,7 +1141,8 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
                       )}
                     </div>
                   </div>
-                ))}
+                  );
+                })}
               </div>
             ) : (
               <p className="text-sm text-text-secondary">Nog geen activiteiten</p>
@@ -1155,6 +1177,21 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
       variant="danger"
     >
       Weet je zeker dat je deze lead wilt verwijderen?
+    </ConfirmDialog>
+    <ConfirmDialog
+      open={activityToDelete !== null}
+      onClose={() => setActivityToDelete(null)}
+      onConfirm={() => {
+        if (lead && activityToDelete) {
+          deleteActivity.mutate({ leadId: lead.id, activityId: activityToDelete });
+        }
+        setActivityToDelete(null);
+      }}
+      title="Activiteit verwijderen"
+      confirmLabel="Verwijderen"
+      variant="danger"
+    >
+      Weet je zeker dat je deze activiteit wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.
     </ConfirmDialog>
     {showLinkNode && lead && (
       <LinkLeadNodeModal

--- a/frontend/src/hooks/useLeads.ts
+++ b/frontend/src/hooks/useLeads.ts
@@ -10,6 +10,7 @@ import {
   reorderLeads,
   getLeadActivities,
   createLeadActivity,
+  deleteLeadActivity,
   addLeadContact,
   removeLeadContact,
   linkLeadNode,
@@ -180,6 +181,15 @@ export function useCreateLeadActivity() {
     mutationFn: ({ leadId, data }: { leadId: string; data: LeadActivityCreate }) =>
       createLeadActivity(leadId, data),
     errorMessage: 'Fout bij toevoegen activiteit',
+    invalidateKeys: [queryKeys.leads.all],
+  });
+}
+
+export function useDeleteLeadActivity() {
+  return useMutationWithError({
+    mutationFn: ({ leadId, activityId }: { leadId: string; activityId: string }) =>
+      deleteLeadActivity(leadId, activityId),
+    errorMessage: 'Fout bij verwijderen activiteit',
     invalidateKeys: [queryKeys.leads.all],
   });
 }


### PR DESCRIPTION
## Samenvatting
- Voegt `DELETE /api/leads/{lead_id}/activities/{activity_id}` toe; check op lead-toegang, activity-hoort-bij-lead, en autorisatie (auteur of `init_ctx.is_admin`)
- Trash-icoon naast elke activiteit in het lead-detail-paneel, alleen zichtbaar voor de auteur of een admin; bevestigingsdialoog voor de delete
- Twee tests in `test_lead_activity.py`: succesvolle delete (204 + rij weg) en activity-die-niet-bij-lead-hoort (404)

## Test plan
- [ ] `just up`, lead openen, notitie toevoegen, hover laat trash-icoon zien, klikken vraagt bevestiging, na bevestiging is de notitie weg
- [ ] Tweede gebruiker (niet-admin, niet-auteur) ziet geen trash-icoon
- [ ] Backend tests: `uv run --project backend pytest backend/tests/test_lead_activity.py -v`