### PR TITLE
Refetch queries on window focus

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -43,7 +43,7 @@ const queryClient = new QueryClient({
     queries: {
       staleTime: 30_000,
       retry: 1,
-      refetchOnWindowFocus: false,
+      refetchOnWindowFocus: true,
     },
   },
 });


### PR DESCRIPTION
## Probleem

Als gebruiker A iets aanmaakt of wijzigt, ziet gebruiker B de update pas na een handmatige refresh of nadat hij naar een andere pagina navigeert. React Query had `refetchOnWindowFocus: false`, dus B's cache bleef staan zolang z'n tab open was.

## Wijziging

`refetchOnWindowFocus` aangezet op de globale `QueryClient`. Met de bestaande `staleTime: 30_000` betekent dat: als B z'n tab terugkrijgt en de query is ouder dan 30s, refetcht React Query op de achtergrond.

Geen polling, geen WebSocket, geen extra load als er niemand kijkt.

## Trade-off

Niet realtime — als beide tabs op de voorgrond staan blijft B 30s+ achterlopen tot een mutatie of expliciete invalidate. Voor de samenwerk-pagina's waar dit echt knelt (taken, leads-inbox, dossier-detail) kunnen we later gericht `refetchInterval` toevoegen.

## Test plan

- [ ] Open dezelfde pagina in twee browsers (twee accounts of zelfde account, andere tab)
- [ ] Maak in tab A een nieuw item aan (taak, lead, persoon, ...)
- [ ] Klik in tab B → item verschijnt na de focus-refetch
- [ ] Controleer dat de notificatie-poller en Mattermost-poller niet verdubbelen