### PR TITLE
Voeg expertise-veld toe aan personen + tonen in leads-netwerk

### DIFF
--- a/backend/bouwmeester/api/routes/leads.py
+++ b/backend/bouwmeester/api/routes/leads.py
@@ -342,6 +342,8 @@ async def get_lead(
             id=rp.id,
             person_id=rp.person_id,
             person_naam=rp.person.naam if rp.person else "",
+            person_functie=rp.person.functie if rp.person else None,
+            person_expertise=rp.person.expertise if rp.person else None,
             rol=rp.rol,
             created_at=rp.created_at,
         )

--- a/backend/bouwmeester/api/routes/people.py
+++ b/backend/bouwmeester/api/routes/people.py
@@ -242,6 +242,21 @@ async def search_people(
     return result
 
 
+@router.get("/expertise-values", response_model=list[str])
+async def list_expertise_values(
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("people:read")),
+) -> list[str]:
+    """Return distinct expertise values used on existing persons.
+
+    Used as suggestion source for the expertise CreatableSelect on the
+    person edit/create form.
+    """
+    repo = PersonRepository(db)
+    return await repo.list_expertise_values()
+
+
 @router.get("/{id}/summary", response_model=PersonSummaryResponse)
 async def get_person_summary(
     id: UUID,

--- a/backend/bouwmeester/migrations/versions/d2e3f4a5b6c7_add_expertise_to_person.py
+++ b/backend/bouwmeester/migrations/versions/d2e3f4a5b6c7_add_expertise_to_person.py
@@ -1,0 +1,26 @@
+"""add expertise to person
+
+Revision ID: d2e3f4a5b6c7
+Revises: a1f3c8e7d402
+Create Date: 2026-05-06 14:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d2e3f4a5b6c7"
+down_revision: str | None = "a1f3c8e7d402"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("person", sa.Column("expertise", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("person", "expertise")

--- a/backend/bouwmeester/models/person.py
+++ b/backend/bouwmeester/models/person.py
@@ -28,6 +28,7 @@ class Person(Base):
     naam: Mapped[str] = mapped_column(nullable=False)
     email: Mapped[str | None] = mapped_column(nullable=True)
     functie: Mapped[str | None] = mapped_column(nullable=True)
+    expertise: Mapped[str | None] = mapped_column(nullable=True)
     description: Mapped[str | None] = mapped_column(nullable=True)
     oidc_subject: Mapped[str | None] = mapped_column(unique=True, nullable=True)
     is_active: Mapped[bool] = mapped_column(default=True, server_default="true")

--- a/backend/bouwmeester/repositories/graph.py
+++ b/backend/bouwmeester/repositories/graph.py
@@ -466,6 +466,7 @@ class GraphRepository:
                     node_type="person",
                     label=person.naam,
                     functie=person.functie,
+                    expertise=person.expertise,
                     person_role=role,
                 )
 

--- a/backend/bouwmeester/repositories/person.py
+++ b/backend/bouwmeester/repositories/person.py
@@ -58,3 +58,13 @@ class PersonRepository(BaseRepository[Person]):
         )
         result = await self.session.execute(stmt)
         return list(result.scalars().all())
+
+    async def list_expertise_values(self) -> list[str]:
+        stmt = (
+            select(Person.expertise)
+            .where(Person.expertise.is_not(None))
+            .distinct()
+            .order_by(Person.expertise)
+        )
+        result = await self.session.execute(stmt)
+        return [v for v in result.scalars().all() if v]

--- a/backend/bouwmeester/schema/community_graph.py
+++ b/backend/bouwmeester/schema/community_graph.py
@@ -13,6 +13,7 @@ class CommunityGraphNode(BaseModel):
     stage: str | None = None  # for leads
     initiatief_id: str | None = None  # for leads
     functie: str | None = None  # for persons
+    expertise: str | None = None  # for persons
     person_role: str | None = None  # "intern" | "extern" — for persons
     org_type: str | None = None  # for organisations
     corpus_node_type: str | None = None  # for corpus nodes

--- a/backend/bouwmeester/schema/lead.py
+++ b/backend/bouwmeester/schema/lead.py
@@ -146,6 +146,8 @@ class LeadContactResponse(BaseModel):
     id: UUID
     person_id: UUID
     person_naam: str = ""
+    person_functie: str | None = None
+    person_expertise: str | None = None
     rol: str
     created_at: datetime
 
@@ -157,6 +159,10 @@ class LeadContactResponse(BaseModel):
         if hasattr(data, "person") and data.person:
             if not hasattr(data, "person_naam") or not data.person_naam:
                 data.person_naam = data.person.naam
+            if not getattr(data, "person_functie", None):
+                data.person_functie = data.person.functie
+            if not getattr(data, "person_expertise", None):
+                data.person_expertise = data.person.expertise
         return data
 
 

--- a/backend/bouwmeester/schema/person.py
+++ b/backend/bouwmeester/schema/person.py
@@ -63,6 +63,7 @@ class PersonBase(BaseModel):
     naam: str = Field(min_length=1, max_length=200)
     email: str | None = Field(None, max_length=254)
     functie: str | None = Field(None, max_length=200)
+    expertise: str | None = Field(None, max_length=200)
     description: str | None = Field(None, max_length=5000)
     is_agent: bool = False
 
@@ -75,6 +76,7 @@ class PersonUpdate(BaseModel):
     naam: str | None = Field(None, min_length=1, max_length=200)
     email: str | None = Field(None, max_length=254)
     functie: str | None = Field(None, max_length=200)
+    expertise: str | None = Field(None, max_length=200)
     description: str | None = Field(None, max_length=5000)
     is_agent: bool | None = None
 
@@ -87,6 +89,7 @@ class PersonResponse(PersonBase):
     naam: str
     email: str | None = None
     functie: str | None = None
+    expertise: str | None = None
     description: str | None = None
 
     id: UUID

--- a/backend/tests/test_people.py
+++ b/backend/tests/test_people.py
@@ -236,3 +236,52 @@ async def test_delete_org_placement(client, sample_person, sample_organisatie):
     # Verify it's gone
     list_resp = await client.get(f"/api/people/{sample_person.id}/organisaties")
     assert len(list_resp.json()) == 0
+
+
+async def test_create_person_with_expertise(client):
+    """POST /api/people accepts an expertise value."""
+    resp = await client.post(
+        "/api/people",
+        json={
+            "naam": "Wetgever Test",
+            "email": "wetgever@example.com",
+            "expertise": "wetgevingsjurist",
+        },
+    )
+    assert resp.status_code == 201
+    assert resp.json()["expertise"] == "wetgevingsjurist"
+
+
+async def test_update_person_expertise(client, sample_person):
+    """PUT /api/people/{id} can update expertise."""
+    resp = await client.put(
+        f"/api/people/{sample_person.id}",
+        json={"expertise": "BIT-adviseur"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["expertise"] == "BIT-adviseur"
+
+
+async def test_list_expertise_values(client):
+    """GET /api/people/expertise-values returns distinct expertise values, sorted."""
+    # Create three persons: two share an expertise, one has another, one has none
+    for naam, expertise in [
+        ("Een", "wetgevingsjurist"),
+        ("Twee", "wetgevingsjurist"),
+        ("Drie", "BIT-adviseur"),
+        ("Vier", None),
+    ]:
+        payload = {"naam": naam, "email": f"{naam.lower()}@example.com"}
+        if expertise:
+            payload["expertise"] = expertise
+        resp = await client.post("/api/people", json=payload)
+        assert resp.status_code == 201
+
+    resp = await client.get("/api/people/expertise-values")
+    assert resp.status_code == 200
+    values = resp.json()
+    # Distinct, sorted, no nulls
+    assert "wetgevingsjurist" in values
+    assert "BIT-adviseur" in values
+    assert values == sorted(values)
+    assert all(v is not None for v in values)

--- a/frontend/src/api/people.ts
+++ b/frontend/src/api/people.ts
@@ -68,6 +68,10 @@ export async function searchPeople(q: string, limit = 10): Promise<Person[]> {
   return apiGet<Person[]>('/api/people/search', { q, limit: String(limit) });
 }
 
+export async function getExpertiseValues(): Promise<string[]> {
+  return apiGet<string[]>('/api/people/expertise-values');
+}
+
 // Emails
 export async function addPersonEmail(
   personId: string,

--- a/frontend/src/components/leads/AddLeadContactModal.tsx
+++ b/frontend/src/components/leads/AddLeadContactModal.tsx
@@ -24,11 +24,14 @@ export function AddLeadContactModal({ leadId, onClose }: Props) {
   const [personId, setPersonId] = useState('');
   const [rol, setRol] = useState('contactpersoon');
 
-  const personOptions: SelectOption[] = people.map((p) => ({
-    value: p.id,
-    label: p.naam,
-    description: p.functie ?? undefined,
-  }));
+  const personOptions: SelectOption[] = people.map((p) => {
+    const parts = [p.functie, p.expertise].filter((v): v is string => !!v);
+    return {
+      value: p.id,
+      label: p.naam,
+      description: parts.length > 0 ? parts.join(' · ') : undefined,
+    };
+  });
 
   const handleCreatePerson = useCallback(
     async (name: string): Promise<string | null> => {

--- a/frontend/src/components/leads/LeadDetailPanel.tsx
+++ b/frontend/src/components/leads/LeadDetailPanel.tsx
@@ -926,7 +926,7 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
                 {lead.contacts.map((contact) => (
                   <div key={contact.id} className="flex items-center gap-2 text-sm rounded-lg px-2 py-1.5 hover:bg-gray-50">
                     <User className="h-3.5 w-3.5 text-text-secondary shrink-0" />
-                    <span className="flex-1 text-text truncate">{contact.person_naam}</span>
+                    <span className="flex-1 text-text">{contact.person_naam}</span>
                     {contact.person_expertise && (
                       <Badge variant="indigo">{contact.person_expertise}</Badge>
                     )}

--- a/frontend/src/components/leads/LeadDetailPanel.tsx
+++ b/frontend/src/components/leads/LeadDetailPanel.tsx
@@ -926,7 +926,10 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
                 {lead.contacts.map((contact) => (
                   <div key={contact.id} className="flex items-center gap-2 text-sm rounded-lg px-2 py-1.5 hover:bg-gray-50">
                     <User className="h-3.5 w-3.5 text-text-secondary shrink-0" />
-                    <span className="flex-1 text-text">{contact.person_naam}</span>
+                    <span className="flex-1 text-text truncate">{contact.person_naam}</span>
+                    {contact.person_expertise && (
+                      <Badge variant="indigo">{contact.person_expertise}</Badge>
+                    )}
                     <Badge variant="gray">{LEAD_CONTACT_ROL_LABELS[contact.rol] ?? contact.rol}</Badge>
                     <button
                       onClick={() => removeContact.mutate({ leadId: lead.id, contactId: contact.id })}

--- a/frontend/src/components/leads/LeadGraphView.tsx
+++ b/frontend/src/components/leads/LeadGraphView.tsx
@@ -112,6 +112,7 @@ interface CommunityGraphNodeData {
   stage?: string | null;
   initiatiefId?: string | null;
   functie?: string | null;
+  expertise?: string | null;
   personRole?: 'intern' | 'extern' | null;
   orgType?: string | null;
   corpusNodeType?: string | null;
@@ -155,11 +156,18 @@ function CommunityGraphNodeComponent({ data }: NodeProps<CommunityGraphNodeData>
       const functieLabel = formatFunctie(data.functie);
       const label = functieLabel ? `${roleLabel} · ${functieLabel}` : roleLabel;
       return (
-        <div className="flex items-center gap-1 mb-1">
-          <PersonIcon className="h-3 w-3" style={{ color }} />
-          <span style={{ color, fontSize: '10px', fontWeight: 600, letterSpacing: '0.025em', textTransform: 'uppercase' }}>
-            {label}
-          </span>
+        <div className="mb-1">
+          <div className="flex items-center gap-1">
+            <PersonIcon className="h-3 w-3" style={{ color }} />
+            <span style={{ color, fontSize: '10px', fontWeight: 600, letterSpacing: '0.025em', textTransform: 'uppercase' }}>
+              {label}
+            </span>
+          </div>
+          {data.expertise && (
+            <div style={{ color, fontSize: '9px', fontWeight: 500, marginTop: '1px', opacity: 0.85 }}>
+              {data.expertise}
+            </div>
+          )}
         </div>
       );
     }
@@ -429,6 +437,7 @@ function CommunityGraphInner({
           stage: node.stage,
           initiatiefId: node.initiatief_id,
           functie: node.functie,
+          expertise: node.expertise,
           personRole: node.person_role ?? null,
           orgType: node.org_type,
           corpusNodeType: node.corpus_node_type,

--- a/frontend/src/components/people/PersonCard.tsx
+++ b/frontend/src/components/people/PersonCard.tsx
@@ -1,4 +1,4 @@
-import { Mail, Briefcase, Phone } from 'lucide-react';
+import { Mail, Briefcase, Phone, Tag } from 'lucide-react';
 import { Card } from '@/components/common/Card';
 import { PersonAvatar } from '@/components/people/PersonAvatar';
 import { formatFunctie } from '@/types';
@@ -60,6 +60,12 @@ export function PersonCard({ person, onClick, draggable, onDragStart }: PersonCa
               <div className="flex items-center gap-1.5 text-xs text-text-secondary">
                 <Briefcase className="h-3 w-3 shrink-0" />
                 <span className="truncate">{formatFunctie(person.functie)}</span>
+              </div>
+            )}
+            {person.expertise && (
+              <div className="flex items-center gap-1.5 text-xs text-text-secondary">
+                <Tag className="h-3 w-3 shrink-0" />
+                <span className="truncate">{person.expertise}</span>
               </div>
             )}
             {person.is_agent && person.description && (

--- a/frontend/src/components/people/PersonEditForm.tsx
+++ b/frontend/src/components/people/PersonEditForm.tsx
@@ -18,6 +18,7 @@ import {
   useAddPersonPhone,
   useRemovePersonPhone,
   useSetDefaultPhone,
+  useExpertiseValues,
 } from '@/hooks/usePeople';
 import { FUNCTIE_LABELS, DIENSTVERBAND_LABELS, PHONE_LABELS, formatFunctie } from '@/types';
 import type { Person, PersonFormSubmitParams } from '@/types';
@@ -65,11 +66,14 @@ export function PersonEditForm({
   const [naam, setNaam] = useState('');
   const [email, setEmail] = useState('');
   const [functie, setFunctie] = useState('');
+  const [expertise, setExpertise] = useState('');
   const [description, setDescription] = useState('');
   const [orgEenheidId, setOrgEenheidId] = useState('');
   const [dienstverband, setDienstverband] = useState('in_dienst');
   const [emailTouched, setEmailTouched] = useState(false);
   const [functieOptions, setFunctieOptions] = useState<SelectOption[]>(DEFAULT_FUNCTIE_OPTIONS);
+  const [expertiseLocalAdded, setExpertiseLocalAdded] = useState<string[]>([]);
+  const { data: expertiseValues = [] } = useExpertiseValues();
 
   // Rotated API key one-time display
   const [rotatedApiKey, setRotatedApiKey] = useState<string | null>(null);
@@ -143,6 +147,7 @@ export function PersonEditForm({
         setNaam(editData.naam);
         setEmail(editData.email || '');
         setFunctie(editData.functie || '');
+        setExpertise(editData.expertise || '');
         setDescription(editData.description || '');
         setOrgEenheidId('');
         // Ensure the existing functie value is in options
@@ -164,6 +169,7 @@ export function PersonEditForm({
         }
         setEmail('');
         setFunctie('');
+        setExpertise('');
         setDescription('');
         setOrgEenheidId(defaultOrgEenheidId || '');
         setDienstverband('in_dienst');
@@ -197,6 +203,7 @@ export function PersonEditForm({
           naam: naam.trim(),
           // In edit mode, don't send email — managed via multi-email section
           functie: isAgent ? undefined : (functie || undefined),
+          expertise: isAgent ? undefined : (expertise.trim() || undefined),
           description: isAgent ? (description.trim() || undefined) : undefined,
           is_agent: isAgent,
         },
@@ -215,6 +222,7 @@ export function PersonEditForm({
           naam: naam.trim(),
           email: email.trim() || undefined,
           functie: isAgent ? undefined : (functie || undefined),
+          expertise: isAgent ? undefined : (expertise.trim() || undefined),
           description: isAgent ? (description.trim() || undefined) : undefined,
           is_agent: isAgent,
         },
@@ -240,6 +248,7 @@ export function PersonEditForm({
       setNaam(person.naam);
       setEmail(person.default_email || person.email || '');
       setFunctie(person.functie || '');
+      setExpertise(person.expertise || '');
       // Ensure the functie value is in options
       if (person.functie) {
         setFunctieOptions((prev) =>
@@ -257,6 +266,7 @@ export function PersonEditForm({
     setNaam(text);
     setEmail('');
     setFunctie('');
+    setExpertise('');
     return null; // don't set a value — we switch to create mode
   };
 
@@ -266,6 +276,7 @@ export function PersonEditForm({
     setNaam('');
     setEmail('');
     setFunctie('');
+    setExpertise('');
     setNaamQuery('');
   };
 
@@ -662,6 +673,29 @@ export function PersonEditForm({
             placeholder="Selecteer of maak functie..."
             onCreate={handleCreateFunctie}
             createLabel="Nieuwe functie aanmaken"
+            disabled={!!selectedPerson}
+          />
+        )}
+        {!isAgent && (
+          <CreatableSelect
+            label="Expertise"
+            value={expertise}
+            onChange={setExpertise}
+            options={[
+              ...expertiseValues.map((v) => ({ value: v, label: v })),
+              ...expertiseLocalAdded
+                .filter((v) => !expertiseValues.includes(v))
+                .map((v) => ({ value: v, label: v })),
+            ]}
+            placeholder="Bijv. wetgevingsjurist, BIT-adviseur..."
+            onCreate={async (text) => {
+              const value = text.trim();
+              if (!value) return null;
+              setExpertiseLocalAdded((prev) => (prev.includes(value) ? prev : [...prev, value]));
+              setExpertise(value);
+              return value;
+            }}
+            createLabel="Nieuwe expertise toevoegen"
             disabled={!!selectedPerson}
           />
         )}

--- a/frontend/src/hooks/queryKeys.ts
+++ b/frontend/src/hooks/queryKeys.ts
@@ -46,6 +46,7 @@ export const queryKeys = {
     summary: (id: string | null) => ['people', id, 'summary'] as const,
     organisaties: (personId: string | null, actief: boolean) => ['people', personId, 'organisaties', { actief }] as const,
     search: (query: string) => ['people', 'search', query] as const,
+    expertiseValues: ['people', 'expertise-values'] as const,
   },
 
   // --- Organisatie ---

--- a/frontend/src/hooks/usePeople.ts
+++ b/frontend/src/hooks/usePeople.ts
@@ -46,7 +46,11 @@ export function useCreatePerson() {
     mutationFn: ({ force, ...data }: PersonCreate & { force?: boolean }) =>
       createPerson(data, force),
     errorMessage: 'Fout bij aanmaken persoon',
-    invalidateKeys: [queryKeys.people.all, queryKeys.organisatie.all],
+    invalidateKeys: [
+      queryKeys.people.all,
+      queryKeys.organisatie.all,
+      queryKeys.people.expertiseValues,
+    ],
   });
 }
 
@@ -63,7 +67,11 @@ export function useUpdatePerson() {
     mutationFn: ({ id, data }: { id: string; data: Partial<PersonCreate> }) =>
       updatePerson(id, data),
     errorMessage: 'Fout bij bijwerken persoon',
-    invalidateKeys: [queryKeys.people.all, queryKeys.organisatie.all],
+    invalidateKeys: [
+      queryKeys.people.all,
+      queryKeys.organisatie.all,
+      queryKeys.people.expertiseValues,
+    ],
   });
 }
 

--- a/frontend/src/hooks/usePeople.ts
+++ b/frontend/src/hooks/usePeople.ts
@@ -10,6 +10,7 @@ import {
   updatePersonOrganisatie,
   removePersonOrganisatie,
   searchPeople,
+  getExpertiseValues,
   rotateApiKey,
   addPersonEmail,
   removePersonEmail,
@@ -126,6 +127,14 @@ export function useSearchPeople(query: string) {
     queryKey: queryKeys.people.search(debouncedQuery),
     queryFn: () => searchPeople(debouncedQuery),
     enabled: debouncedQuery.length >= 2,
+  });
+}
+
+export function useExpertiseValues() {
+  return useQuery({
+    queryKey: queryKeys.people.expertiseValues,
+    queryFn: getExpertiseValues,
+    staleTime: 5 * 60_000,
   });
 }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -515,6 +515,7 @@ export interface Person {
   naam: string;
   email?: string;
   functie?: string;
+  expertise?: string | null;
   description?: string;
   is_agent: boolean;
   is_admin: boolean;
@@ -537,6 +538,7 @@ export interface PersonCreate {
   naam: string;
   email?: string;
   functie?: string;
+  expertise?: string;
   description?: string;
   is_agent?: boolean;
 }
@@ -1689,6 +1691,8 @@ export interface LeadContact {
   id: string;
   person_id: string;
   person_naam: string;
+  person_functie?: string | null;
+  person_expertise?: string | null;
   rol: string;
   created_at: string;
 }
@@ -2062,6 +2066,7 @@ export interface CommunityGraphNode {
   stage?: string | null;
   initiatief_id?: string | null;
   functie?: string | null;
+  expertise?: string | null;
   person_role?: 'intern' | 'extern' | null;
   org_type?: string | null;
   corpus_node_type?: string | null;


### PR DESCRIPTION
## Summary

- Personen krijgen een vrij `expertise`-veld (wetgevingsjurist, BIT-adviseur, ...) naast het bestaande `functie`-veld. CreatableSelect met suggesties uit eerder ingevulde waarden via `GET /api/people/expertise-values`, geen aparte tabel of enum.
- Tonen op PersonCard, in de lead-contactenlijst (badge), op de person-node in de community-graph (sublabel onder functie), en in de selector-description bij het toevoegen van een contact.
- `LeadContactResponse` en `CommunityGraphNode` geven het veld mee zodat de UI niets extra hoeft op te halen.

Eerste van drie sporen uit het plan rond contactpersoon-typering en ad-hoc samenwerkingsverbanden — de samenwerkingsverband-modellering en de uitgebreide inline-aanmaak komen in vervolg-PR's.

## Test plan

- [ ] `just reset-db && just up`
- [ ] Maak via `/persons` een persoon aan met expertise "wetgevingsjurist"; verifieer dat een tweede persoon "wetgevingsjurist" krijgt aangeboden in de CreatableSelect-suggesties
- [ ] Bewerk een bestaande persoon en zet expertise op "BIT-adviseur"; verifieer dat de waarde persisteert
- [ ] Open een lead-detail; voeg de persoon toe als contact en bevestig dat de expertise als badge verschijnt naast de rol
- [ ] Open de community-graph in de lead-overzichtsmodus en bevestig dat de expertise als sublabel onder de functie staat op de person-node
- [ ] `uv run --project backend pytest backend/tests/test_people.py -v` — drie nieuwe tests groen