### PR TITLE
Bouwmeester leest mee in Mattermost

### DIFF
--- a/backend/bouwmeester/api/routes/__init__.py
+++ b/backend/bouwmeester/api/routes/__init__.py
@@ -24,6 +24,9 @@ from bouwmeester.api.routes.initiatief_update import (
 from bouwmeester.api.routes.leads import router as leads_router
 from bouwmeester.api.routes.llm import router as llm_router
 from bouwmeester.api.routes.mattermost import router as mattermost_router
+from bouwmeester.api.routes.mattermost_channels import (
+    router as mattermost_channels_router,
+)
 from bouwmeester.api.routes.mentions import router as mentions_router
 from bouwmeester.api.routes.nodes import router as nodes_router
 from bouwmeester.api.routes.notifications import router as notifications_router
@@ -72,6 +75,7 @@ api_router.include_router(import_export_router)
 api_router.include_router(leads_router)
 api_router.include_router(llm_router)
 api_router.include_router(mattermost_router)
+api_router.include_router(mattermost_channels_router)
 api_router.include_router(mentions_router)
 api_router.include_router(nodes_router)
 api_router.include_router(notifications_router)

--- a/backend/bouwmeester/api/routes/leads.py
+++ b/backend/bouwmeester/api/routes/leads.py
@@ -354,12 +354,15 @@ async def get_lead(
     response = LeadDetailResponse.model_validate(lead)
     response.contacts = contacts
 
-    # Mark attachments whose files no longer exist on disk.
+    # Mark file-attachments whose files no longer exist on disk.
+    # URL-attachments (soort='link') hebben geen pad — die blijven beschikbaar.
     pad_by_id = {a.id: a.pad for a in lead.attachments}
     for att in response.attachments:
-        att.bestand_beschikbaar = file_exists_on_disk(
-            LEADS_BIJLAGEN_ROOT, pad_by_id[att.id]
-        )
+        pad = pad_by_id.get(att.id)
+        if att.soort == "file" and pad:
+            att.bestand_beschikbaar = file_exists_on_disk(LEADS_BIJLAGEN_ROOT, pad)
+        else:
+            att.bestand_beschikbaar = True
 
     return response
 

--- a/backend/bouwmeester/api/routes/mattermost.py
+++ b/backend/bouwmeester/api/routes/mattermost.py
@@ -272,7 +272,17 @@ async def handle_action(
     request: Request,
     db: AsyncSession = Depends(get_db),
 ) -> dict:
-    """Handle interactive button actions from Mattermost."""
+    """Handle interactive button actions from Mattermost.
+
+    **Trust model**: het integration-token (gedeelde geheim) is hier de
+    enige authenticatie. Wie het token kent, kan ``user_id`` van iedere
+    MM-user naïef invullen en als die persoon acties uitvoeren. Het token
+    moet daarom als admin-equivalent worden behandeld en alleen aan de
+    Mattermost-server toevertrouwd. Voor extra audit loggen we hier de
+    door MM doorgestuurde ``post_id`` + ``trigger_id`` zodat een
+    onbekende/onverwachte action achteraf gecorreleerd kan worden met de
+    server-side post-trail van Mattermost.
+    """
     body = await request.json()
 
     # Mattermost sends the integration token at the top level for interactive
@@ -285,14 +295,31 @@ async def handle_action(
     user_id = body.get("user_id", "unknown")
     _check_rate_limit("action", user_id)
 
+    context = body.get("context", {}) or {}
+    action_name = context.get("action", "")
+    suggested_lead_id = context.get("suggested_lead_id")
+    if suggested_lead_id:
+        # Per-suggestion rate-limit voorkomt brute-force toggling.
+        _check_rate_limit("action", f"sl:{suggested_lead_id}")
+
+    logger.info(
+        "Mattermost action: action=%s mm_user_id=%s post_id=%s trigger_id=%s "
+        "channel_id=%s suggested_lead_id=%s",
+        action_name,
+        user_id,
+        body.get("post_id"),
+        body.get("trigger_id"),
+        body.get("channel_id"),
+        suggested_lead_id,
+    )
+
     from bouwmeester.services.mattermost_slash_service import MattermostSlashService
 
     service = MattermostSlashService(db)
-    context = body.get("context", {})
 
     result = await service.handle_action(
         mattermost_user_id=user_id,
-        action=context.get("action", ""),
+        action=action_name,
         context=context,
     )
     await db.commit()

--- a/backend/bouwmeester/api/routes/mattermost.py
+++ b/backend/bouwmeester/api/routes/mattermost.py
@@ -247,6 +247,9 @@ async def handle_slash_command(
     user_id: str = Form(""),
     text: str = Form(""),
     command: str = Form(""),
+    channel_id: str = Form(""),
+    channel_name: str = Form(""),
+    team_id: str = Form(""),
 ) -> dict:
     """Handle /bouwmeester slash commands from Mattermost."""
     await _verify_webhook_token(token, db)
@@ -258,6 +261,9 @@ async def handle_slash_command(
     return await service.handle_command(
         mattermost_user_id=user_id,
         command_text=text.strip(),
+        channel_id=channel_id or None,
+        channel_name=channel_name or None,
+        team_id=team_id or None,
     )
 
 

--- a/backend/bouwmeester/api/routes/mattermost.py
+++ b/backend/bouwmeester/api/routes/mattermost.py
@@ -49,6 +49,11 @@ _RATE_LIMITS: dict[str, tuple[int, int]] = {
     "verify-link": (10, 60),
     "slash": (30, 60),
     "action": (30, 60),
+    # Aparte bucket per suggested-lead-id — voorkomt dat één gebruiker per
+    # ongeluk zijn ``action``-quota opmaakt door snelle clicks op één
+    # suggestie, en omgekeerd dat brute-force op één suggestie geen
+    # andere acties van dezelfde user blokkeert.
+    "action-suggested-lead": (10, 60),
 }
 
 # Cap total tracked keys per bucket to prevent unbounded memory growth.
@@ -299,8 +304,9 @@ async def handle_action(
     action_name = context.get("action", "")
     suggested_lead_id = context.get("suggested_lead_id")
     if suggested_lead_id:
-        # Per-suggestion rate-limit voorkomt brute-force toggling.
-        _check_rate_limit("action", f"sl:{suggested_lead_id}")
+        # Per-suggestion rate-limit voorkomt brute-force toggling. Aparte
+        # bucket zodat dit niet de per-user ``action``-quota opeet.
+        _check_rate_limit("action-suggested-lead", str(suggested_lead_id))
 
     logger.info(
         "Mattermost action: action=%s mm_user_id=%s post_id=%s trigger_id=%s "

--- a/backend/bouwmeester/api/routes/mattermost_channels.py
+++ b/backend/bouwmeester/api/routes/mattermost_channels.py
@@ -1,0 +1,313 @@
+"""Mattermost-kanaalkoppelingen aan initiatieven en leads.
+
+Routes:
+  GET  /api/initiatieven/{id}/mattermost-channels
+  POST /api/initiatieven/{id}/mattermost-channels
+  GET  /api/leads/{id}/mattermost-channels
+  POST /api/leads/{id}/mattermost-channels
+  GET  /api/mattermost-channels/search?q=...
+  PATCH /api/mattermost-channels/{link_id}
+  DELETE /api/mattermost-channels/{link_id}
+"""
+
+import logging
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bouwmeester.core.auth import OptionalUser
+from bouwmeester.core.database import get_db
+from bouwmeester.core.initiatief_context import (
+    InitiatiefContext,
+    get_initiatief_context,
+)
+from bouwmeester.models.initiatief import Initiatief
+from bouwmeester.models.lead import Lead
+from bouwmeester.models.mattermost_channel_link import (
+    SCOPE_INITIATIEF,
+    SCOPE_LEAD,
+    MattermostChannelLink,
+)
+from bouwmeester.repositories.mattermost_channel_link import (
+    MattermostChannelLinkRepository,
+)
+from bouwmeester.schema.mattermost_channel_link import (
+    MattermostChannelLinkCreate,
+    MattermostChannelLinkResponse,
+    MattermostChannelLinkUpdate,
+    MattermostChannelSearchResult,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["mattermost-channels"])
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _not_found() -> HTTPException:
+    return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Niet gevonden")
+
+
+async def _resolve_initiatief(
+    db: AsyncSession, initiatief_id: UUID, init_ctx: InitiatiefContext
+) -> Initiatief:
+    """Haal initiatief op en check toegang. 404 bij geen toegang."""
+    if not init_ctx.is_admin and not init_ctx.is_authenticated:
+        raise _not_found()
+    if not init_ctx.is_admin and initiatief_id not in init_ctx.visible_initiatief_ids:
+        raise _not_found()
+    result = await db.execute(select(Initiatief).where(Initiatief.id == initiatief_id))
+    initiatief = result.scalar_one_or_none()
+    if initiatief is None:
+        raise _not_found()
+    return initiatief
+
+
+async def _resolve_lead(
+    db: AsyncSession, lead_id: UUID, init_ctx: InitiatiefContext
+) -> Lead:
+    """Haal lead op en check toegang via initiatief_id."""
+    result = await db.execute(select(Lead).where(Lead.id == lead_id))
+    lead = result.scalar_one_or_none()
+    if lead is None:
+        raise _not_found()
+    if init_ctx.is_admin:
+        return lead
+    if not init_ctx.is_authenticated:
+        raise _not_found()
+    if (
+        lead.initiatief_id is not None
+        and lead.initiatief_id not in init_ctx.visible_initiatief_ids
+    ):
+        raise _not_found()
+    return lead
+
+
+def _can_manage_link(link: MattermostChannelLink, init_ctx: InitiatiefContext) -> bool:
+    """Mag de huidige user deze koppeling beheren?"""
+    if init_ctx.is_admin:
+        return True
+    if not init_ctx.is_authenticated:
+        return False
+    if link.scope_type == SCOPE_INITIATIEF:
+        return link.scope_id in init_ctx.visible_initiatief_ids
+    if link.scope_type == SCOPE_LEAD:
+        # Lead-koppelingen worden via de lead's initiatief geverifieerd —
+        # zonder initiatief is een lead voor iedereen toegankelijk in de
+        # migratieperiode (zie _check_lead_access in leads.py).
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Initiatief-scope endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/initiatieven/{initiatief_id}/mattermost-channels",
+    response_model=list[MattermostChannelLinkResponse],
+)
+async def list_initiatief_channels(
+    initiatief_id: UUID,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    init_ctx: InitiatiefContext = Depends(get_initiatief_context),
+) -> list[MattermostChannelLinkResponse]:
+    await _resolve_initiatief(db, initiatief_id, init_ctx)
+    repo = MattermostChannelLinkRepository(db)
+    links = await repo.list_for_scope(SCOPE_INITIATIEF, initiatief_id)
+    return [MattermostChannelLinkResponse.model_validate(link) for link in links]
+
+
+@router.post(
+    "/initiatieven/{initiatief_id}/mattermost-channels",
+    response_model=MattermostChannelLinkResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_initiatief_channel(
+    initiatief_id: UUID,
+    data: MattermostChannelLinkCreate,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    init_ctx: InitiatiefContext = Depends(get_initiatief_context),
+) -> MattermostChannelLinkResponse:
+    await _resolve_initiatief(db, initiatief_id, init_ctx)
+    repo = MattermostChannelLinkRepository(db)
+    existing = await repo.get_by_channel_id(data.channel_id)
+    if existing is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Dit kanaal is al gekoppeld",
+        )
+    try:
+        link = await repo.create(
+            channel_id=data.channel_id,
+            channel_name=data.channel_name,
+            channel_display_name=data.channel_display_name,
+            team_id=data.team_id,
+            scope_type=SCOPE_INITIATIEF,
+            scope_id=initiatief_id,
+            auto_note_enabled=data.auto_note_enabled
+            if data.auto_note_enabled is not None
+            else False,
+            suggest_leads_enabled=data.suggest_leads_enabled
+            if data.suggest_leads_enabled is not None
+            else True,
+            created_by_id=current_user.id if current_user else None,
+        )
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Dit kanaal is al gekoppeld",
+        )
+    return MattermostChannelLinkResponse.model_validate(link)
+
+
+# ---------------------------------------------------------------------------
+# Lead-scope endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/leads/{lead_id}/mattermost-channels",
+    response_model=list[MattermostChannelLinkResponse],
+)
+async def list_lead_channels(
+    lead_id: UUID,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    init_ctx: InitiatiefContext = Depends(get_initiatief_context),
+) -> list[MattermostChannelLinkResponse]:
+    await _resolve_lead(db, lead_id, init_ctx)
+    repo = MattermostChannelLinkRepository(db)
+    links = await repo.list_for_scope(SCOPE_LEAD, lead_id)
+    return [MattermostChannelLinkResponse.model_validate(link) for link in links]
+
+
+@router.post(
+    "/leads/{lead_id}/mattermost-channels",
+    response_model=MattermostChannelLinkResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_lead_channel(
+    lead_id: UUID,
+    data: MattermostChannelLinkCreate,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    init_ctx: InitiatiefContext = Depends(get_initiatief_context),
+) -> MattermostChannelLinkResponse:
+    await _resolve_lead(db, lead_id, init_ctx)
+    repo = MattermostChannelLinkRepository(db)
+    existing = await repo.get_by_channel_id(data.channel_id)
+    if existing is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Dit kanaal is al gekoppeld",
+        )
+    try:
+        link = await repo.create(
+            channel_id=data.channel_id,
+            channel_name=data.channel_name,
+            channel_display_name=data.channel_display_name,
+            team_id=data.team_id,
+            scope_type=SCOPE_LEAD,
+            scope_id=lead_id,
+            auto_note_enabled=data.auto_note_enabled
+            if data.auto_note_enabled is not None
+            else True,
+            suggest_leads_enabled=data.suggest_leads_enabled
+            if data.suggest_leads_enabled is not None
+            else False,
+            created_by_id=current_user.id if current_user else None,
+        )
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Dit kanaal is al gekoppeld",
+        )
+    return MattermostChannelLinkResponse.model_validate(link)
+
+
+# ---------------------------------------------------------------------------
+# Cross-cutting endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/mattermost-channels/search",
+    response_model=list[MattermostChannelSearchResult],
+)
+async def search_channels(
+    current_user: OptionalUser,
+    q: str = Query(..., min_length=2, max_length=64),
+    db: AsyncSession = Depends(get_db),
+    init_ctx: InitiatiefContext = Depends(get_initiatief_context),
+) -> list[MattermostChannelSearchResult]:
+    """Zoek MM-kanalen via de bot. Vereist authenticated user."""
+    if not init_ctx.is_authenticated and not init_ctx.is_admin:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+
+    from bouwmeester.services.mattermost_service import MattermostService
+
+    service = MattermostService(db)
+    if not await service.is_enabled():
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Mattermost is niet geconfigureerd",
+        )
+    results = await service.search_channels(q)
+    return [MattermostChannelSearchResult.model_validate(r) for r in results]
+
+
+@router.patch(
+    "/mattermost-channels/{link_id}",
+    response_model=MattermostChannelLinkResponse,
+)
+async def update_channel_link(
+    link_id: UUID,
+    data: MattermostChannelLinkUpdate,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    init_ctx: InitiatiefContext = Depends(get_initiatief_context),
+) -> MattermostChannelLinkResponse:
+    repo = MattermostChannelLinkRepository(db)
+    link = await repo.get(link_id)
+    if link is None:
+        raise _not_found()
+    if not _can_manage_link(link, init_ctx):
+        raise _not_found()
+    updated = await repo.update_settings(
+        link,
+        auto_note_enabled=data.auto_note_enabled,
+        suggest_leads_enabled=data.suggest_leads_enabled,
+    )
+    return MattermostChannelLinkResponse.model_validate(updated)
+
+
+@router.delete(
+    "/mattermost-channels/{link_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_channel_link(
+    link_id: UUID,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    init_ctx: InitiatiefContext = Depends(get_initiatief_context),
+) -> None:
+    repo = MattermostChannelLinkRepository(db)
+    link = await repo.get(link_id)
+    if link is None:
+        raise _not_found()
+    if not _can_manage_link(link, init_ctx):
+        raise _not_found()
+    await repo.delete(link)

--- a/backend/bouwmeester/api/routes/mattermost_channels.py
+++ b/backend/bouwmeester/api/routes/mattermost_channels.py
@@ -117,6 +117,10 @@ async def _can_manage_link(
         ).scalar_one_or_none()
         if lead is None:
             return False
+        # TODO(post-migratie): drop deze tak zodra alle leads een
+        # ``initiatief_id`` hebben. Tijdens de migratieperiode is een lead
+        # zonder initiatief voor elke authenticated user toegankelijk; dat
+        # spiegelt ``_check_lead_access`` in ``leads.py``.
         if lead.initiatief_id is None:
             return True
         return lead.initiatief_id in init_ctx.visible_initiatief_ids
@@ -303,6 +307,31 @@ async def update_channel_link(
         raise _not_found()
     if not await _can_manage_link(db, link, init_ctx):
         raise _not_found()
+
+    # Reenable mag alleen als de bot daadwerkelijk weer in het kanaal zit
+    # — anders zet je `disabled_at=None` op een dode koppeling en raakt de
+    # UI uit sync met Mattermost.
+    if data.reenable:
+        from bouwmeester.services.mattermost_service import MattermostService
+
+        service = MattermostService(db)
+        try:
+            if not await service.is_enabled():
+                raise HTTPException(
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    detail="Mattermost is niet geconfigureerd",
+                )
+            if not await service.is_bot_member_of_channel(link.channel_id):
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail=(
+                        "Bot is geen lid van dit kanaal. "
+                        "Voeg de bot eerst toe in Mattermost en probeer opnieuw."
+                    ),
+                )
+        finally:
+            await service.close()
+
     updated = await repo.update_settings(
         link,
         auto_note_enabled=data.auto_note_enabled,

--- a/backend/bouwmeester/api/routes/mattermost_channels.py
+++ b/backend/bouwmeester/api/routes/mattermost_channels.py
@@ -312,7 +312,10 @@ async def update_channel_link(
     # — anders zet je `disabled_at=None` op een dode koppeling en raakt de
     # UI uit sync met Mattermost.
     if data.reenable:
-        from bouwmeester.services.mattermost_service import MattermostService
+        from bouwmeester.services.mattermost_service import (
+            MattermostService,
+            MattermostUnavailableError,
+        )
 
         service = MattermostService(db)
         try:
@@ -321,7 +324,20 @@ async def update_channel_link(
                     status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                     detail="Mattermost is niet geconfigureerd",
                 )
-            if not await service.is_bot_member_of_channel(link.channel_id):
+            try:
+                is_member = await service.is_bot_member_of_channel(link.channel_id)
+            except MattermostUnavailableError:
+                # Tijdelijke MM-storing — niet interpreteren als "geen lid".
+                # 503 zodat de UI de gebruiker kan vragen het later te
+                # proberen, in plaats van ten onrechte 409 te tonen.
+                raise HTTPException(
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    detail=(
+                        "Mattermost is tijdelijk niet bereikbaar. "
+                        "Probeer het zo opnieuw."
+                    ),
+                )
+            if not is_member:
                 raise HTTPException(
                     status_code=status.HTTP_409_CONFLICT,
                     detail=(

--- a/backend/bouwmeester/api/routes/mattermost_channels.py
+++ b/backend/bouwmeester/api/routes/mattermost_channels.py
@@ -90,8 +90,21 @@ async def _resolve_lead(
     return lead
 
 
-def _can_manage_link(link: MattermostChannelLink, init_ctx: InitiatiefContext) -> bool:
-    """Mag de huidige user deze koppeling beheren?"""
+async def _can_manage_link(
+    db: AsyncSession,
+    link: MattermostChannelLink,
+    init_ctx: InitiatiefContext,
+) -> bool:
+    """Mag de huidige user deze koppeling beheren?
+
+    Voor initiatief-scope: kanaal-koppeling beheren = het initiatief mogen
+    zien (zelfde drempel als de UI-detailpagina).
+
+    Voor lead-scope: laad de Lead en delegeer naar dezelfde regel als
+    ``_resolve_lead`` — een lead met initiatief is alleen beheerbaar door
+    iemand die dat initiatief mag zien; zonder initiatief is hij voor alle
+    authenticated users toegankelijk (migratiepad).
+    """
     if init_ctx.is_admin:
         return True
     if not init_ctx.is_authenticated:
@@ -99,10 +112,14 @@ def _can_manage_link(link: MattermostChannelLink, init_ctx: InitiatiefContext) -
     if link.scope_type == SCOPE_INITIATIEF:
         return link.scope_id in init_ctx.visible_initiatief_ids
     if link.scope_type == SCOPE_LEAD:
-        # Lead-koppelingen worden via de lead's initiatief geverifieerd —
-        # zonder initiatief is een lead voor iedereen toegankelijk in de
-        # migratieperiode (zie _check_lead_access in leads.py).
-        return True
+        lead = (
+            await db.execute(select(Lead).where(Lead.id == link.scope_id))
+        ).scalar_one_or_none()
+        if lead is None:
+            return False
+        if lead.initiatief_id is None:
+            return True
+        return lead.initiatief_id in init_ctx.visible_initiatief_ids
     return False
 
 
@@ -284,12 +301,13 @@ async def update_channel_link(
     link = await repo.get(link_id)
     if link is None:
         raise _not_found()
-    if not _can_manage_link(link, init_ctx):
+    if not await _can_manage_link(db, link, init_ctx):
         raise _not_found()
     updated = await repo.update_settings(
         link,
         auto_note_enabled=data.auto_note_enabled,
         suggest_leads_enabled=data.suggest_leads_enabled,
+        reenable=data.reenable,
     )
     return MattermostChannelLinkResponse.model_validate(updated)
 
@@ -308,6 +326,6 @@ async def delete_channel_link(
     link = await repo.get(link_id)
     if link is None:
         raise _not_found()
-    if not _can_manage_link(link, init_ctx):
+    if not await _can_manage_link(db, link, init_ctx):
         raise _not_found()
     await repo.delete(link)

--- a/backend/bouwmeester/migrations/versions/2c4d6e8f9a01_add_mattermost_channel_links_and_suggested_leads.py
+++ b/backend/bouwmeester/migrations/versions/2c4d6e8f9a01_add_mattermost_channel_links_and_suggested_leads.py
@@ -13,7 +13,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "2c4d6e8f9a01"
-down_revision: str | None = "d2e3f4a5b6c7"
+down_revision: str | None = "e4f5a6b7c8d9"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/bouwmeester/migrations/versions/2c4d6e8f9a01_add_mattermost_channel_links_and_suggested_leads.py
+++ b/backend/bouwmeester/migrations/versions/2c4d6e8f9a01_add_mattermost_channel_links_and_suggested_leads.py
@@ -1,0 +1,298 @@
+"""add mattermost channel links, post links, suggested leads + lead_attachment url type
+
+Revision ID: 2c4d6e8f9a01
+Revises: a1f3c8e7d402
+Create Date: 2026-05-06 12:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "2c4d6e8f9a01"
+down_revision: str | None = "a1f3c8e7d402"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # ----- mattermost_channel_link -----
+    op.create_table(
+        "mattermost_channel_link",
+        sa.Column(
+            "id",
+            sa.UUID(),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("channel_id", sa.String(length=26), nullable=False),
+        sa.Column("channel_name", sa.String(length=255), nullable=False),
+        sa.Column("channel_display_name", sa.String(length=255), nullable=False),
+        sa.Column("team_id", sa.String(length=26), nullable=True),
+        sa.Column(
+            "scope_type",
+            sa.String(length=32),
+            nullable=False,
+            comment="initiatief|lead",
+        ),
+        sa.Column("scope_id", sa.UUID(), nullable=False),
+        sa.Column(
+            "auto_note_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column(
+            "suggest_leads_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column(
+            "last_seen_post_at",
+            sa.BigInteger(),
+            nullable=True,
+            comment=(
+                "Mattermost ms-timestamp van laatst verwerkte post "
+                "(recovery na reconnect)"
+            ),
+        ),
+        sa.Column(
+            "disabled_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+            comment="Bot is uit kanaal getrapt of kanaal is verwijderd",
+        ),
+        sa.Column("created_by_id", sa.UUID(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["created_by_id"], ["person.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("channel_id"),
+    )
+    op.create_index(
+        "ix_mattermost_channel_link_channel_id",
+        "mattermost_channel_link",
+        ["channel_id"],
+    )
+    op.create_index(
+        "ix_mattermost_channel_link_scope_id",
+        "mattermost_channel_link",
+        ["scope_id"],
+    )
+
+    # ----- suggested_lead -----
+    op.create_table(
+        "suggested_lead",
+        sa.Column(
+            "id",
+            sa.UUID(),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "source_type",
+            sa.String(length=32),
+            server_default="mattermost",
+            nullable=False,
+        ),
+        sa.Column("source_post_id", sa.String(length=26), nullable=False),
+        sa.Column("source_channel_id", sa.String(length=26), nullable=False),
+        sa.Column("source_root_id", sa.String(length=26), nullable=True),
+        sa.Column("initiatief_id", sa.UUID(), nullable=False),
+        sa.Column("proposed_title", sa.String(length=500), nullable=False),
+        sa.Column("proposed_description", sa.Text(), nullable=True),
+        sa.Column("raw_text", sa.Text(), nullable=True),
+        sa.Column("confidence", sa.Float(), nullable=True),
+        sa.Column("reasoning", sa.Text(), nullable=True),
+        sa.Column("match_existing_lead_id", sa.UUID(), nullable=True),
+        sa.Column(
+            "status",
+            sa.String(length=32),
+            server_default="pending",
+            nullable=False,
+            comment="pending|approved_new|approved_linked|rejected",
+        ),
+        sa.Column(
+            "mm_thread_post_id",
+            sa.String(length=26),
+            nullable=True,
+            comment="Bot-reply-post met de approval-knoppen, voor latere edit",
+        ),
+        sa.Column("approved_lead_id", sa.UUID(), nullable=True),
+        sa.Column("reviewed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("reviewed_by_id", sa.UUID(), nullable=True),
+        sa.Column(
+            "review_source",
+            sa.String(length=32),
+            nullable=True,
+            comment="mattermost|ui",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["initiatief_id"], ["initiatief.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["match_existing_lead_id"], ["lead.id"], ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(["approved_lead_id"], ["lead.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["reviewed_by_id"], ["person.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_suggested_lead_initiatief_id", "suggested_lead", ["initiatief_id"]
+    )
+    op.create_index("ix_suggested_lead_status", "suggested_lead", ["status"])
+
+    # ----- mattermost_post_link -----
+    op.create_table(
+        "mattermost_post_link",
+        sa.Column(
+            "id",
+            sa.UUID(),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("post_id", sa.String(length=26), nullable=False),
+        sa.Column("channel_id", sa.String(length=26), nullable=False),
+        sa.Column("root_id", sa.String(length=26), nullable=True),
+        sa.Column(
+            "scope_type",
+            sa.String(length=32),
+            nullable=False,
+            comment="initiatief|lead",
+        ),
+        sa.Column("scope_id", sa.UUID(), nullable=False),
+        sa.Column("lead_activity_id", sa.UUID(), nullable=True),
+        sa.Column("suggested_lead_id", sa.UUID(), nullable=True),
+        sa.Column("mm_user_id", sa.String(length=26), nullable=True),
+        sa.Column("person_id", sa.UUID(), nullable=True),
+        sa.Column(
+            "skipped_reason",
+            sa.String(length=64),
+            nullable=True,
+            comment="bot_self|noise|no_link|other — voor diagnose",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["lead_activity_id"], ["lead_activity.id"], ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(
+            ["suggested_lead_id"], ["suggested_lead.id"], ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(["person_id"], ["person.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("post_id"),
+    )
+    op.create_index(
+        "ix_mattermost_post_link_post_id", "mattermost_post_link", ["post_id"]
+    )
+    op.create_index(
+        "ix_mattermost_post_link_channel_id", "mattermost_post_link", ["channel_id"]
+    )
+    op.create_index(
+        "ix_mattermost_post_link_scope_id", "mattermost_post_link", ["scope_id"]
+    )
+
+    # ----- lead_attachment: url-type velden -----
+    op.add_column(
+        "lead_attachment",
+        sa.Column(
+            "soort",
+            sa.String(),
+            nullable=False,
+            server_default="file",
+            comment="file|link",
+        ),
+    )
+    op.add_column("lead_attachment", sa.Column("url", sa.String(), nullable=True))
+    op.add_column(
+        "lead_attachment",
+        sa.Column(
+            "source",
+            sa.String(),
+            nullable=False,
+            server_default="upload",
+            comment="upload|mattermost",
+        ),
+    )
+    op.add_column(
+        "lead_attachment",
+        sa.Column(
+            "source_ref",
+            sa.String(),
+            nullable=True,
+            comment="bv. mattermost post_id",
+        ),
+    )
+    # File-velden worden nullable zodat URL-attachments zonder pad/grootte kunnen.
+    op.alter_column(
+        "lead_attachment", "bestandsnaam", existing_type=sa.String(), nullable=True
+    )
+    op.alter_column(
+        "lead_attachment", "content_type", existing_type=sa.String(), nullable=True
+    )
+    op.alter_column(
+        "lead_attachment",
+        "bestandsgrootte",
+        existing_type=sa.Integer(),
+        nullable=True,
+    )
+    op.alter_column("lead_attachment", "pad", existing_type=sa.String(), nullable=True)
+
+
+def downgrade() -> None:
+    op.alter_column("lead_attachment", "pad", existing_type=sa.String(), nullable=False)
+    op.alter_column(
+        "lead_attachment",
+        "bestandsgrootte",
+        existing_type=sa.Integer(),
+        nullable=False,
+    )
+    op.alter_column(
+        "lead_attachment", "content_type", existing_type=sa.String(), nullable=False
+    )
+    op.alter_column(
+        "lead_attachment", "bestandsnaam", existing_type=sa.String(), nullable=False
+    )
+    op.drop_column("lead_attachment", "source_ref")
+    op.drop_column("lead_attachment", "source")
+    op.drop_column("lead_attachment", "url")
+    op.drop_column("lead_attachment", "soort")
+
+    op.drop_index("ix_mattermost_post_link_scope_id", table_name="mattermost_post_link")
+    op.drop_index(
+        "ix_mattermost_post_link_channel_id", table_name="mattermost_post_link"
+    )
+    op.drop_index("ix_mattermost_post_link_post_id", table_name="mattermost_post_link")
+    op.drop_table("mattermost_post_link")
+
+    op.drop_index("ix_suggested_lead_status", table_name="suggested_lead")
+    op.drop_index("ix_suggested_lead_initiatief_id", table_name="suggested_lead")
+    op.drop_table("suggested_lead")
+
+    op.drop_index(
+        "ix_mattermost_channel_link_scope_id", table_name="mattermost_channel_link"
+    )
+    op.drop_index(
+        "ix_mattermost_channel_link_channel_id", table_name="mattermost_channel_link"
+    )
+    op.drop_table("mattermost_channel_link")

--- a/backend/bouwmeester/migrations/versions/2c4d6e8f9a01_add_mattermost_channel_links_and_suggested_leads.py
+++ b/backend/bouwmeester/migrations/versions/2c4d6e8f9a01_add_mattermost_channel_links_and_suggested_leads.py
@@ -13,7 +13,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "2c4d6e8f9a01"
-down_revision: str | None = "a1f3c8e7d402"
+down_revision: str | None = "d2e3f4a5b6c7"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/bouwmeester/models/__init__.py
+++ b/backend/bouwmeester/models/__init__.py
@@ -30,6 +30,10 @@ from bouwmeester.models.lead_activity import LeadActivity  # noqa: F401
 from bouwmeester.models.lead_attachment import LeadAttachment  # noqa: F401
 from bouwmeester.models.lead_node import LeadNode  # noqa: F401
 from bouwmeester.models.maatregel import Maatregel  # noqa: F401
+from bouwmeester.models.mattermost_channel_link import (  # noqa: F401
+    MattermostChannelLink,
+)
+from bouwmeester.models.mattermost_post_link import MattermostPostLink  # noqa: F401
 from bouwmeester.models.mattermost_user import (  # noqa: F401
     MattermostLinkCode,
     MattermostUser,
@@ -69,6 +73,7 @@ from bouwmeester.models.shared_access import SharedAccess  # noqa: F401
 from bouwmeester.models.stakeholder_assessment import (
     StakeholderAssessment,  # noqa: F401
 )
+from bouwmeester.models.suggested_lead import SuggestedLead  # noqa: F401
 from bouwmeester.models.tag import LeadTag, NodeTag, Tag  # noqa: F401
 from bouwmeester.models.task import Task  # noqa: F401
 from bouwmeester.models.webauthn_credential import WebAuthnCredential  # noqa: F401
@@ -107,7 +112,9 @@ __all__ = [
     "LeadNode",
     "LeadTag",
     "Maatregel",
+    "MattermostChannelLink",
     "MattermostLinkCode",
+    "MattermostPostLink",
     "MattermostUser",
     "Mention",
     "ParlementairItem",
@@ -134,6 +141,7 @@ __all__ = [
     "SharedAccess",
     "StakeholderAssessment",
     "SuggestedEdge",
+    "SuggestedLead",
     "Tag",
     "Task",
     "WebAuthnCredential",

--- a/backend/bouwmeester/models/lead_attachment.py
+++ b/backend/bouwmeester/models/lead_attachment.py
@@ -28,10 +28,27 @@ class LeadAttachment(Base):
         nullable=False,
         index=True,
     )
-    bestandsnaam: Mapped[str] = mapped_column(nullable=False)
-    content_type: Mapped[str] = mapped_column(nullable=False)
-    bestandsgrootte: Mapped[int] = mapped_column(nullable=False)
-    pad: Mapped[str] = mapped_column(nullable=False)
+    soort: Mapped[str] = mapped_column(
+        nullable=False,
+        default="file",
+        server_default="file",
+        comment="file|link",
+    )
+    bestandsnaam: Mapped[str | None] = mapped_column(nullable=True)
+    content_type: Mapped[str | None] = mapped_column(nullable=True)
+    bestandsgrootte: Mapped[int | None] = mapped_column(nullable=True)
+    pad: Mapped[str | None] = mapped_column(nullable=True)
+    url: Mapped[str | None] = mapped_column(nullable=True)
+    source: Mapped[str] = mapped_column(
+        nullable=False,
+        default="upload",
+        server_default="upload",
+        comment="upload|mattermost",
+    )
+    source_ref: Mapped[str | None] = mapped_column(
+        nullable=True,
+        comment="bv. mattermost post_id",
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/backend/bouwmeester/models/mattermost_channel_link.py
+++ b/backend/bouwmeester/models/mattermost_channel_link.py
@@ -1,0 +1,83 @@
+"""MattermostChannelLink - bindt een MM-kanaal aan een initiatief of lead."""
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional
+
+from sqlalchemy import BigInteger, Boolean, DateTime, ForeignKey, String, func, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from bouwmeester.core.database import Base
+
+if TYPE_CHECKING:
+    from bouwmeester.models.person import Person
+
+
+SCOPE_INITIATIEF = "initiatief"
+SCOPE_LEAD = "lead"
+
+
+class MattermostChannelLink(Base):
+    """Eén kanaal hangt aan precies één initiatief of één lead.
+
+    `scope_id` is polymorf — geen DB-FK omdat het zowel naar `initiatief.id`
+    als naar `lead.id` kan wijzen. De route checkt scope_type vóór gebruik.
+    """
+
+    __tablename__ = "mattermost_channel_link"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    channel_id: Mapped[str] = mapped_column(
+        String(26), unique=True, nullable=False, index=True
+    )
+    channel_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    channel_display_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    team_id: Mapped[str | None] = mapped_column(String(26), nullable=True)
+    scope_type: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        comment="initiatief|lead",
+    )
+    scope_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        nullable=False,
+        index=True,
+    )
+    auto_note_enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
+    suggest_leads_enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
+    last_seen_post_at: Mapped[int | None] = mapped_column(
+        BigInteger,
+        nullable=True,
+        comment=(
+            "Mattermost ms-timestamp van laatst verwerkte post (recovery na reconnect)"
+        ),
+    )
+    disabled_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="Bot is uit kanaal getrapt of kanaal is verwijderd",
+    )
+    created_by_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("person.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), onupdate=func.now(), nullable=True
+    )
+
+    created_by: Mapped[Optional["Person"]] = relationship(
+        "Person", foreign_keys=[created_by_id]
+    )

--- a/backend/bouwmeester/models/mattermost_post_link.py
+++ b/backend/bouwmeester/models/mattermost_post_link.py
@@ -1,0 +1,77 @@
+"""MattermostPostLink - idempotency-record voor verwerkte Mattermost-posts."""
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional
+
+from sqlalchemy import DateTime, ForeignKey, String, func, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from bouwmeester.core.database import Base
+
+if TYPE_CHECKING:
+    from bouwmeester.models.lead_activity import LeadActivity
+    from bouwmeester.models.person import Person
+
+
+class MattermostPostLink(Base):
+    """Eén record per Mattermost-post die we hebben gezien.
+
+    Dient drie doelen:
+    - Idempotency: ``post_id`` is unique, dubbele verwerking onmogelijk.
+    - Audit-trail: welke post leidde tot welke `LeadActivity` of `SuggestedLead`.
+    - Recovery: na reconnect weten we welke posts al verwerkt zijn.
+    """
+
+    __tablename__ = "mattermost_post_link"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    post_id: Mapped[str] = mapped_column(
+        String(26), unique=True, nullable=False, index=True
+    )
+    channel_id: Mapped[str] = mapped_column(String(26), nullable=False, index=True)
+    root_id: Mapped[str | None] = mapped_column(String(26), nullable=True)
+    scope_type: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        comment="initiatief|lead",
+    )
+    scope_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), nullable=False, index=True
+    )
+    lead_activity_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("lead_activity.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    suggested_lead_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("suggested_lead.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    mm_user_id: Mapped[str | None] = mapped_column(String(26), nullable=True)
+    person_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("person.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    skipped_reason: Mapped[str | None] = mapped_column(
+        String(64),
+        nullable=True,
+        comment="bot_self|noise|no_link|other — voor diagnose",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+    lead_activity: Mapped[Optional["LeadActivity"]] = relationship(
+        "LeadActivity", foreign_keys=[lead_activity_id]
+    )
+    person: Mapped[Optional["Person"]] = relationship(
+        "Person", foreign_keys=[person_id]
+    )

--- a/backend/bouwmeester/models/suggested_lead.py
+++ b/backend/bouwmeester/models/suggested_lead.py
@@ -1,0 +1,111 @@
+"""SuggestedLead - LLM-voorgestelde lead op basis van een Mattermost-bericht."""
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional
+
+from sqlalchemy import DateTime, Float, ForeignKey, String, Text, func, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from bouwmeester.core.database import Base
+
+if TYPE_CHECKING:
+    from bouwmeester.models.initiatief import Initiatief
+    from bouwmeester.models.lead import Lead
+    from bouwmeester.models.person import Person
+
+
+STATUS_PENDING = "pending"
+STATUS_APPROVED_NEW = "approved_new"
+STATUS_APPROVED_LINKED = "approved_linked"
+STATUS_REJECTED = "rejected"
+
+
+class SuggestedLead(Base):
+    """Voorstel om van een Mattermost-bericht een lead te maken.
+
+    Approval gebeurt in Mattermost zelf (interactive buttons) of via een
+    fallback-lijst in de UI. Bij approval wordt ``status`` bijgewerkt en
+    ``approved_lead_id`` gezet.
+    """
+
+    __tablename__ = "suggested_lead"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    source_type: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        default="mattermost",
+        server_default="mattermost",
+    )
+    source_post_id: Mapped[str] = mapped_column(String(26), nullable=False)
+    source_channel_id: Mapped[str] = mapped_column(String(26), nullable=False)
+    source_root_id: Mapped[str | None] = mapped_column(String(26), nullable=True)
+    initiatief_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("initiatief.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    proposed_title: Mapped[str] = mapped_column(String(500), nullable=False)
+    proposed_description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    raw_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    confidence: Mapped[float | None] = mapped_column(Float, nullable=True)
+    reasoning: Mapped[str | None] = mapped_column(Text, nullable=True)
+    match_existing_lead_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("lead.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    status: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        default=STATUS_PENDING,
+        server_default=STATUS_PENDING,
+        comment="pending|approved_new|approved_linked|rejected",
+        index=True,
+    )
+    mm_thread_post_id: Mapped[str | None] = mapped_column(
+        String(26),
+        nullable=True,
+        comment="Bot-reply-post met de approval-knoppen, voor latere edit",
+    )
+    approved_lead_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("lead.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    reviewed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    reviewed_by_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("person.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    review_source: Mapped[str | None] = mapped_column(
+        String(32),
+        nullable=True,
+        comment="mattermost|ui",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+    initiatief: Mapped[Optional["Initiatief"]] = relationship(
+        "Initiatief", foreign_keys=[initiatief_id]
+    )
+    match_existing_lead: Mapped[Optional["Lead"]] = relationship(
+        "Lead", foreign_keys=[match_existing_lead_id]
+    )
+    approved_lead: Mapped[Optional["Lead"]] = relationship(
+        "Lead", foreign_keys=[approved_lead_id]
+    )
+    reviewed_by: Mapped[Optional["Person"]] = relationship(
+        "Person", foreign_keys=[reviewed_by_id]
+    )

--- a/backend/bouwmeester/repositories/mattermost_channel_link.py
+++ b/backend/bouwmeester/repositories/mattermost_channel_link.py
@@ -1,0 +1,103 @@
+"""Repository voor MattermostChannelLink."""
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bouwmeester.models.mattermost_channel_link import MattermostChannelLink
+
+
+class MattermostChannelLinkRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def get(self, link_id: UUID) -> MattermostChannelLink | None:
+        stmt = select(MattermostChannelLink).where(MattermostChannelLink.id == link_id)
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def get_by_channel_id(self, channel_id: str) -> MattermostChannelLink | None:
+        stmt = select(MattermostChannelLink).where(
+            MattermostChannelLink.channel_id == channel_id
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def list_for_scope(
+        self, scope_type: str, scope_id: UUID
+    ) -> list[MattermostChannelLink]:
+        stmt = (
+            select(MattermostChannelLink)
+            .where(
+                MattermostChannelLink.scope_type == scope_type,
+                MattermostChannelLink.scope_id == scope_id,
+            )
+            .order_by(MattermostChannelLink.created_at.desc())
+        )
+        result = await self.session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def list_active(self) -> list[MattermostChannelLink]:
+        """Alle gekoppelde kanalen die niet uitgeschakeld zijn (voor de
+        websocket-loop om events op te filteren)."""
+        stmt = select(MattermostChannelLink).where(
+            MattermostChannelLink.disabled_at.is_(None)
+        )
+        result = await self.session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def create(
+        self,
+        *,
+        channel_id: str,
+        channel_name: str,
+        channel_display_name: str,
+        team_id: str | None,
+        scope_type: str,
+        scope_id: UUID,
+        auto_note_enabled: bool,
+        suggest_leads_enabled: bool,
+        created_by_id: UUID | None,
+    ) -> MattermostChannelLink:
+        link = MattermostChannelLink(
+            channel_id=channel_id,
+            channel_name=channel_name,
+            channel_display_name=channel_display_name,
+            team_id=team_id,
+            scope_type=scope_type,
+            scope_id=scope_id,
+            auto_note_enabled=auto_note_enabled,
+            suggest_leads_enabled=suggest_leads_enabled,
+            created_by_id=created_by_id,
+        )
+        self.session.add(link)
+        await self.session.flush()
+        await self.session.refresh(link)
+        return link
+
+    async def update_settings(
+        self,
+        link: MattermostChannelLink,
+        *,
+        auto_note_enabled: bool | None = None,
+        suggest_leads_enabled: bool | None = None,
+    ) -> MattermostChannelLink:
+        if auto_note_enabled is not None:
+            link.auto_note_enabled = auto_note_enabled
+        if suggest_leads_enabled is not None:
+            link.suggest_leads_enabled = suggest_leads_enabled
+        await self.session.flush()
+        await self.session.refresh(link)
+        return link
+
+    async def update_last_seen(
+        self, link: MattermostChannelLink, last_seen_post_at: int
+    ) -> None:
+        if link.last_seen_post_at is None or last_seen_post_at > link.last_seen_post_at:
+            link.last_seen_post_at = last_seen_post_at
+            await self.session.flush()
+
+    async def delete(self, link: MattermostChannelLink) -> None:
+        await self.session.delete(link)
+        await self.session.flush()

--- a/backend/bouwmeester/repositories/mattermost_channel_link.py
+++ b/backend/bouwmeester/repositories/mattermost_channel_link.py
@@ -82,11 +82,14 @@ class MattermostChannelLinkRepository:
         *,
         auto_note_enabled: bool | None = None,
         suggest_leads_enabled: bool | None = None,
+        reenable: bool | None = None,
     ) -> MattermostChannelLink:
         if auto_note_enabled is not None:
             link.auto_note_enabled = auto_note_enabled
         if suggest_leads_enabled is not None:
             link.suggest_leads_enabled = suggest_leads_enabled
+        if reenable:
+            link.disabled_at = None
         await self.session.flush()
         await self.session.refresh(link)
         return link

--- a/backend/bouwmeester/schema/__init__.py
+++ b/backend/bouwmeester/schema/__init__.py
@@ -142,6 +142,12 @@ from bouwmeester.schema.llm import (
     TagSuggestionRequest,
     TagSuggestionResponse,
 )
+from bouwmeester.schema.mattermost_channel_link import (
+    MattermostChannelLinkCreate,
+    MattermostChannelLinkResponse,
+    MattermostChannelLinkUpdate,
+    MattermostChannelSearchResult,
+)
 from bouwmeester.schema.mattermost_user import (
     MattermostLinkCodeResponse,
     MattermostLinkStatusResponse,
@@ -479,6 +485,10 @@ __all__ = [
     "TagTreeResponse",
     "TagUpdate",
     # mattermost
+    "MattermostChannelLinkCreate",
+    "MattermostChannelLinkResponse",
+    "MattermostChannelLinkUpdate",
+    "MattermostChannelSearchResult",
     "MattermostLinkCodeResponse",
     "MattermostLinkStatusResponse",
     "MattermostUserResponse",

--- a/backend/bouwmeester/schema/__init__.py
+++ b/backend/bouwmeester/schema/__init__.py
@@ -245,6 +245,7 @@ from bouwmeester.schema.stakeholder_assessment import (
     StakeholderHouding,
     StakeholderScopeType,
 )
+from bouwmeester.schema.suggested_lead import SuggestedLeadResponse
 from bouwmeester.schema.tag import (
     LeadTagCreate,
     LeadTagResponse,
@@ -538,6 +539,8 @@ __all__ = [
     "ParlementairItemResponse",
     "ReviewAction",
     "SuggestedEdgeResponse",
+    # suggested_lead
+    "SuggestedLeadResponse",
     # whitelist / admin
     "AdminToggleRequest",
     "AdminUserResponse",

--- a/backend/bouwmeester/schema/lead.py
+++ b/backend/bouwmeester/schema/lead.py
@@ -133,9 +133,13 @@ class LeadExterneOrgSummary(BaseModel):
 class LeadAttachmentResponse(BaseModel):
     id: UUID
     lead_id: UUID
-    bestandsnaam: str
-    content_type: str
-    bestandsgrootte: int
+    soort: str = "file"
+    bestandsnaam: str | None = None
+    content_type: str | None = None
+    bestandsgrootte: int | None = None
+    url: str | None = None
+    source: str = "upload"
+    source_ref: str | None = None
     bestand_beschikbaar: bool = True
     created_at: datetime
 

--- a/backend/bouwmeester/schema/mattermost_channel_link.py
+++ b/backend/bouwmeester/schema/mattermost_channel_link.py
@@ -1,0 +1,50 @@
+"""Pydantic-schema's voor MattermostChannelLink."""
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class MattermostChannelSearchResult(BaseModel):
+    """Resultaat van een MM-kanaal-zoekopdracht via de bot."""
+
+    channel_id: str
+    channel_name: str
+    channel_display_name: str
+    team_id: str | None = None
+    member_count: int | None = None
+    is_bot_member: bool = False
+
+
+class MattermostChannelLinkCreate(BaseModel):
+    channel_id: str = Field(..., pattern=r"^[a-z0-9]{26}$")
+    channel_name: str = Field(..., min_length=1, max_length=255)
+    channel_display_name: str = Field(..., min_length=1, max_length=255)
+    team_id: str | None = Field(None, pattern=r"^[a-z0-9]{26}$")
+    auto_note_enabled: bool | None = None
+    suggest_leads_enabled: bool | None = None
+
+
+class MattermostChannelLinkUpdate(BaseModel):
+    auto_note_enabled: bool | None = None
+    suggest_leads_enabled: bool | None = None
+
+
+class MattermostChannelLinkResponse(BaseModel):
+    id: UUID
+    channel_id: str
+    channel_name: str
+    channel_display_name: str
+    team_id: str | None
+    scope_type: str
+    scope_id: UUID
+    auto_note_enabled: bool
+    suggest_leads_enabled: bool
+    last_seen_post_at: int | None
+    disabled_at: datetime | None
+    created_by_id: UUID | None
+    created_at: datetime
+    updated_at: datetime | None
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/bouwmeester/schema/mattermost_channel_link.py
+++ b/backend/bouwmeester/schema/mattermost_channel_link.py
@@ -1,6 +1,7 @@
 """Pydantic-schema's voor MattermostChannelLink."""
 
 from datetime import datetime
+from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -30,8 +31,10 @@ class MattermostChannelLinkUpdate(BaseModel):
     auto_note_enabled: bool | None = None
     suggest_leads_enabled: bool | None = None
     # Stuur ``reenable=true`` om een uitgeschakelde koppeling weer aan te
-    # zetten nadat de bot terug is in het kanaal.
-    reenable: bool | None = None
+    # zetten nadat de bot terug is in het kanaal. ``false`` is geen
+    # zinvolle waarde (uitschakelen gebeurt automatisch via WS-events of
+    # via DELETE) — daarom alleen ``true`` of weglaten.
+    reenable: Literal[True] | None = None
 
 
 class MattermostChannelLinkResponse(BaseModel):

--- a/backend/bouwmeester/schema/mattermost_channel_link.py
+++ b/backend/bouwmeester/schema/mattermost_channel_link.py
@@ -29,6 +29,9 @@ class MattermostChannelLinkCreate(BaseModel):
 class MattermostChannelLinkUpdate(BaseModel):
     auto_note_enabled: bool | None = None
     suggest_leads_enabled: bool | None = None
+    # Stuur ``reenable=true`` om een uitgeschakelde koppeling weer aan te
+    # zetten nadat de bot terug is in het kanaal.
+    reenable: bool | None = None
 
 
 class MattermostChannelLinkResponse(BaseModel):

--- a/backend/bouwmeester/schema/suggested_lead.py
+++ b/backend/bouwmeester/schema/suggested_lead.py
@@ -1,0 +1,29 @@
+"""Pydantic-schemas voor SuggestedLead (Mattermost-suggesties)."""
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+class SuggestedLeadResponse(BaseModel):
+    id: UUID
+    source_type: str
+    source_post_id: str
+    source_channel_id: str
+    initiatief_id: UUID
+    proposed_title: str
+    proposed_description: str | None
+    raw_text: str | None
+    confidence: float | None
+    reasoning: str | None
+    match_existing_lead_id: UUID | None
+    status: str
+    mm_thread_post_id: str | None
+    approved_lead_id: UUID | None
+    reviewed_at: datetime | None
+    reviewed_by_id: UUID | None
+    review_source: str | None
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/bouwmeester/services/llm/base.py
+++ b/backend/bouwmeester/services/llm/base.py
@@ -63,6 +63,15 @@ class GapAnalysisResult(BaseModel):
     recommendations: list[str]
 
 
+class LeadCandidateClassification(BaseModel):
+    is_lead: bool
+    confidence: float
+    proposed_title: str
+    proposed_description: str
+    match_existing_lead_id: str | None
+    reasoning: str
+
+
 class BaseLLMService(ABC):
     """Abstract base for all LLM providers."""
 
@@ -257,3 +266,85 @@ class BaseLLMService(ABC):
         except Exception:
             logger.exception("Fout bij LLM gap-analyse")
             return GapAnalysisResult(narrative="", recommendations=[])
+
+    async def is_mattermost_noise(self, message: str) -> bool:
+        """True als het bericht ruis is (ack/emoji/no-content)."""
+        from bouwmeester.services.llm.prompts import build_is_noise_prompt
+
+        prompt = build_is_noise_prompt(message)
+        try:
+            text = await self._complete(prompt, max_tokens=64)
+            result = self._parse_json(text)
+            return bool(result.get("is_noise", False))
+        except Exception:
+            logger.exception("Fout bij LLM noise-classificatie")
+            return False  # Bij twijfel: behouden.
+
+    async def summarize_mattermost_message(
+        self, message: str, *, max_words: int = 80
+    ) -> str:
+        """Vat een lang MM-bericht samen. Returns lege string bij fout."""
+        from bouwmeester.services.llm.prompts import (
+            build_summarize_mattermost_thread_prompt,
+        )
+
+        prompt = build_summarize_mattermost_thread_prompt(
+            message=message, max_words=max_words
+        )
+        try:
+            text = await self._complete(prompt, max_tokens=300)
+            result = self._parse_json(text)
+            return str(result.get("samenvatting") or "")
+        except Exception:
+            logger.exception("Fout bij LLM samenvatting")
+            return ""
+
+    async def classify_mattermost_lead_candidate(
+        self,
+        *,
+        message: str,
+        initiatief_naam: str,
+        channel_display_name: str,
+        recent_leads: list[dict],
+    ) -> LeadCandidateClassification:
+        """Classificeer een Mattermost-bericht als (mogelijke) lead.
+
+        Wordt aangeroepen voor berichten in een aan een initiatief gekoppeld
+        kanaal. CONFIDENTIAL: alleen door VLAM uitvoerbaar.
+        """
+        from bouwmeester.services.llm.prompts import (
+            build_classify_mattermost_lead_prompt,
+        )
+
+        prompt = build_classify_mattermost_lead_prompt(
+            message=message,
+            initiatief_naam=initiatief_naam,
+            channel_display_name=channel_display_name,
+            recent_leads=recent_leads,
+        )
+        try:
+            text = await self._complete(prompt, max_tokens=512)
+            result = self._parse_json(text)
+            match_id = result.get("match_existing_lead_id")
+            if isinstance(match_id, str):
+                match_id = match_id.strip() or None
+            else:
+                match_id = None
+            return LeadCandidateClassification(
+                is_lead=bool(result.get("is_lead", False)),
+                confidence=float(result.get("confidence") or 0.0),
+                proposed_title=str(result.get("proposed_title") or "")[:500],
+                proposed_description=str(result.get("proposed_description") or ""),
+                match_existing_lead_id=match_id,
+                reasoning=str(result.get("reasoning") or ""),
+            )
+        except Exception:
+            logger.exception("Fout bij LLM lead-classificatie")
+            return LeadCandidateClassification(
+                is_lead=False,
+                confidence=0.0,
+                proposed_title="",
+                proposed_description="",
+                match_existing_lead_id=None,
+                reasoning="LLM-call mislukt",
+            )

--- a/backend/bouwmeester/services/llm/base.py
+++ b/backend/bouwmeester/services/llm/base.py
@@ -330,9 +330,14 @@ class BaseLLMService(ABC):
                 match_id = match_id.strip() or None
             else:
                 match_id = None
+            try:
+                raw_confidence = float(result.get("confidence") or 0.0)
+            except (TypeError, ValueError):
+                raw_confidence = 0.0
+            confidence = max(0.0, min(1.0, raw_confidence))
             return LeadCandidateClassification(
                 is_lead=bool(result.get("is_lead", False)),
-                confidence=float(result.get("confidence") or 0.0),
+                confidence=confidence,
                 proposed_title=str(result.get("proposed_title") or "")[:500],
                 proposed_description=str(result.get("proposed_description") or ""),
                 match_existing_lead_id=match_id,

--- a/backend/bouwmeester/services/llm/prompts.py
+++ b/backend/bouwmeester/services/llm/prompts.py
@@ -538,3 +538,106 @@ def build_chat_context_message(context: dict | None) -> str:
         )
 
     return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Mattermost-meelees-prompts
+# ---------------------------------------------------------------------------
+
+
+MAX_RECENT_LEADS_IN_PROMPT = 20
+
+
+def build_classify_mattermost_lead_prompt(
+    *,
+    message: str,
+    initiatief_naam: str,
+    channel_display_name: str,
+    recent_leads: list[dict],
+) -> str:
+    """Bouw een prompt voor het classificeren van een Mattermost-bericht
+    als (potentiële) lead binnen een initiatief.
+
+    ``recent_leads`` is een lijst dicts ``{id, title, stage}`` van leads
+    binnen hetzelfde initiatief, zodat de LLM duplicaten kan voorstellen.
+    """
+    leads_block = ""
+    if recent_leads:
+        items = []
+        for lead in recent_leads[:MAX_RECENT_LEADS_IN_PROMPT]:
+            items.append(
+                f"- id: {lead['id']}, "
+                f'titel: "{lead["title"]}", '
+                f"stage: {lead.get('stage', '?')}"
+            )
+        leads_block = (
+            "\nBESTAANDE LEADS in dit initiatief (kandidaten voor 'koppelen'):\n"
+            + "\n".join(items)
+            + "\n"
+        )
+
+    return (
+        "Je bent een medewerker van team Regelrecht bij het ministerie van BZK.\n"
+        f'Het Mattermost-kanaal "{channel_display_name}" is gekoppeld aan'
+        f' het initiatief "{initiatief_naam}". In dit kanaal worden nieuwe'
+        " leads (organisaties of mensen die geïnteresseerd zijn in onze"
+        " dienstverlening) besproken.\n\n"
+        "Beoordeel of het volgende bericht een nieuwe of bestaande lead"
+        " beschrijft. Een lead is een concreet contactmoment of signaal"
+        " van een externe organisatie/persoon — niet een collega die"
+        " intern iets meldt of een algemene update.\n\n"
+        f"BERICHT:\n{message[:MAX_TEXT_IN_PROMPT]}\n"
+        f"{leads_block}\n"
+        "Antwoord met JSON (en ALLEEN JSON):\n"
+        "{\n"
+        '  "is_lead": true|false,\n'
+        '  "confidence": 0.0-1.0,\n'
+        '  "proposed_title": "korte titel (organisatie of '
+        'onderwerp), max 80 chars",\n'
+        '  "proposed_description": "1-2 zinnen samenvatting wat ze willen",\n'
+        '  "match_existing_lead_id": "uuid van bestaande lead of null",\n'
+        '  "reasoning": "kort waarom je dit denkt (max 1 zin)"\n'
+        "}\n"
+        "Regels:\n"
+        '- Bij twijfel: "is_lead": false. Beter een gemiste suggestie'
+        " dan ruis.\n"
+        '- Triviale berichten ("ok", "👍", "morgen even bellen")'
+        ' krijgen "is_lead": false.\n'
+        "- Als het overduidelijk over een bestaande lead uit de lijst"
+        ' gaat, vul "match_existing_lead_id" met die UUID en houd'
+        ' "is_lead": true.\n'
+        '- Als geen match: "match_existing_lead_id": null.'
+    )
+
+
+def build_is_noise_prompt(message: str) -> str:
+    """Bouw een prompt die ruis-berichten als zodanig markeert.
+
+    Ruis = ack-berichten, korte emoji-replies, "ok", "👍", lege thread-pings.
+    Géén ruis = inhoudelijke updates, vragen, beschrijvingen — ook al zijn
+    ze kort.
+    """
+    return (
+        "Beoordeel of dit Mattermost-bericht ruis is (ack, emoji-only,"
+        " social chit-chat zonder inhoudelijke informatie) of een"
+        " inhoudelijke notitie die op een lead bewaard zou moeten worden."
+        " Bij twijfel: niet-ruis.\n\n"
+        f"BERICHT:\n{message[:2000]}\n\n"
+        "Antwoord met JSON (en ALLEEN JSON):\n"
+        '{"is_noise": true|false}'
+    )
+
+
+def build_summarize_mattermost_thread_prompt(
+    *, message: str, max_words: int = 80
+) -> str:
+    """Bouw een prompt voor het samenvatten van een (lang) MM-bericht."""
+    return (
+        "Vat onderstaand Mattermost-bericht samen in maximaal"
+        f" {max_words} woorden, in het Nederlands. Behoud concrete feiten,"
+        " namen, datums en deadlines. Geen meta-commentaar, geen"
+        " inleiding."
+        f"\n\nBERICHT:\n{message[:MAX_TEXT_IN_PROMPT]}\n\n"
+        "Antwoord met JSON (en ALLEEN JSON):\n"
+        '{"samenvatting": "..."}'
+    )

--- a/backend/bouwmeester/services/mattermost_doc_link_extractor.py
+++ b/backend/bouwmeester/services/mattermost_doc_link_extractor.py
@@ -1,0 +1,128 @@
+"""Doc-link extractie uit Mattermost-berichten.
+
+Pikt URLs op die naar bekende documentbronnen wijzen (Drive, Confluence,
+SharePoint, Dropbox, Notion) plus expliciete bestandstypen (.pdf/.docx).
+Bewust conservatief: een willekeurige nieuwsartikel-URL telt niet als
+document.
+"""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import urlparse
+
+# https?:// gevolgd door tekens die in een URL passen, geen aanhalingstekens.
+# Stript veelvoorkomende trailing punctuation (komma's, haakjes, punten).
+_URL_PATTERN = re.compile(
+    r"https?://[^\s<>\"\\]+",
+    re.IGNORECASE,
+)
+_TRAILING_STRIP = ".,;:!?)]}>"
+
+# Hostnamen (suffix-match) waarvan we URLs altijd als doc-link beschouwen.
+_DOC_HOST_SUFFIXES: tuple[str, ...] = (
+    "drive.google.com",
+    "docs.google.com",
+    "sheets.google.com",
+    "slides.google.com",
+    "atlassian.net",  # Confluence cloud
+    "sharepoint.com",
+    "onedrive.live.com",
+    "dropbox.com",
+    "notion.so",
+    "notion.site",
+    "miro.com",
+    "figma.com",
+)
+
+# Padsuffixen die ook zonder bekende host gelden als doc-link.
+_DOC_PATH_SUFFIXES: tuple[str, ...] = (
+    ".pdf",
+    ".docx",
+    ".doc",
+    ".pptx",
+    ".ppt",
+    ".xlsx",
+    ".xls",
+    ".odt",
+    ".ods",
+)
+
+
+def _normalize(url: str) -> str:
+    """Strip trailing punctuation die vaak per ongeluk in de match zit."""
+    while url and url[-1] in _TRAILING_STRIP:
+        url = url[:-1]
+    return url
+
+
+def _matches_doc_host(host: str) -> bool:
+    host = host.lower()
+    return any(
+        host == suffix or host.endswith("." + suffix) for suffix in _DOC_HOST_SUFFIXES
+    )
+
+
+def _matches_doc_path(path: str) -> bool:
+    p = path.lower()
+    return any(p.endswith(suffix) for suffix in _DOC_PATH_SUFFIXES)
+
+
+def extract_doc_links(message: str) -> list[dict]:
+    """Vind alle URLs die kwalificeren als doc-link.
+
+    Returneert een lijst dicts: ``{"url": str, "host": str}``. De caller
+    bepaalt zelf hoe deze als attachment worden opgeslagen. Dubbele URLs
+    worden gededupliceerd in volgorde van eerste voorkomen.
+    """
+    if not message:
+        return []
+
+    seen: set[str] = set()
+    out: list[dict] = []
+    for raw in _URL_PATTERN.findall(message):
+        url = _normalize(raw)
+        if not url or url in seen:
+            continue
+        try:
+            parsed = urlparse(url)
+        except ValueError:
+            continue
+        host = (parsed.hostname or "").lower()
+        if not host:
+            continue
+        if not (_matches_doc_host(host) or _matches_doc_path(parsed.path or "")):
+            continue
+        seen.add(url)
+        out.append({"url": url, "host": host})
+    return out
+
+
+def derive_attachment_label(url: str) -> str:
+    """Verzin een leesbaar label voor een URL-attachment.
+
+    We willen geen full-URL als label tonen — voor Google Drive nemen we
+    'Drive', voor Confluence 'Confluence', anders de host zonder www.
+    """
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return url
+    host = (parsed.hostname or "").lower()
+    if "drive.google.com" in host or "docs.google.com" in host:
+        return "Google Drive"
+    if "atlassian.net" in host:
+        return "Confluence"
+    if "sharepoint.com" in host or "onedrive.live.com" in host:
+        return "SharePoint/OneDrive"
+    if "dropbox.com" in host:
+        return "Dropbox"
+    if "notion." in host:
+        return "Notion"
+    if "figma.com" in host:
+        return "Figma"
+    if "miro.com" in host:
+        return "Miro"
+    if host.startswith("www."):
+        host = host[4:]
+    return host or url

--- a/backend/bouwmeester/services/mattermost_ingest_service.py
+++ b/backend/bouwmeester/services/mattermost_ingest_service.py
@@ -124,7 +124,7 @@ class MattermostIngestService:
             and channel_link.suggest_leads_enabled
             and message.strip()
         ):
-            suggested_lead_id = await self._create_suggested_lead(
+            suggested_lead_id, suggest_reason = await self._create_suggested_lead(
                 channel_link_initiatief_id=channel_link.scope_id,
                 channel_display_name=channel_link.channel_display_name,
                 channel_id=channel_id,
@@ -132,7 +132,7 @@ class MattermostIngestService:
                 message=message,
             )
             if suggested_lead_id is None:
-                skipped_reason = "noise"
+                skipped_reason = suggest_reason
         elif channel_link.scope_type == SCOPE_LEAD and not message.strip():
             # Joins, leaves, system-events — nuttig om vast te leggen
             # zodat we de post niet opnieuw zien, maar geen note van maken.
@@ -268,18 +268,24 @@ class MattermostIngestService:
         channel_id: str,
         post: dict,
         message: str,
-    ) -> UUID | None:
+    ) -> tuple[UUID | None, str | None]:
         """Vraag VLAM of dit een lead is en maak — bij ja — een SuggestedLead
         plus een bot-reply met approval-knoppen in de thread.
 
-        Returns ``None`` als het bericht volgens de LLM geen lead is."""
+        Returns ``(uuid_of_None, reason)`` met ``reason`` ∈
+        ``"llm_unavailable" | "no_lead" | "stale_initiatief" | None``.
+        ``reason`` wordt door de caller in ``MattermostPostLink.skipped_reason``
+        bewaard, zodat we onderscheid kunnen maken tussen "VLAM was tijdelijk
+        offline" (reprocessable) en "echt geen lead" (definitief)."""
         from bouwmeester.services.llm import DataSensitivity
         from bouwmeester.services.llm.factory import get_llm_service_for
 
         llm = await get_llm_service_for(DataSensitivity.CONFIDENTIAL, self.session)
         if llm is None:
-            logger.debug("Geen CONFIDENTIAL-LLM beschikbaar — sla suggested-lead over")
-            return None
+            logger.warning(
+                "Geen CONFIDENTIAL-LLM beschikbaar — sla suggested-lead over"
+            )
+            return None, "llm_unavailable"
 
         initiatief = await self.session.get(Initiatief, channel_link_initiatief_id)
         if initiatief is None:
@@ -287,7 +293,7 @@ class MattermostIngestService:
                 "Initiatief %s voor kanaal-koppeling bestaat niet (meer)",
                 channel_link_initiatief_id,
             )
-            return None
+            return None, "stale_initiatief"
 
         recent_leads_stmt = (
             select(Lead.id, Lead.title, Lead.stage)
@@ -307,7 +313,7 @@ class MattermostIngestService:
             recent_leads=recent,
         )
         if not result.is_lead:
-            return None
+            return None, "no_lead"
 
         match_lead_uuid: UUID | None = None
         if result.match_existing_lead_id:
@@ -356,7 +362,7 @@ class MattermostIngestService:
                 "Kon bot-reply voor suggested lead %s niet plaatsen", suggested.id
             )
 
-        return suggested.id
+        return suggested.id, None
 
     async def _post_suggestion_reply(
         self,
@@ -435,17 +441,13 @@ class MattermostIngestService:
                 "footer": "Bouwmeester · suggestie vanuit Mattermost",
                 "actions": actions,
             }
-            client = await service._get_client()
-            payload = {
-                "channel_id": channel_id,
-                "root_id": root_post_id,
-                "message": text,
-                "props": {"attachments": [attachment]},
-            }
-            resp = await client.post("/api/v4/posts", json=payload)
-            resp.raise_for_status()
-            data = resp.json()
-            mm_thread_post_id = data.get("id")
+            data = await service.reply_to_post(
+                channel_id,
+                root_post_id,
+                text,
+                props={"attachments": [attachment]},
+            )
+            mm_thread_post_id = (data or {}).get("id")
             if mm_thread_post_id:
                 suggested.mm_thread_post_id = mm_thread_post_id
                 await self.session.flush()

--- a/backend/bouwmeester/services/mattermost_ingest_service.py
+++ b/backend/bouwmeester/services/mattermost_ingest_service.py
@@ -1,0 +1,464 @@
+"""Verwerking van Mattermost-posts in gekoppelde kanalen.
+
+Per binnenkomend ``posted``-event:
+- skip bot-eigen berichten en niet-gekoppelde kanalen
+- match auteur via bestaande ``mattermost_user``-link
+- voor lead-scope met ``auto_note_enabled``: maak ``LeadActivity`` (note)
+  en haal doc-links op naar ``LeadAttachment(soort=link)``
+- voor initiatief-scope met ``suggest_leads_enabled``: nog niet — komt in
+  PR3 (hier alleen ``mattermost_post_link``-record)
+- altijd: schrijf ``mattermost_post_link`` zodat de post niet opnieuw
+  wordt verwerkt
+"""
+
+from __future__ import annotations
+
+import logging
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bouwmeester.models.initiatief import Initiatief
+from bouwmeester.models.lead import Lead
+from bouwmeester.models.lead_activity import LeadActivity
+from bouwmeester.models.lead_attachment import LeadAttachment
+from bouwmeester.models.mattermost_channel_link import (
+    SCOPE_INITIATIEF,
+    SCOPE_LEAD,
+)
+from bouwmeester.models.mattermost_post_link import MattermostPostLink
+from bouwmeester.models.suggested_lead import (
+    STATUS_PENDING,
+    SuggestedLead,
+)
+from bouwmeester.repositories.mattermost_channel_link import (
+    MattermostChannelLinkRepository,
+)
+from bouwmeester.repositories.mattermost_user import MattermostUserRepository
+from bouwmeester.services.mattermost_doc_link_extractor import (
+    derive_attachment_label,
+    extract_doc_links,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class MattermostIngestService:
+    """Stateless verwerking — instantieer per session, gooi daarna weg."""
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        *,
+        bot_user_id: str | None = None,
+        mm_base_url: str | None = None,
+    ):
+        self.session = session
+        self.bot_user_id = bot_user_id
+        self.mm_base_url = mm_base_url.rstrip("/") if mm_base_url else None
+
+    async def ingest_post(self, post: dict) -> None:
+        """Verwerk één Mattermost-post.
+
+        De caller is verantwoordelijk voor commit/rollback van de session.
+        """
+        post_id = post.get("id")
+        channel_id = post.get("channel_id")
+        if not post_id or not channel_id:
+            return
+
+        mm_user_id = post.get("user_id") or None
+        root_id = post.get("root_id") or None
+
+        # Skip bot's eigen posts (anti feedback-loop).
+        if self.bot_user_id and mm_user_id == self.bot_user_id:
+            return
+
+        link_repo = MattermostChannelLinkRepository(self.session)
+        channel_link = await link_repo.get_by_channel_id(channel_id)
+        if channel_link is None or channel_link.disabled_at is not None:
+            return
+
+        # Idempotency-check vóór insert vermijdt een IntegrityError-rollback
+        # die in een ge-savepointe testtransactie de hele session sloopt.
+        existing_stmt = select(MattermostPostLink.id).where(
+            MattermostPostLink.post_id == post_id
+        )
+        if (await self.session.execute(existing_stmt)).scalar_one_or_none():
+            return
+
+        # Auteur-match via mattermost_user (alleen via expliciete koppeling).
+        person_id: UUID | None = None
+        if mm_user_id:
+            mm_repo = MattermostUserRepository(self.session)
+            mapping = await mm_repo.get_by_mattermost_user_id(mm_user_id)
+            if mapping is not None:
+                person_id = mapping.person_id
+
+        message = post.get("message") or ""
+        lead_activity_id: UUID | None = None
+        suggested_lead_id: UUID | None = None
+        skipped_reason: str | None = None
+
+        if (
+            channel_link.scope_type == SCOPE_LEAD
+            and channel_link.auto_note_enabled
+            and message.strip()
+        ):
+            if await self._is_noise(message):
+                skipped_reason = "noise"
+            else:
+                lead_activity_id = await self._create_auto_note(
+                    lead_id=channel_link.scope_id,
+                    post=post,
+                    message=message,
+                    author_person_id=person_id,
+                    mm_user_id=mm_user_id,
+                    post_id=post_id,
+                    channel_id=channel_id,
+                )
+        elif (
+            channel_link.scope_type == SCOPE_INITIATIEF
+            and channel_link.suggest_leads_enabled
+            and message.strip()
+        ):
+            suggested_lead_id = await self._create_suggested_lead(
+                channel_link_initiatief_id=channel_link.scope_id,
+                channel_display_name=channel_link.channel_display_name,
+                channel_id=channel_id,
+                post=post,
+                message=message,
+            )
+            if suggested_lead_id is None:
+                skipped_reason = "noise"
+        elif channel_link.scope_type == SCOPE_LEAD and not message.strip():
+            # Joins, leaves, system-events — nuttig om vast te leggen
+            # zodat we de post niet opnieuw zien, maar geen note van maken.
+            skipped_reason = "no_link"
+
+        record = MattermostPostLink(
+            post_id=post_id,
+            channel_id=channel_id,
+            root_id=root_id,
+            scope_type=channel_link.scope_type,
+            scope_id=channel_link.scope_id,
+            mm_user_id=mm_user_id,
+            person_id=person_id,
+            lead_activity_id=lead_activity_id,
+            suggested_lead_id=suggested_lead_id,
+            skipped_reason=skipped_reason,
+        )
+        self.session.add(record)
+        try:
+            async with self.session.begin_nested():
+                await self.session.flush()
+        except IntegrityError:
+            # Race-condition op unique post_id — andere worker was sneller.
+            return
+
+        # Bump last_seen_post_at zodat recovery na reconnect klopt.
+        create_at = post.get("create_at")
+        if isinstance(create_at, int):
+            await link_repo.update_last_seen(channel_link, create_at)
+
+    async def _is_noise(self, message: str) -> bool:
+        """Vraag VLAM of dit een triviaal/ack-bericht is.
+
+        Korte heuristiek vooraf: berichten van < 4 chars of alleen emoji's
+        zijn sowieso ruis — daar verspillen we geen LLM-call aan.
+        """
+        stripped = message.strip()
+        if len(stripped) < 4:
+            return True
+        from bouwmeester.services.llm import DataSensitivity
+        from bouwmeester.services.llm.factory import get_llm_service_for
+
+        llm = await get_llm_service_for(DataSensitivity.CONFIDENTIAL, self.session)
+        if llm is None:
+            return False
+        return await llm.is_mattermost_noise(stripped)
+
+    async def _maybe_summarize(self, message: str) -> str | None:
+        """Vat lange berichten samen via VLAM. Returns None als niet
+        gesummariseerd is."""
+        if len(message) <= 600:
+            return None
+        from bouwmeester.services.llm import DataSensitivity
+        from bouwmeester.services.llm.factory import get_llm_service_for
+
+        llm = await get_llm_service_for(DataSensitivity.CONFIDENTIAL, self.session)
+        if llm is None:
+            return None
+        summary = await llm.summarize_mattermost_message(message)
+        return summary or None
+
+    async def _create_auto_note(
+        self,
+        *,
+        lead_id: UUID,
+        post: dict,
+        message: str,
+        author_person_id: UUID | None,
+        mm_user_id: str | None,
+        post_id: str,
+        channel_id: str,
+    ) -> UUID:
+        """Schrijf een LeadActivity en eventuele doc-link-attachments."""
+        permalink = self._build_permalink(channel_id, post_id)
+        summary = await self._maybe_summarize(message)
+        body = summary or message
+        prefix = ""
+        if author_person_id is None and mm_user_id:
+            prefix = f"_(via mm:@{mm_user_id})_  \n"
+        content = prefix + body
+
+        metadata = {
+            "source": "mattermost",
+            "mm_post_id": post_id,
+            "mm_channel_id": channel_id,
+            "mm_user_id": mm_user_id,
+            "mm_root_id": post.get("root_id") or None,
+            "mm_create_at": post.get("create_at"),
+            "mm_permalink": permalink,
+        }
+        if summary:
+            metadata["mm_original"] = message
+
+        activity = LeadActivity(
+            lead_id=lead_id,
+            author_id=author_person_id,
+            content=content,
+            activity_type="note",
+            metadata_=metadata,
+        )
+        self.session.add(activity)
+        await self.session.flush()
+        await self.session.refresh(activity)
+
+        for link in extract_doc_links(message):
+            url = link["url"]
+            label = derive_attachment_label(url)
+            attachment = LeadAttachment(
+                lead_id=lead_id,
+                soort="link",
+                url=url,
+                bestandsnaam=label,
+                source="mattermost",
+                source_ref=post_id,
+            )
+            # Naïef dedupe binnen één lead: niet twee keer dezelfde URL.
+            existing = await self.session.execute(
+                select(LeadAttachment.id).where(
+                    LeadAttachment.lead_id == lead_id,
+                    LeadAttachment.url == url,
+                )
+            )
+            if existing.scalar_one_or_none() is None:
+                self.session.add(attachment)
+        await self.session.flush()
+        return activity.id
+
+    async def _create_suggested_lead(
+        self,
+        *,
+        channel_link_initiatief_id: UUID,
+        channel_display_name: str,
+        channel_id: str,
+        post: dict,
+        message: str,
+    ) -> UUID | None:
+        """Vraag VLAM of dit een lead is en maak — bij ja — een SuggestedLead
+        plus een bot-reply met approval-knoppen in de thread.
+
+        Returns ``None`` als het bericht volgens de LLM geen lead is."""
+        from bouwmeester.services.llm import DataSensitivity
+        from bouwmeester.services.llm.factory import get_llm_service_for
+
+        llm = await get_llm_service_for(DataSensitivity.CONFIDENTIAL, self.session)
+        if llm is None:
+            logger.debug("Geen CONFIDENTIAL-LLM beschikbaar — sla suggested-lead over")
+            return None
+
+        initiatief = await self.session.get(Initiatief, channel_link_initiatief_id)
+        if initiatief is None:
+            logger.warning(
+                "Initiatief %s voor kanaal-koppeling bestaat niet (meer)",
+                channel_link_initiatief_id,
+            )
+            return None
+
+        recent_leads_stmt = (
+            select(Lead.id, Lead.title, Lead.stage)
+            .where(Lead.initiatief_id == channel_link_initiatief_id)
+            .order_by(Lead.created_at.desc())
+            .limit(20)
+        )
+        rows = (await self.session.execute(recent_leads_stmt)).all()
+        recent = [
+            {"id": str(row.id), "title": row.title, "stage": row.stage} for row in rows
+        ]
+
+        result = await llm.classify_mattermost_lead_candidate(
+            message=message,
+            initiatief_naam=initiatief.naam,
+            channel_display_name=channel_display_name,
+            recent_leads=recent,
+        )
+        if not result.is_lead:
+            return None
+
+        match_lead_uuid: UUID | None = None
+        if result.match_existing_lead_id:
+            try:
+                candidate = UUID(result.match_existing_lead_id)
+            except ValueError:
+                candidate = None
+            if candidate is not None and any(
+                str(row.id) == str(candidate) for row in rows
+            ):
+                match_lead_uuid = candidate
+
+        suggested = SuggestedLead(
+            source_type="mattermost",
+            source_post_id=post["id"],
+            source_channel_id=channel_id,
+            source_root_id=post.get("root_id") or None,
+            initiatief_id=channel_link_initiatief_id,
+            proposed_title=(result.proposed_title or "Nieuwe lead vanuit Mattermost")[
+                :500
+            ],
+            proposed_description=result.proposed_description or None,
+            raw_text=message,
+            confidence=result.confidence,
+            reasoning=result.reasoning or None,
+            match_existing_lead_id=match_lead_uuid,
+            status=STATUS_PENDING,
+        )
+        self.session.add(suggested)
+        await self.session.flush()
+        await self.session.refresh(suggested)
+
+        # Post de bot-reply met knoppen — fout daar is niet fataal voor het
+        # SuggestedLead-record. Als er geen MattermostService is (test) doen
+        # we niets.
+        try:
+            await self._post_suggestion_reply(
+                channel_id=channel_id,
+                root_post_id=post.get("root_id") or post["id"],
+                suggested=suggested,
+                initiatief=initiatief,
+                match_lead=match_lead_uuid is not None,
+            )
+        except Exception:
+            logger.exception(
+                "Kon bot-reply voor suggested lead %s niet plaatsen", suggested.id
+            )
+
+        return suggested.id
+
+    async def _post_suggestion_reply(
+        self,
+        *,
+        channel_id: str,
+        root_post_id: str,
+        suggested: SuggestedLead,
+        initiatief: Initiatief,
+        match_lead: bool,
+    ) -> None:
+        """Plaats een bot-reply met interactive attachment in de thread."""
+        from bouwmeester.services.mattermost_service import MattermostService
+
+        service = MattermostService(self.session)
+        try:
+            if not await service.is_enabled():
+                return
+            text = (
+                f":dart: Ik denk dat dit een lead is voor "
+                f"**{initiatief.naam}**.\n"
+                f"_Voorstel:_ {suggested.proposed_title}\n"
+                f"_Vertrouwen:_ {int((suggested.confidence or 0) * 100)}%"
+            )
+            actions = [
+                {
+                    "id": "create_lead",
+                    "name": "Maak lead aan",
+                    "integration": {
+                        "url": (
+                            f"{service.settings.BACKEND_URL.rstrip('/')}"
+                            "/api/mattermost/action"
+                        ),
+                        "context": {
+                            "action": "create_lead_from_suggestion",
+                            "suggested_lead_id": str(suggested.id),
+                        },
+                    },
+                },
+                {
+                    "id": "reject_lead",
+                    "name": "Negeer",
+                    "integration": {
+                        "url": (
+                            f"{service.settings.BACKEND_URL.rstrip('/')}"
+                            "/api/mattermost/action"
+                        ),
+                        "context": {
+                            "action": "reject_suggestion",
+                            "suggested_lead_id": str(suggested.id),
+                        },
+                    },
+                },
+            ]
+            if match_lead:
+                actions.insert(
+                    1,
+                    {
+                        "id": "link_lead",
+                        "name": "Koppel aan bestaande lead",
+                        "integration": {
+                            "url": (
+                                f"{service.settings.BACKEND_URL.rstrip('/')}"
+                                "/api/mattermost/action"
+                            ),
+                            "context": {
+                                "action": "link_lead_to_suggestion",
+                                "suggested_lead_id": str(suggested.id),
+                            },
+                        },
+                    },
+                )
+            attachment = {
+                "color": "#3B82F6",
+                "title": suggested.proposed_title,
+                "text": suggested.proposed_description or "",
+                "footer": "Bouwmeester · suggestie vanuit Mattermost",
+                "actions": actions,
+            }
+            client = await service._get_client()
+            payload = {
+                "channel_id": channel_id,
+                "root_id": root_post_id,
+                "message": text,
+                "props": {"attachments": [attachment]},
+            }
+            resp = await client.post("/api/v4/posts", json=payload)
+            resp.raise_for_status()
+            data = resp.json()
+            mm_thread_post_id = data.get("id")
+            if mm_thread_post_id:
+                suggested.mm_thread_post_id = mm_thread_post_id
+                await self.session.flush()
+        finally:
+            await service.close()
+
+    def _build_permalink(self, channel_id: str, post_id: str) -> str | None:
+        """Best-effort permalink: ``{mm_base}/_redirect/pl/{post_id}``.
+
+        Mattermost ondersteunt een teamonafhankelijke redirect-URL voor
+        post-permalinks. Dat scheelt ons het opzoeken van de team-naam.
+        Zonder bekende base-URL geven we ``None`` terug.
+        """
+        if not self.mm_base_url:
+            return None
+        return f"{self.mm_base_url}/_redirect/pl/{post_id}"

--- a/backend/bouwmeester/services/mattermost_service.py
+++ b/backend/bouwmeester/services/mattermost_service.py
@@ -498,6 +498,31 @@ class MattermostService:
         except httpx.HTTPError:
             return mattermost_user_id
 
+    async def is_bot_member_of_channel(self, channel_id: str) -> bool:
+        """Check of de bot momenteel lid is van een kanaal.
+
+        Gebruikt het ``/channels/{id}/members/{bot_user_id}``-endpoint:
+        404 = geen lid, 200 = lid. Returns ``False`` bij elke andere
+        fout — caller behandelt dit als "kan niet bevestigen".
+        """
+        bot_user_id = await self.get_bot_user_id()
+        if not bot_user_id:
+            return False
+        client = await self._get_client()
+        try:
+            resp = await client.get(
+                f"/api/v4/channels/{channel_id}/members/{bot_user_id}"
+            )
+            if resp.status_code == 404:
+                return False
+            resp.raise_for_status()
+            return True
+        except httpx.HTTPError:
+            logger.exception(
+                "Kon bot-membership voor kanaal %s niet checken", channel_id
+            )
+            return False
+
     async def search_channels(self, query: str) -> list[dict]:
         """Zoek kanalen waar de bot in zit, gefilterd op naam.
 

--- a/backend/bouwmeester/services/mattermost_service.py
+++ b/backend/bouwmeester/services/mattermost_service.py
@@ -29,6 +29,13 @@ _mm_config_cache_ts: float = 0.0
 _MM_CONFIG_CACHE_TTL = 60  # seconds
 
 
+class MattermostUnavailableError(RuntimeError):
+    """Raised wanneer een Mattermost-API-call niet uitvoerbaar is door
+    een tijdelijk probleem (netwerk, server-fout, ontbrekende config)
+    en de caller dat niet als "expliciet nee" mag interpreteren.
+    """
+
+
 def clear_mattermost_config_cache() -> None:
     """Clear the Mattermost config cache so the next call rebuilds from DB."""
     global _mm_config_cache, _mm_config_cache_ts  # noqa: PLW0603
@@ -502,26 +509,45 @@ class MattermostService:
         """Check of de bot momenteel lid is van een kanaal.
 
         Gebruikt het ``/channels/{id}/members/{bot_user_id}``-endpoint:
-        404 = geen lid, 200 = lid. Returns ``False`` bij elke andere
-        fout — caller behandelt dit als "kan niet bevestigen".
+        - 200 → lid (``True``)
+        - 404 → expliciet geen lid (``False``)
+        - andere statussen of netwerkfout → ``MattermostUnavailableError``
+          zodat de caller onderscheid kan maken tussen "echt geen lid"
+          en "kan het niet bevestigen". Een soft-fail naar ``False``
+          zou een tijdelijke MM-storing onterecht laten lijken op een
+          weggegooide bot-membership.
         """
         bot_user_id = await self.get_bot_user_id()
         if not bot_user_id:
-            return False
+            raise MattermostUnavailableError(
+                "Bot-user-id niet beschikbaar — Mattermost niet bereikbaar"
+            )
         client = await self._get_client()
         try:
             resp = await client.get(
                 f"/api/v4/channels/{channel_id}/members/{bot_user_id}"
             )
-            if resp.status_code == 404:
-                return False
-            resp.raise_for_status()
-            return True
-        except httpx.HTTPError:
-            logger.exception(
-                "Kon bot-membership voor kanaal %s niet checken", channel_id
+        except httpx.HTTPError as exc:
+            logger.warning(
+                "Mattermost membership-check faalde voor kanaal %s: %s",
+                channel_id,
+                exc,
             )
+            raise MattermostUnavailableError(
+                f"Kon bot-membership voor kanaal {channel_id} niet checken"
+            ) from exc
+        if resp.status_code == 404:
             return False
+        if resp.status_code == 200:
+            return True
+        logger.warning(
+            "Mattermost membership-check gaf onverwachte status %s voor kanaal %s",
+            resp.status_code,
+            channel_id,
+        )
+        raise MattermostUnavailableError(
+            f"Onverwachte status {resp.status_code} bij membership-check"
+        )
 
     async def search_channels(self, query: str) -> list[dict]:
         """Zoek kanalen waar de bot in zit, gefilterd op naam.

--- a/backend/bouwmeester/services/mattermost_service.py
+++ b/backend/bouwmeester/services/mattermost_service.py
@@ -442,23 +442,35 @@ class MattermostService:
             logger.exception("Failed to poll bot DMs")
             return []
 
-    async def reply_to_post(self, channel_id: str, root_id: str, message: str) -> bool:
-        """Reply to a specific post in a channel."""
+    async def reply_to_post(
+        self,
+        channel_id: str,
+        root_id: str,
+        message: str,
+        *,
+        props: dict | None = None,
+    ) -> dict | None:
+        """Plaats een reply in dezelfde thread.
+
+        Geeft de aangemaakte post-data terug (incl. ``id``) of ``None`` bij
+        fout. Backwards compat: callers die alleen op truthy/falsy checken
+        blijven werken.
+        """
         client = await self._get_client()
         try:
-            resp = await client.post(
-                "/api/v4/posts",
-                json={
-                    "channel_id": channel_id,
-                    "root_id": root_id,
-                    "message": message,
-                },
-            )
+            payload: dict = {
+                "channel_id": channel_id,
+                "root_id": root_id,
+                "message": message,
+            }
+            if props:
+                payload["props"] = props
+            resp = await client.post("/api/v4/posts", json=payload)
             resp.raise_for_status()
-            return True
+            return resp.json()
         except httpx.HTTPError:
             logger.exception("Failed to reply to post %s", root_id)
-            return False
+            return None
 
     async def update_post(
         self, post_id: str, message: str, props: dict | None = None

--- a/backend/bouwmeester/services/mattermost_service.py
+++ b/backend/bouwmeester/services/mattermost_service.py
@@ -486,6 +486,88 @@ class MattermostService:
         except httpx.HTTPError:
             return mattermost_user_id
 
+    async def search_channels(self, query: str) -> list[dict]:
+        """Zoek kanalen waar de bot in zit, gefilterd op naam.
+
+        Returns een lijst van dicts met channel_id, channel_name,
+        channel_display_name, team_id, member_count, is_bot_member.
+
+        We zoeken alleen binnen de kanalen waarvan de bot lid is — pas
+        wanneer de bot toegevoegd wordt aan een kanaal kunnen we daar
+        meelezen.
+        """
+        bot_user_id = await self.get_bot_user_id()
+        if not bot_user_id:
+            return []
+
+        client = await self._get_client()
+        needle = query.strip().lower()
+        if not needle:
+            return []
+
+        try:
+            resp = await client.get(
+                f"/api/v4/users/{bot_user_id}/channels",
+                params={"last_delete_at": 0},
+            )
+            resp.raise_for_status()
+            channels = resp.json()
+        except httpx.HTTPError:
+            logger.exception("Failed to list bot channels")
+            return []
+
+        results: list[dict] = []
+        for ch in channels:
+            ch_type = ch.get("type")
+            # Open kanalen ("O") en private kanalen ("P"). DMs ("D") en
+            # group-DMs ("G") zijn niet relevant voor lead-koppelingen.
+            if ch_type not in ("O", "P"):
+                continue
+            name = ch.get("name", "")
+            display_name = ch.get("display_name", "") or name
+            if needle not in name.lower() and needle not in display_name.lower():
+                continue
+            results.append(
+                {
+                    "channel_id": ch.get("id", ""),
+                    "channel_name": name,
+                    "channel_display_name": display_name,
+                    "team_id": ch.get("team_id"),
+                    "member_count": ch.get("total_msg_count"),
+                    "is_bot_member": True,
+                }
+            )
+            if len(results) >= 25:
+                break
+        return results
+
+    async def get_channel_posts_since(
+        self, channel_id: str, since: int, *, per_page: int = 60
+    ) -> list[dict]:
+        """Haal posts uit een kanaal op vanaf een ms-timestamp.
+
+        Gebruikt voor recovery na websocket-reconnect. Returneert posts
+        in chronologische volgorde (oudste eerst) zodat downstream-logica
+        ze in volgorde kan verwerken.
+        """
+        client = await self._get_client()
+        try:
+            resp = await client.get(
+                f"/api/v4/channels/{channel_id}/posts",
+                params={"since": since, "per_page": per_page},
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        except httpx.HTTPError:
+            logger.exception("Failed to fetch posts for channel %s", channel_id)
+            return []
+
+        order = data.get("order", [])
+        posts_map = data.get("posts", {})
+        # `order` komt nieuw->oud terug. Zet om naar oud->nieuw.
+        posts = [posts_map.get(pid) for pid in reversed(order) if posts_map.get(pid)]
+        return posts
+
     async def close(self) -> None:
         if self._client:
             await self._client.aclose()

--- a/backend/bouwmeester/services/mattermost_slash_service.py
+++ b/backend/bouwmeester/services/mattermost_slash_service.py
@@ -1,22 +1,39 @@
 """Handlers for Mattermost slash commands and interactive button actions."""
 
 import logging
+from dataclasses import dataclass
 from datetime import date, timedelta
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from bouwmeester.core.config import get_settings
 from bouwmeester.core.query_utils import escape_like
 from bouwmeester.models.corpus_node import CorpusNode
+from bouwmeester.models.initiatief import Initiatief
+from bouwmeester.models.lead import Lead
+from bouwmeester.models.mattermost_channel_link import (
+    SCOPE_INITIATIEF,
+    SCOPE_LEAD,
+)
 from bouwmeester.models.task import Task
+from bouwmeester.repositories.mattermost_channel_link import (
+    MattermostChannelLinkRepository,
+)
 from bouwmeester.repositories.mattermost_user import MattermostUserRepository
 from bouwmeester.repositories.search import SearchRepository
 from bouwmeester.services.mattermost_utils import escape_mattermost_md as _escape_md
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _ChannelCtx:
+    channel_id: str | None
+    channel_name: str | None
+    team_id: str | None
 
 
 class MattermostSlashService:
@@ -29,23 +46,37 @@ class MattermostSlashService:
         mapping = await self.repo.get_by_mattermost_user_id(mattermost_user_id)
         return mapping.person_id if mapping else None
 
-    async def handle_command(self, mattermost_user_id: str, command_text: str) -> dict:
+    async def handle_command(
+        self,
+        mattermost_user_id: str,
+        command_text: str,
+        *,
+        channel_id: str | None = None,
+        channel_name: str | None = None,
+        team_id: str | None = None,
+    ) -> dict:
         """Route a /bouwmeester slash command to the right handler."""
         parts = command_text.split(maxsplit=1)
         subcommand = parts[0].lower() if parts else "help"
         args = parts[1].strip() if len(parts) > 1 else ""
 
+        ch_ctx = _ChannelCtx(channel_id, channel_name, team_id)
         handlers = {
             "taken": self._handle_taken,
             "zoek": self._handle_zoek,
             "status": self._handle_status,
             "help": self._handle_help,
+            "koppel": self._handle_koppel,
+            "ontkoppel": self._handle_ontkoppel,
+            "kanaal": self._handle_kanaal_status,
         }
 
         handler = handlers.get(subcommand, self._handle_help)
-        return await handler(mattermost_user_id, args)
+        return await handler(mattermost_user_id, args, ch_ctx)
 
-    async def _handle_taken(self, mattermost_user_id: str, args: str) -> dict:
+    async def _handle_taken(
+        self, mattermost_user_id: str, args: str, _ch: _ChannelCtx
+    ) -> dict:
         """List the user's open tasks, optionally filtered by deadline."""
         person_id = await self._resolve_person_id(mattermost_user_id)
         if not person_id:
@@ -103,7 +134,9 @@ class MattermostSlashService:
 
         return _ephemeral("\n".join(lines))
 
-    async def _handle_zoek(self, mattermost_user_id: str, args: str) -> dict:
+    async def _handle_zoek(
+        self, mattermost_user_id: str, args: str, _ch: _ChannelCtx
+    ) -> dict:
         """Full-text search in the corpus."""
         if not args:
             return _ephemeral("Gebruik: `/bouwmeester zoek <zoekterm>`")
@@ -131,7 +164,9 @@ class MattermostSlashService:
 
         return _ephemeral("\n".join(lines))
 
-    async def _handle_status(self, mattermost_user_id: str, args: str) -> dict:
+    async def _handle_status(
+        self, mattermost_user_id: str, args: str, _ch: _ChannelCtx
+    ) -> dict:
         """Show status of a dossier (open/total task counts)."""
         if not args:
             return _ephemeral("Gebruik: `/bouwmeester status <dossiernaam>`")
@@ -180,15 +215,218 @@ class MattermostSlashService:
             f"- Totaal taken: {row.total}\n"
         )
 
-    async def _handle_help(self, mattermost_user_id: str, args: str) -> dict:
+    async def _handle_help(
+        self, mattermost_user_id: str, args: str, _ch: _ChannelCtx
+    ) -> dict:
         """Show available commands."""
         return _ephemeral(
             "**Bouwmeester commando's:**\n"
             "- `/bouwmeester taken [vandaag|week|alles]` — Jouw open taken\n"
             "- `/bouwmeester zoek <term>` — Zoek in het corpus\n"
             "- `/bouwmeester status <dossier>` — Status van een dossier\n"
+            "- `/bouwmeester koppel initiatief <slug-of-naam>` — "
+            "koppel dit kanaal aan een initiatief\n"
+            "- `/bouwmeester koppel lead <id-of-titel>` — "
+            "koppel dit kanaal aan een lead\n"
+            "- `/bouwmeester ontkoppel` — verwijder de kanaal-koppeling\n"
+            "- `/bouwmeester kanaal` — toon de huidige koppeling\n"
             "- `/bouwmeester help` — Dit overzicht\n"
         )
+
+    # ---------------------------------------------------------------------
+    # Kanaal-koppelen
+    # ---------------------------------------------------------------------
+
+    async def _handle_koppel(
+        self, mattermost_user_id: str, args: str, ch: _ChannelCtx
+    ) -> dict:
+        """Koppel het kanaal waarin het commando staat aan initiatief/lead."""
+        if not ch.channel_id or not ch.channel_name:
+            return _ephemeral("Ik kan dit kanaal niet bepalen vanuit het commando.")
+        person_id = await self._resolve_person_id(mattermost_user_id)
+        if not person_id:
+            return _ephemeral(
+                "Je Mattermost-account is niet gekoppeld aan Bouwmeester. "
+                "Ga naar Instellingen om te koppelen."
+            )
+
+        parts = args.split(maxsplit=1)
+        if len(parts) < 2:
+            return _ephemeral(
+                "Gebruik: `/bouwmeester koppel initiatief <slug-of-naam>` of "
+                "`/bouwmeester koppel lead <id-of-titel>`."
+            )
+        kind = parts[0].lower()
+        query = parts[1].strip()
+        if kind not in ("initiatief", "lead"):
+            return _ephemeral("Eerste argument moet `initiatief` of `lead` zijn.")
+
+        link_repo = MattermostChannelLinkRepository(self.session)
+        existing = await link_repo.get_by_channel_id(ch.channel_id)
+        if existing is not None:
+            return _ephemeral(
+                "Dit kanaal is al gekoppeld. Gebruik `/bouwmeester ontkoppel` "
+                "om de bestaande koppeling te verwijderen."
+            )
+
+        if kind == "initiatief":
+            target = await self._lookup_initiatief(query, person_id)
+            if target is None:
+                return _ephemeral(
+                    f"Geen initiatief gevonden voor '{_escape_md(query)}' "
+                    "(of geen toegang)."
+                )
+            await link_repo.create(
+                channel_id=ch.channel_id,
+                channel_name=ch.channel_name,
+                channel_display_name=ch.channel_name,
+                team_id=ch.team_id,
+                scope_type=SCOPE_INITIATIEF,
+                scope_id=target.id,
+                auto_note_enabled=False,
+                suggest_leads_enabled=True,
+                created_by_id=person_id,
+            )
+            return _ephemeral(
+                f":link: Kanaal gekoppeld aan **{_escape_md(target.naam)}**. "
+                "Nieuwe berichten worden voortaan voorgesteld als lead."
+            )
+
+        target_lead = await self._lookup_lead(query, person_id)
+        if target_lead is None:
+            return _ephemeral(
+                f"Geen lead gevonden voor '{_escape_md(query)}' (of geen toegang)."
+            )
+        await link_repo.create(
+            channel_id=ch.channel_id,
+            channel_name=ch.channel_name,
+            channel_display_name=ch.channel_name,
+            team_id=ch.team_id,
+            scope_type=SCOPE_LEAD,
+            scope_id=target_lead.id,
+            auto_note_enabled=True,
+            suggest_leads_enabled=False,
+            created_by_id=person_id,
+        )
+        return _ephemeral(
+            f":link: Kanaal gekoppeld aan lead **{_escape_md(target_lead.title)}**. "
+            "Berichten in dit kanaal worden notities op de lead."
+        )
+
+    async def _handle_ontkoppel(
+        self, mattermost_user_id: str, args: str, ch: _ChannelCtx
+    ) -> dict:
+        if not ch.channel_id:
+            return _ephemeral("Ik kan dit kanaal niet bepalen.")
+        person_id = await self._resolve_person_id(mattermost_user_id)
+        if not person_id:
+            return _ephemeral("Je account is niet gekoppeld.")
+
+        link_repo = MattermostChannelLinkRepository(self.session)
+        link = await link_repo.get_by_channel_id(ch.channel_id)
+        if link is None:
+            return _ephemeral("Dit kanaal is niet gekoppeld.")
+        await link_repo.delete(link)
+        return _ephemeral(":wastebasket: Koppeling verwijderd.")
+
+    async def _handle_kanaal_status(
+        self, mattermost_user_id: str, args: str, ch: _ChannelCtx
+    ) -> dict:
+        if not ch.channel_id:
+            return _ephemeral("Ik kan dit kanaal niet bepalen.")
+        link_repo = MattermostChannelLinkRepository(self.session)
+        link = await link_repo.get_by_channel_id(ch.channel_id)
+        if link is None:
+            return _ephemeral(
+                "Dit kanaal is niet gekoppeld. Gebruik "
+                "`/bouwmeester koppel initiatief|lead <…>` om te koppelen."
+            )
+        if link.scope_type == SCOPE_INITIATIEF:
+            init = await self.session.get(Initiatief, link.scope_id)
+            naam = init.naam if init else str(link.scope_id)
+            return _ephemeral(
+                f":link: Gekoppeld aan initiatief **{_escape_md(naam)}**. "
+                f"Auto-note: {'aan' if link.auto_note_enabled else 'uit'} · "
+                f"Suggesties: {'aan' if link.suggest_leads_enabled else 'uit'}"
+            )
+        lead = await self.session.get(Lead, link.scope_id)
+        titel = lead.title if lead else str(link.scope_id)
+        return _ephemeral(
+            f":link: Gekoppeld aan lead **{_escape_md(titel)}**. "
+            f"Auto-note: {'aan' if link.auto_note_enabled else 'uit'} · "
+            f"Suggesties: {'aan' if link.suggest_leads_enabled else 'uit'}"
+        )
+
+    async def _lookup_initiatief(
+        self, query: str, person_id: UUID
+    ) -> Initiatief | None:
+        """Zoek initiatief op slug of naam, gerespecteerd door visibility."""
+        from bouwmeester.core.initiatief_context import build_initiatief_context
+        from bouwmeester.models.person import Person
+
+        person = await self.session.get(Person, person_id)
+        if person is None:
+            return None
+        ctx = await build_initiatief_context(self.session, person)
+        if not ctx.is_admin and not ctx.visible_initiatief_ids:
+            return None
+
+        escaped = escape_like(query)
+        stmt = select(Initiatief).where(
+            or_(
+                Initiatief.slug == query,
+                Initiatief.naam.ilike(f"%{escaped}%", escape="\\"),
+            )
+        )
+        if not ctx.is_admin:
+            stmt = stmt.where(Initiatief.id.in_(ctx.visible_initiatief_ids))
+        stmt = stmt.limit(1)
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def _lookup_lead(self, query: str, person_id: UUID) -> Lead | None:
+        """Zoek lead op id of titel; respecteer initiatief-visibility."""
+        # Probeer eerst exact UUID-match.
+        try:
+            lead_uuid = UUID(query)
+        except ValueError:
+            lead_uuid = None
+
+        from bouwmeester.core.initiatief_context import build_initiatief_context
+        from bouwmeester.models.person import Person
+
+        person = await self.session.get(Person, person_id)
+        if person is None:
+            return None
+        ctx = await build_initiatief_context(self.session, person)
+
+        if lead_uuid is not None:
+            lead = await self.session.get(Lead, lead_uuid)
+            if lead is None:
+                return None
+            if ctx.is_admin:
+                return lead
+            if (
+                lead.initiatief_id is None
+                or lead.initiatief_id in ctx.visible_initiatief_ids
+            ):
+                return lead
+            return None
+
+        escaped = escape_like(query)
+        stmt = select(Lead).where(
+            Lead.title.ilike(f"%{escaped}%", escape="\\"),
+        )
+        if not ctx.is_admin:
+            stmt = stmt.where(
+                or_(
+                    Lead.initiatief_id.is_(None),
+                    Lead.initiatief_id.in_(ctx.visible_initiatief_ids),
+                )
+            )
+        stmt = stmt.limit(1)
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
 
     # ---------------------------------------------------------------------------
     # Interactive button actions
@@ -200,6 +438,16 @@ class MattermostSlashService:
         """Handle an interactive button click."""
         if action == "complete_task":
             return await self._action_complete_task(mattermost_user_id, context)
+        if action == "create_lead_from_suggestion":
+            return await self._action_create_lead_from_suggestion(
+                mattermost_user_id, context
+            )
+        if action == "link_lead_to_suggestion":
+            return await self._action_link_lead_to_suggestion(
+                mattermost_user_id, context
+            )
+        if action == "reject_suggestion":
+            return await self._action_reject_suggestion(mattermost_user_id, context)
         return {"ephemeral_text": "Onbekende actie."}
 
     async def _action_complete_task(
@@ -265,6 +513,221 @@ class MattermostSlashService:
                 },
             },
         }
+
+    # ------------------------------------------------------------------
+    # Suggested-lead approval
+    # ------------------------------------------------------------------
+
+    async def _action_create_lead_from_suggestion(
+        self, mattermost_user_id: str, context: dict
+    ) -> dict:
+        """Klik 'Maak lead aan' onder een MM-suggestie."""
+        person_id = await self._resolve_person_id(mattermost_user_id)
+        if not person_id:
+            return _ephemeral("Je account is niet gekoppeld.")
+
+        suggested = await self._get_suggestion(context)
+        if isinstance(suggested, dict):
+            return suggested
+        if suggested.status != "pending":
+            return _ephemeral("Deze suggestie is al verwerkt.")
+        if not await self._has_initiatief_access(person_id, suggested.initiatief_id):
+            return _ephemeral("Je hebt geen toegang tot dit initiatief.")
+
+        from bouwmeester.models.lead import Lead
+
+        lead = Lead(
+            title=suggested.proposed_title or "Nieuwe lead vanuit Mattermost",
+            description=suggested.proposed_description or None,
+            initiatief_id=suggested.initiatief_id,
+            stage="inbox",
+            raw_intake_text=suggested.raw_text,
+            brought_by_id=person_id,
+        )
+        self.session.add(lead)
+        await self.session.flush()
+        await self.session.refresh(lead)
+
+        # Eerste activiteit: het oorspronkelijke MM-bericht.
+        from bouwmeester.models.lead_activity import LeadActivity
+
+        self.session.add(
+            LeadActivity(
+                lead_id=lead.id,
+                author_id=person_id,
+                content=suggested.raw_text or "",
+                activity_type="note",
+                metadata_={
+                    "source": "mattermost",
+                    "mm_post_id": suggested.source_post_id,
+                    "mm_channel_id": suggested.source_channel_id,
+                },
+            )
+        )
+
+        suggested.status = "approved_new"
+        suggested.approved_lead_id = lead.id
+        suggested.review_source = "mattermost"
+        suggested.reviewed_by_id = person_id
+        from datetime import UTC, datetime
+
+        suggested.reviewed_at = datetime.now(UTC)
+        await self.session.flush()
+
+        await self._update_thread_post(
+            suggested,
+            text=f":white_check_mark: Lead aangemaakt: **{_escape_md(lead.title)}**",
+            color="#22C55E",
+        )
+        return {"ephemeral_text": "Lead aangemaakt in Bouwmeester."}
+
+    async def _action_link_lead_to_suggestion(
+        self, mattermost_user_id: str, context: dict
+    ) -> dict:
+        """Klik 'Koppel aan bestaande lead' — gebruikt match_existing_lead_id
+        van de suggestie. (Een echte multi-keuze-dialog houden we voor later.)"""
+        person_id = await self._resolve_person_id(mattermost_user_id)
+        if not person_id:
+            return _ephemeral("Je account is niet gekoppeld.")
+
+        suggested = await self._get_suggestion(context)
+        if isinstance(suggested, dict):
+            return suggested
+        if suggested.status != "pending":
+            return _ephemeral("Deze suggestie is al verwerkt.")
+        if not await self._has_initiatief_access(person_id, suggested.initiatief_id):
+            return _ephemeral("Je hebt geen toegang tot dit initiatief.")
+        if suggested.match_existing_lead_id is None:
+            return _ephemeral(
+                "Geen kandidaat-lead bekend. Maak een nieuwe lead aan of negeer."
+            )
+
+        from bouwmeester.models.lead import Lead
+        from bouwmeester.models.lead_activity import LeadActivity
+
+        lead = await self.session.get(Lead, suggested.match_existing_lead_id)
+        if lead is None:
+            return _ephemeral("De gekoppelde lead bestaat niet meer.")
+
+        self.session.add(
+            LeadActivity(
+                lead_id=lead.id,
+                author_id=person_id,
+                content=suggested.raw_text or "",
+                activity_type="note",
+                metadata_={
+                    "source": "mattermost",
+                    "mm_post_id": suggested.source_post_id,
+                    "mm_channel_id": suggested.source_channel_id,
+                },
+            )
+        )
+
+        suggested.status = "approved_linked"
+        suggested.approved_lead_id = lead.id
+        suggested.review_source = "mattermost"
+        suggested.reviewed_by_id = person_id
+        from datetime import UTC, datetime
+
+        suggested.reviewed_at = datetime.now(UTC)
+        await self.session.flush()
+
+        await self._update_thread_post(
+            suggested,
+            text=f":link: Gekoppeld aan lead **{_escape_md(lead.title)}**",
+            color="#3B82F6",
+        )
+        return {"ephemeral_text": "Bericht gekoppeld als notitie aan de lead."}
+
+    async def _action_reject_suggestion(
+        self, mattermost_user_id: str, context: dict
+    ) -> dict:
+        person_id = await self._resolve_person_id(mattermost_user_id)
+        if not person_id:
+            return _ephemeral("Je account is niet gekoppeld.")
+        suggested = await self._get_suggestion(context)
+        if isinstance(suggested, dict):
+            return suggested
+        if suggested.status != "pending":
+            return _ephemeral("Deze suggestie is al verwerkt.")
+
+        suggested.status = "rejected"
+        suggested.review_source = "mattermost"
+        suggested.reviewed_by_id = person_id
+        from datetime import UTC, datetime
+
+        suggested.reviewed_at = datetime.now(UTC)
+        await self.session.flush()
+
+        await self._update_thread_post(
+            suggested,
+            text=":no_entry_sign: Suggestie genegeerd.",
+            color="#94A3B8",
+        )
+        return {"ephemeral_text": "Suggestie genegeerd."}
+
+    async def _get_suggestion(self, context: dict):
+        from bouwmeester.models.suggested_lead import SuggestedLead
+
+        sid_str = context.get("suggested_lead_id")
+        if not sid_str:
+            return _ephemeral("Geen suggestie-id meegegeven.")
+        try:
+            sid = UUID(sid_str)
+        except (ValueError, AttributeError):
+            return _ephemeral("Ongeldig suggestie-id.")
+        suggested = await self.session.get(SuggestedLead, sid)
+        if suggested is None:
+            return _ephemeral("Suggestie niet gevonden.")
+        return suggested
+
+    async def _has_initiatief_access(
+        self, person_id: UUID, initiatief_id: UUID
+    ) -> bool:
+        from bouwmeester.core.initiatief_context import build_initiatief_context
+        from bouwmeester.models.person import Person
+
+        person = await self.session.get(Person, person_id)
+        if person is None:
+            return False
+        ctx = await build_initiatief_context(self.session, person)
+        return ctx.is_admin or initiatief_id in ctx.visible_initiatief_ids
+
+    async def _update_thread_post(self, suggested, *, text: str, color: str) -> None:
+        if not suggested.mm_thread_post_id:
+            return
+        from bouwmeester.services.mattermost_service import MattermostService
+
+        service = MattermostService(self.session)
+        try:
+            if not await service.is_enabled():
+                return
+            client = await service._get_client()
+            payload = {
+                "id": suggested.mm_thread_post_id,
+                "message": text,
+                "props": {
+                    "attachments": [
+                        {
+                            "color": color,
+                            "text": text,
+                            "footer": "Bouwmeester · suggestie verwerkt",
+                        }
+                    ]
+                },
+            }
+            try:
+                resp = await client.put(
+                    f"/api/v4/posts/{suggested.mm_thread_post_id}", json=payload
+                )
+                resp.raise_for_status()
+            except Exception:
+                logger.exception(
+                    "Kon thread-post %s niet updaten",
+                    suggested.mm_thread_post_id,
+                )
+        finally:
+            await service.close()
 
 
 def _ephemeral(text: str) -> dict:

--- a/backend/bouwmeester/services/mattermost_slash_service.py
+++ b/backend/bouwmeester/services/mattermost_slash_service.py
@@ -435,7 +435,13 @@ class MattermostSlashService:
     async def handle_action(
         self, mattermost_user_id: str, action: str, context: dict
     ) -> dict:
-        """Handle an interactive button click."""
+        """Handle an interactive button click.
+
+        Mattermost interactive response-shape: ``{"ephemeral_text": "..."}``
+        voor in-line feedback aan de klikker, of ``{"update": {...}}`` om
+        de oorspronkelijke post te overschrijven. Dit verschilt van de
+        slash-command-shape (``{"response_type": "ephemeral", "text": ...}``).
+        """
         if action == "complete_task":
             return await self._action_complete_task(mattermost_user_id, context)
         if action == "create_lead_from_suggestion":
@@ -524,15 +530,15 @@ class MattermostSlashService:
         """Klik 'Maak lead aan' onder een MM-suggestie."""
         person_id = await self._resolve_person_id(mattermost_user_id)
         if not person_id:
-            return _ephemeral("Je account is niet gekoppeld.")
+            return _action_msg("Je account is niet gekoppeld.")
 
-        suggested = await self._get_suggestion(context)
+        suggested = await self._lock_suggestion(context)
         if isinstance(suggested, dict):
             return suggested
         if suggested.status != "pending":
-            return _ephemeral("Deze suggestie is al verwerkt.")
+            return _action_msg("Deze suggestie is al verwerkt.")
         if not await self._has_initiatief_access(person_id, suggested.initiatief_id):
-            return _ephemeral("Je hebt geen toegang tot dit initiatief.")
+            return _action_msg("Je hebt geen toegang tot dit initiatief.")
 
         from bouwmeester.models.lead import Lead
 
@@ -565,13 +571,8 @@ class MattermostSlashService:
             )
         )
 
-        suggested.status = "approved_new"
+        self._mark_reviewed(suggested, person_id, status="approved_new")
         suggested.approved_lead_id = lead.id
-        suggested.review_source = "mattermost"
-        suggested.reviewed_by_id = person_id
-        from datetime import UTC, datetime
-
-        suggested.reviewed_at = datetime.now(UTC)
         await self.session.flush()
 
         await self._update_thread_post(
@@ -579,7 +580,7 @@ class MattermostSlashService:
             text=f":white_check_mark: Lead aangemaakt: **{_escape_md(lead.title)}**",
             color="#22C55E",
         )
-        return {"ephemeral_text": "Lead aangemaakt in Bouwmeester."}
+        return _action_msg("Lead aangemaakt in Bouwmeester.")
 
     async def _action_link_lead_to_suggestion(
         self, mattermost_user_id: str, context: dict
@@ -588,17 +589,17 @@ class MattermostSlashService:
         van de suggestie. (Een echte multi-keuze-dialog houden we voor later.)"""
         person_id = await self._resolve_person_id(mattermost_user_id)
         if not person_id:
-            return _ephemeral("Je account is niet gekoppeld.")
+            return _action_msg("Je account is niet gekoppeld.")
 
-        suggested = await self._get_suggestion(context)
+        suggested = await self._lock_suggestion(context)
         if isinstance(suggested, dict):
             return suggested
         if suggested.status != "pending":
-            return _ephemeral("Deze suggestie is al verwerkt.")
+            return _action_msg("Deze suggestie is al verwerkt.")
         if not await self._has_initiatief_access(person_id, suggested.initiatief_id):
-            return _ephemeral("Je hebt geen toegang tot dit initiatief.")
+            return _action_msg("Je hebt geen toegang tot dit initiatief.")
         if suggested.match_existing_lead_id is None:
-            return _ephemeral(
+            return _action_msg(
                 "Geen kandidaat-lead bekend. Maak een nieuwe lead aan of negeer."
             )
 
@@ -607,7 +608,11 @@ class MattermostSlashService:
 
         lead = await self.session.get(Lead, suggested.match_existing_lead_id)
         if lead is None:
-            return _ephemeral("De gekoppelde lead bestaat niet meer.")
+            return _action_msg("De gekoppelde lead bestaat niet meer.")
+        # Verifieer dat de lead nog bij hetzelfde initiatief hoort — voorkomt
+        # cross-initiatief-leak via een geknoeide context of LLM-suggestie.
+        if lead.initiatief_id != suggested.initiatief_id:
+            return _action_msg("Lead hoort niet bij dit initiatief.")
 
         self.session.add(
             LeadActivity(
@@ -623,13 +628,8 @@ class MattermostSlashService:
             )
         )
 
-        suggested.status = "approved_linked"
+        self._mark_reviewed(suggested, person_id, status="approved_linked")
         suggested.approved_lead_id = lead.id
-        suggested.review_source = "mattermost"
-        suggested.reviewed_by_id = person_id
-        from datetime import UTC, datetime
-
-        suggested.reviewed_at = datetime.now(UTC)
         await self.session.flush()
 
         await self._update_thread_post(
@@ -637,26 +637,23 @@ class MattermostSlashService:
             text=f":link: Gekoppeld aan lead **{_escape_md(lead.title)}**",
             color="#3B82F6",
         )
-        return {"ephemeral_text": "Bericht gekoppeld als notitie aan de lead."}
+        return _action_msg("Bericht gekoppeld als notitie aan de lead.")
 
     async def _action_reject_suggestion(
         self, mattermost_user_id: str, context: dict
     ) -> dict:
         person_id = await self._resolve_person_id(mattermost_user_id)
         if not person_id:
-            return _ephemeral("Je account is niet gekoppeld.")
-        suggested = await self._get_suggestion(context)
+            return _action_msg("Je account is niet gekoppeld.")
+        suggested = await self._lock_suggestion(context)
         if isinstance(suggested, dict):
             return suggested
         if suggested.status != "pending":
-            return _ephemeral("Deze suggestie is al verwerkt.")
+            return _action_msg("Deze suggestie is al verwerkt.")
+        if not await self._has_initiatief_access(person_id, suggested.initiatief_id):
+            return _action_msg("Je hebt geen toegang tot dit initiatief.")
 
-        suggested.status = "rejected"
-        suggested.review_source = "mattermost"
-        suggested.reviewed_by_id = person_id
-        from datetime import UTC, datetime
-
-        suggested.reviewed_at = datetime.now(UTC)
+        self._mark_reviewed(suggested, person_id, status="rejected")
         await self.session.flush()
 
         await self._update_thread_post(
@@ -664,21 +661,36 @@ class MattermostSlashService:
             text=":no_entry_sign: Suggestie genegeerd.",
             color="#94A3B8",
         )
-        return {"ephemeral_text": "Suggestie genegeerd."}
+        return _action_msg("Suggestie genegeerd.")
 
-    async def _get_suggestion(self, context: dict):
+    @staticmethod
+    def _mark_reviewed(suggested, person_id: UUID, *, status: str) -> None:
+        from datetime import UTC, datetime
+
+        suggested.status = status
+        suggested.review_source = "mattermost"
+        suggested.reviewed_by_id = person_id
+        suggested.reviewed_at = datetime.now(UTC)
+
+    async def _lock_suggestion(self, context: dict):
+        """Lock-and-load: voorkomt dat twee gelijktijdige knop-clicks tegelijk
+        twee Lead-records aanmaken. ``with_for_update`` blokkeert tot de
+        andere transactie commit/rollback doet, en daarna leest de tweede
+        de bijgewerkte status (pending → approved_*) en valt netjes om in
+        "Deze suggestie is al verwerkt."""
         from bouwmeester.models.suggested_lead import SuggestedLead
 
         sid_str = context.get("suggested_lead_id")
         if not sid_str:
-            return _ephemeral("Geen suggestie-id meegegeven.")
+            return _action_msg("Geen suggestie-id meegegeven.")
         try:
             sid = UUID(sid_str)
         except (ValueError, AttributeError):
-            return _ephemeral("Ongeldig suggestie-id.")
-        suggested = await self.session.get(SuggestedLead, sid)
+            return _action_msg("Ongeldig suggestie-id.")
+        stmt = select(SuggestedLead).where(SuggestedLead.id == sid).with_for_update()
+        suggested = (await self.session.execute(stmt)).scalar_one_or_none()
         if suggested is None:
-            return _ephemeral("Suggestie niet gevonden.")
+            return _action_msg("Suggestie niet gevonden.")
         return suggested
 
     async def _has_initiatief_access(
@@ -702,11 +714,10 @@ class MattermostSlashService:
         try:
             if not await service.is_enabled():
                 return
-            client = await service._get_client()
-            payload = {
-                "id": suggested.mm_thread_post_id,
-                "message": text,
-                "props": {
+            ok = await service.update_post(
+                suggested.mm_thread_post_id,
+                text,
+                props={
                     "attachments": [
                         {
                             "color": color,
@@ -715,15 +726,10 @@ class MattermostSlashService:
                         }
                     ]
                 },
-            }
-            try:
-                resp = await client.put(
-                    f"/api/v4/posts/{suggested.mm_thread_post_id}", json=payload
-                )
-                resp.raise_for_status()
-            except Exception:
-                logger.exception(
-                    "Kon thread-post %s niet updaten",
+            )
+            if not ok:
+                logger.warning(
+                    "Update van thread-post %s gaf geen success terug",
                     suggested.mm_thread_post_id,
                 )
         finally:
@@ -731,5 +737,15 @@ class MattermostSlashService:
 
 
 def _ephemeral(text: str) -> dict:
-    """Build an ephemeral (only visible to requester) response."""
+    """Slash-command response — alleen zichtbaar voor de uitvoerder.
+
+    Mattermost interpreteert ``response_type: ephemeral`` voor
+    slash-commando's. Voor button-action responses verwacht MM een ander
+    veld (``ephemeral_text``); gebruik daarvoor :func:`_action_msg`.
+    """
     return {"response_type": "ephemeral", "text": text}
+
+
+def _action_msg(text: str) -> dict:
+    """Interactive button action response — alleen zichtbaar voor de klikker."""
+    return {"ephemeral_text": text}

--- a/backend/bouwmeester/services/mattermost_websocket_service.py
+++ b/backend/bouwmeester/services/mattermost_websocket_service.py
@@ -47,6 +47,36 @@ def _ws_url_from_http(http_url: str) -> str:
     return f"{scheme}://{netloc}/api/v4/websocket"
 
 
+async def disable_channel_link(
+    session: AsyncSession, channel_id: str, *, event: str = "manual"
+) -> bool:
+    """Zet ``disabled_at`` op een ``MattermostChannelLink``.
+
+    Module-level zodat tests dit pad kunnen oefenen zonder de hele
+    websocket-loop te mocken. Returns ``True`` als de link bestond en is
+    bijgewerkt, ``False`` als hij niet bestond of al disabled was.
+    """
+    from datetime import UTC, datetime
+
+    from bouwmeester.repositories.mattermost_channel_link import (
+        MattermostChannelLinkRepository,
+    )
+
+    repo = MattermostChannelLinkRepository(session)
+    link = await repo.get_by_channel_id(channel_id)
+    if link is None or link.disabled_at is not None:
+        return False
+    link.disabled_at = datetime.now(UTC)
+    await session.flush()
+    logger.info(
+        "Channel-link %s uitgeschakeld via event=%s op kanaal %s",
+        link.id,
+        event,
+        channel_id,
+    )
+    return True
+
+
 class MattermostWebsocketService:
     """Eén persistente websocket-verbinding voor het meelezen.
 
@@ -225,50 +255,38 @@ class MattermostWebsocketService:
         verwijderde user) en ``channel_id`` in ``broadcast`` of ``data``.
         We schakelen de koppeling alleen uit als het de bot zelf is.
         """
-        data = msg.get("data") or {}
-        broadcast = msg.get("broadcast") or {}
-
-        if event == "user_removed":
-            removed_user_id = data.get("user_id") or broadcast.get("user_id")
-            if not removed_user_id or removed_user_id != self._bot_user_id:
-                return
-            channel_id = data.get("channel_id") or broadcast.get("channel_id")
-        else:  # channel_deleted
-            channel_id = (
-                data.get("channel_id")
-                or broadcast.get("channel_id")
-                or (data.get("channel") or {}).get("id")
-            )
-
+        channel_id = self._channel_lost_channel_id(event, msg)
         if not channel_id:
             return
 
         async with async_session() as session:
             try:
-                from datetime import UTC, datetime
-
-                from bouwmeester.repositories.mattermost_channel_link import (
-                    MattermostChannelLinkRepository,
-                )
-
-                repo = MattermostChannelLinkRepository(session)
-                link = await repo.get_by_channel_id(channel_id)
-                if link is None or link.disabled_at is not None:
-                    return
-                link.disabled_at = datetime.now(UTC)
-                await session.flush()
+                await disable_channel_link(session, channel_id, event=event)
                 await session.commit()
-                logger.info(
-                    "Channel-link %s uitgeschakeld na %s op kanaal %s",
-                    link.id,
-                    event,
-                    channel_id,
-                )
             except Exception:
                 await session.rollback()
                 logger.exception(
                     "Kon channel-link voor %s niet uitschakelen", channel_id
                 )
+
+    def _channel_lost_channel_id(self, event: str, msg: dict) -> str | None:
+        """Pure helper — pikt de juiste channel_id op, mits het de bot
+        zelf is die uit het kanaal is. Geen DB-toegang, makkelijk te
+        testen met dummy event-payloads."""
+        data = msg.get("data") or {}
+        broadcast = msg.get("broadcast") or {}
+        if event == "user_removed":
+            removed_user_id = data.get("user_id") or broadcast.get("user_id")
+            if not removed_user_id or removed_user_id != self._bot_user_id:
+                return None
+            return data.get("channel_id") or broadcast.get("channel_id")
+        if event == "channel_deleted":
+            return (
+                data.get("channel_id")
+                or broadcast.get("channel_id")
+                or (data.get("channel") or {}).get("id")
+            )
+        return None
 
     async def _record_post(self, session: AsyncSession, post: dict) -> None:
         """Verwerk één Mattermost-post via :class:`MattermostIngestService`."""

--- a/backend/bouwmeester/services/mattermost_websocket_service.py
+++ b/backend/bouwmeester/services/mattermost_websocket_service.py
@@ -1,0 +1,317 @@
+"""Persistente Mattermost-websocket voor het meelezen in gekoppelde kanalen.
+
+Skeleton-versie (PR1): connect/auth/heartbeat/reconnect, filter op
+gekoppelde kanalen, schrijf voor elke post een idempotency-record naar
+``mattermost_post_link``. Verwerking (auto-note, suggested-lead) volgt in
+PR2/PR3 via een ``MattermostIngestService``.
+
+Protocol-referentie: het Mattermost websocket-protocol uit
+`claude-threads/src/platform/mattermost/client.ts`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from urllib.parse import urlparse
+
+import httpx
+import websockets
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bouwmeester.core.database import async_session
+from bouwmeester.models.mattermost_channel_link import MattermostChannelLink
+from bouwmeester.models.mattermost_post_link import MattermostPostLink
+from bouwmeester.repositories.mattermost_channel_link import (
+    MattermostChannelLinkRepository,
+)
+from bouwmeester.repositories.mattermost_user import MattermostUserRepository
+from bouwmeester.services.mattermost_service import (
+    MattermostService,
+    _load_mattermost_config,
+)
+
+logger = logging.getLogger(__name__)
+
+
+_HEARTBEAT_INTERVAL = 30.0  # sec
+_RECONNECT_BACKOFF_BASE = 2.0
+_RECONNECT_BACKOFF_MAX = 60.0
+_BACKOFF_RESET_AFTER_HEALTHY_SEC = 120.0
+
+
+def _ws_url_from_http(http_url: str) -> str:
+    """Vervang het scheme zodat http(s) → ws(s) en plak `/api/v4/websocket`."""
+    parsed = urlparse(http_url.rstrip("/"))
+    scheme = "wss" if parsed.scheme == "https" else "ws"
+    netloc = parsed.netloc
+    return f"{scheme}://{netloc}/api/v4/websocket"
+
+
+class MattermostWebsocketService:
+    """Eén persistente websocket-verbinding voor het meelezen.
+
+    Loop-pattern: ``run()`` blijft draaien tot de event-loop hem stopt.
+    Bij disconnects past hij exponential backoff toe binnen dezelfde call.
+    """
+
+    def __init__(self) -> None:
+        self._seq = 0
+        self._stop = False
+        self._bot_user_id: str | None = None
+
+    async def run(self) -> None:
+        """Hoofdloop: connect, auth, lees events, reconnect bij disconnect."""
+        backoff = _RECONNECT_BACKOFF_BASE
+        while not self._stop:
+            connected_at: float | None = None
+            try:
+                async with async_session() as bootstrap:
+                    config = await _load_mattermost_config(bootstrap)
+                enabled = (config.get("MATTERMOST_ENABLED") or "").lower()
+                if enabled in ("", "false", "0"):
+                    await asyncio.sleep(_RECONNECT_BACKOFF_MAX)
+                    continue
+
+                http_url = config.get("MATTERMOST_URL", "")
+                token = config.get("MATTERMOST_BOT_TOKEN", "")
+                if not http_url or not token:
+                    logger.debug("Mattermost niet geconfigureerd, skip websocket-loop")
+                    await asyncio.sleep(_RECONNECT_BACKOFF_MAX)
+                    continue
+
+                ws_url = _ws_url_from_http(http_url)
+                logger.info("Mattermost websocket: connect %s", ws_url)
+                async with websockets.connect(
+                    ws_url, ping_interval=None, max_size=2 * 1024 * 1024
+                ) as ws:
+                    connected_at = time.monotonic()
+                    await self._authenticate(ws, token)
+                    await self._resolve_bot_user_id()
+                    await self._recover_missed_posts()
+                    await self._read_loop(ws)
+                    backoff = _RECONNECT_BACKOFF_BASE
+            except asyncio.CancelledError:
+                logger.info("Mattermost websocket: loop cancelled")
+                raise
+            except Exception:
+                logger.exception(
+                    "Mattermost websocket: error, reconnect in %.1fs", backoff
+                )
+
+            if self._stop:
+                break
+
+            # Reset backoff als we lang stabiel verbonden waren.
+            if (
+                connected_at is not None
+                and time.monotonic() - connected_at > _BACKOFF_RESET_AFTER_HEALTHY_SEC
+            ):
+                backoff = _RECONNECT_BACKOFF_BASE
+
+            await asyncio.sleep(backoff)
+            backoff = min(backoff * 2, _RECONNECT_BACKOFF_MAX)
+
+    async def stop(self) -> None:
+        self._stop = True
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _next_seq(self) -> int:
+        self._seq += 1
+        return self._seq
+
+    async def _authenticate(self, ws, token: str) -> None:
+        await ws.send(
+            json.dumps(
+                {
+                    "seq": self._next_seq(),
+                    "action": "authentication_challenge",
+                    "data": {"token": token},
+                }
+            )
+        )
+        # Wacht op de eerste paar messages tot we hello/auth-ok zien.
+        for _ in range(5):
+            raw = await asyncio.wait_for(ws.recv(), timeout=10.0)
+            try:
+                msg = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            event = msg.get("event")
+            if event == "hello":
+                logger.info("Mattermost websocket: authenticated")
+                return
+            if msg.get("status") == "OK":
+                continue
+            if msg.get("status") == "FAIL" or msg.get("error"):
+                raise RuntimeError(f"Mattermost websocket auth failed: {msg}")
+        raise RuntimeError("Mattermost websocket: no hello received")
+
+    async def _resolve_bot_user_id(self) -> None:
+        async with async_session() as session:
+            service = MattermostService(session)
+            try:
+                self._bot_user_id = await service.get_bot_user_id()
+            finally:
+                await service.close()
+
+    async def _read_loop(self, ws) -> None:
+        last_activity = time.monotonic()
+        while not self._stop:
+            try:
+                raw = await asyncio.wait_for(ws.recv(), timeout=_HEARTBEAT_INTERVAL)
+                last_activity = time.monotonic()
+            except TimeoutError:
+                # Stuur een lichte ping via een no-op authentication_challenge?
+                # Mattermost gebruikt geen expliciet ping/pong voor clients;
+                # bij langdurige stilte (>2x interval) breken we de connectie.
+                if time.monotonic() - last_activity > _HEARTBEAT_INTERVAL * 2:
+                    raise RuntimeError("Mattermost websocket: idle timeout")
+                continue
+
+            try:
+                msg = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            await self._dispatch(msg)
+
+    async def _dispatch(self, msg: dict) -> None:
+        event = msg.get("event")
+        if event != "posted":
+            # `post_edited`, `post_deleted`, `reaction_added` worden in een
+            # latere PR ingehaakt. Voor PR1 alleen 'posted'.
+            return
+
+        data = msg.get("data") or {}
+        post_raw = data.get("post")
+        if not post_raw:
+            return
+        try:
+            post = json.loads(post_raw) if isinstance(post_raw, str) else post_raw
+        except json.JSONDecodeError:
+            logger.warning("Kan posted-event niet parsen")
+            return
+
+        post_id = post.get("id")
+        channel_id = post.get("channel_id")
+        if not post_id or not channel_id:
+            return
+
+        async with async_session() as session:
+            try:
+                await self._record_post(session, post)
+                await session.commit()
+            except Exception:
+                await session.rollback()
+                logger.exception("Fout bij verwerken Mattermost-post %s", post_id)
+
+    async def _record_post(self, session: AsyncSession, post: dict) -> None:
+        """Skeleton: leg de post vast in `mattermost_post_link` als het
+        kanaal gekoppeld is. Verdere verwerking volgt in PR2/PR3."""
+        post_id = post["id"]
+        channel_id = post["channel_id"]
+        mm_user_id = post.get("user_id") or None
+        root_id = post.get("root_id") or None
+
+        # Skip: bot's eigen posts (anders feedback-loop).
+        if self._bot_user_id and mm_user_id == self._bot_user_id:
+            return
+
+        link_repo = MattermostChannelLinkRepository(session)
+        channel_link = await link_repo.get_by_channel_id(channel_id)
+        if channel_link is None or channel_link.disabled_at is not None:
+            return
+
+        # Resolve person_id via mattermost_user-mapping (alleen als gekoppeld).
+        person_id = None
+        if mm_user_id:
+            mm_repo = MattermostUserRepository(session)
+            mapping = await mm_repo.get_by_mattermost_user_id(mm_user_id)
+            if mapping is not None:
+                person_id = mapping.person_id
+
+        # Idempotency-check vóór insert vermijdt een IntegrityError-rollback
+        # die in een ge-savepointe testtransactie de hele session sloopt.
+        existing_stmt = select(MattermostPostLink.id).where(
+            MattermostPostLink.post_id == post_id
+        )
+        existing = (await session.execute(existing_stmt)).scalar_one_or_none()
+        if existing is not None:
+            return
+
+        record = MattermostPostLink(
+            post_id=post_id,
+            channel_id=channel_id,
+            root_id=root_id,
+            scope_type=channel_link.scope_type,
+            scope_id=channel_link.scope_id,
+            mm_user_id=mm_user_id,
+            person_id=person_id,
+        )
+        session.add(record)
+        try:
+            async with session.begin_nested():
+                await session.flush()
+        except IntegrityError:
+            # Race-condition: een andere worker schreef gelijktijdig hetzelfde
+            # post_id. SAVEPOINT-rollback houdt de buitenste transactie heel.
+            return
+
+        # Bump last_seen_post_at zodat recovery na reconnect klopt.
+        create_at = post.get("create_at")
+        if isinstance(create_at, int):
+            await link_repo.update_last_seen(channel_link, create_at)
+
+    async def _recover_missed_posts(self) -> None:
+        """Haal posts op die binnenkwamen terwijl we offline waren.
+
+        We doen dit per gekoppeld kanaal, vanaf ``last_seen_post_at``.
+        Posts die we al hadden (unique post_id) worden door de
+        IntegrityError-handler in ``_record_post`` afgevangen.
+        """
+        async with async_session() as session:
+            stmt = select(MattermostChannelLink).where(
+                MattermostChannelLink.disabled_at.is_(None)
+            )
+            result = await session.execute(stmt)
+            links = list(result.scalars().all())
+
+            if not links:
+                return
+
+            service = MattermostService(session)
+            try:
+                if not await service.is_enabled():
+                    return
+                for link in links:
+                    since = link.last_seen_post_at or 0
+                    if since == 0:
+                        # Niet recoveren bij verse koppeling — anders
+                        # importeren we een hele kanaal-historie.
+                        continue
+                    try:
+                        posts = await service.get_channel_posts_since(
+                            link.channel_id, since
+                        )
+                    except httpx.HTTPError:
+                        logger.exception(
+                            "Recovery faalde voor kanaal %s", link.channel_id
+                        )
+                        continue
+                    for post in posts:
+                        try:
+                            await self._record_post(session, post)
+                        except Exception:
+                            logger.exception(
+                                "Recovery: fout bij post %s", post.get("id")
+                            )
+                await session.commit()
+            finally:
+                await service.close()

--- a/backend/bouwmeester/services/mattermost_websocket_service.py
+++ b/backend/bouwmeester/services/mattermost_websocket_service.py
@@ -1,9 +1,8 @@
 """Persistente Mattermost-websocket voor het meelezen in gekoppelde kanalen.
 
-Skeleton-versie (PR1): connect/auth/heartbeat/reconnect, filter op
-gekoppelde kanalen, schrijf voor elke post een idempotency-record naar
-``mattermost_post_link``. Verwerking (auto-note, suggested-lead) volgt in
-PR2/PR3 via een ``MattermostIngestService``.
+Auth/heartbeat/reconnect, plus recovery via REST na disconnect. Voor de
+verwerking van individuele posts delegeren we naar
+``MattermostIngestService``.
 
 Protocol-referentie: het Mattermost websocket-protocol uit
 `claude-threads/src/platform/mattermost/client.ts`.
@@ -20,16 +19,11 @@ from urllib.parse import urlparse
 import httpx
 import websockets
 from sqlalchemy import select
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from bouwmeester.core.database import async_session
 from bouwmeester.models.mattermost_channel_link import MattermostChannelLink
-from bouwmeester.models.mattermost_post_link import MattermostPostLink
-from bouwmeester.repositories.mattermost_channel_link import (
-    MattermostChannelLinkRepository,
-)
-from bouwmeester.repositories.mattermost_user import MattermostUserRepository
+from bouwmeester.services.mattermost_ingest_service import MattermostIngestService
 from bouwmeester.services.mattermost_service import (
     MattermostService,
     _load_mattermost_config,
@@ -63,6 +57,7 @@ class MattermostWebsocketService:
         self._seq = 0
         self._stop = False
         self._bot_user_id: str | None = None
+        self._mm_base_url: str | None = None
 
     async def run(self) -> None:
         """Hoofdloop: connect, auth, lees events, reconnect bij disconnect."""
@@ -84,6 +79,7 @@ class MattermostWebsocketService:
                     await asyncio.sleep(_RECONNECT_BACKOFF_MAX)
                     continue
 
+                self._mm_base_url = http_url.rstrip("/")
                 ws_url = _ws_url_from_http(http_url)
                 logger.info("Mattermost websocket: connect %s", ws_url)
                 async with websockets.connect(
@@ -213,61 +209,13 @@ class MattermostWebsocketService:
                 logger.exception("Fout bij verwerken Mattermost-post %s", post_id)
 
     async def _record_post(self, session: AsyncSession, post: dict) -> None:
-        """Skeleton: leg de post vast in `mattermost_post_link` als het
-        kanaal gekoppeld is. Verdere verwerking volgt in PR2/PR3."""
-        post_id = post["id"]
-        channel_id = post["channel_id"]
-        mm_user_id = post.get("user_id") or None
-        root_id = post.get("root_id") or None
-
-        # Skip: bot's eigen posts (anders feedback-loop).
-        if self._bot_user_id and mm_user_id == self._bot_user_id:
-            return
-
-        link_repo = MattermostChannelLinkRepository(session)
-        channel_link = await link_repo.get_by_channel_id(channel_id)
-        if channel_link is None or channel_link.disabled_at is not None:
-            return
-
-        # Resolve person_id via mattermost_user-mapping (alleen als gekoppeld).
-        person_id = None
-        if mm_user_id:
-            mm_repo = MattermostUserRepository(session)
-            mapping = await mm_repo.get_by_mattermost_user_id(mm_user_id)
-            if mapping is not None:
-                person_id = mapping.person_id
-
-        # Idempotency-check vóór insert vermijdt een IntegrityError-rollback
-        # die in een ge-savepointe testtransactie de hele session sloopt.
-        existing_stmt = select(MattermostPostLink.id).where(
-            MattermostPostLink.post_id == post_id
+        """Verwerk één Mattermost-post via :class:`MattermostIngestService`."""
+        ingest = MattermostIngestService(
+            session,
+            bot_user_id=self._bot_user_id,
+            mm_base_url=self._mm_base_url,
         )
-        existing = (await session.execute(existing_stmt)).scalar_one_or_none()
-        if existing is not None:
-            return
-
-        record = MattermostPostLink(
-            post_id=post_id,
-            channel_id=channel_id,
-            root_id=root_id,
-            scope_type=channel_link.scope_type,
-            scope_id=channel_link.scope_id,
-            mm_user_id=mm_user_id,
-            person_id=person_id,
-        )
-        session.add(record)
-        try:
-            async with session.begin_nested():
-                await session.flush()
-        except IntegrityError:
-            # Race-condition: een andere worker schreef gelijktijdig hetzelfde
-            # post_id. SAVEPOINT-rollback houdt de buitenste transactie heel.
-            return
-
-        # Bump last_seen_post_at zodat recovery na reconnect klopt.
-        create_at = post.get("create_at")
-        if isinstance(create_at, int):
-            await link_repo.update_last_seen(channel_link, create_at)
+        await ingest.ingest_post(post)
 
     async def _recover_missed_posts(self) -> None:
         """Haal posts op die binnenkwamen terwijl we offline waren.

--- a/backend/bouwmeester/services/mattermost_websocket_service.py
+++ b/backend/bouwmeester/services/mattermost_websocket_service.py
@@ -27,6 +27,7 @@ from bouwmeester.services.mattermost_ingest_service import MattermostIngestServi
 from bouwmeester.services.mattermost_service import (
     MattermostService,
     _load_mattermost_config,
+    _validate_mattermost_url,
 )
 
 logger = logging.getLogger(__name__)
@@ -79,6 +80,9 @@ class MattermostWebsocketService:
                     await asyncio.sleep(_RECONNECT_BACKOFF_MAX)
                     continue
 
+                # Block SSRF naar interne hosts (link-local, loopback, etc.)
+                # net als de HTTP-client doet voor de REST API.
+                _validate_mattermost_url(http_url)
                 self._mm_base_url = http_url.rstrip("/")
                 ws_url = _ws_url_from_http(http_url)
                 logger.info("Mattermost websocket: connect %s", ws_url)
@@ -180,11 +184,16 @@ class MattermostWebsocketService:
 
     async def _dispatch(self, msg: dict) -> None:
         event = msg.get("event")
-        if event != "posted":
-            # `post_edited`, `post_deleted`, `reaction_added` worden in een
-            # latere PR ingehaakt. Voor PR1 alleen 'posted'.
+        if event == "posted":
+            await self._dispatch_posted(msg)
             return
+        if event in ("user_removed", "channel_deleted"):
+            await self._dispatch_channel_lost(event, msg)
+            return
+        # Andere events (`post_edited`, `post_deleted`, `reaction_added`)
+        # worden in een latere PR ingehaakt.
 
+    async def _dispatch_posted(self, msg: dict) -> None:
         data = msg.get("data") or {}
         post_raw = data.get("post")
         if not post_raw:
@@ -207,6 +216,59 @@ class MattermostWebsocketService:
             except Exception:
                 await session.rollback()
                 logger.exception("Fout bij verwerken Mattermost-post %s", post_id)
+
+    async def _dispatch_channel_lost(self, event: str, msg: dict) -> None:
+        """Markeer kanaal-koppelingen als ``disabled_at`` wanneer de bot
+        verdwijnt (uit kanaal getrapt of kanaal verwijderd).
+
+        Mattermost stuurt ``user_removed`` als event met ``user_id`` (de
+        verwijderde user) en ``channel_id`` in ``broadcast`` of ``data``.
+        We schakelen de koppeling alleen uit als het de bot zelf is.
+        """
+        data = msg.get("data") or {}
+        broadcast = msg.get("broadcast") or {}
+
+        if event == "user_removed":
+            removed_user_id = data.get("user_id") or broadcast.get("user_id")
+            if not removed_user_id or removed_user_id != self._bot_user_id:
+                return
+            channel_id = data.get("channel_id") or broadcast.get("channel_id")
+        else:  # channel_deleted
+            channel_id = (
+                data.get("channel_id")
+                or broadcast.get("channel_id")
+                or (data.get("channel") or {}).get("id")
+            )
+
+        if not channel_id:
+            return
+
+        async with async_session() as session:
+            try:
+                from datetime import UTC, datetime
+
+                from bouwmeester.repositories.mattermost_channel_link import (
+                    MattermostChannelLinkRepository,
+                )
+
+                repo = MattermostChannelLinkRepository(session)
+                link = await repo.get_by_channel_id(channel_id)
+                if link is None or link.disabled_at is not None:
+                    return
+                link.disabled_at = datetime.now(UTC)
+                await session.flush()
+                await session.commit()
+                logger.info(
+                    "Channel-link %s uitgeschakeld na %s op kanaal %s",
+                    link.id,
+                    event,
+                    channel_id,
+                )
+            except Exception:
+                await session.rollback()
+                logger.exception(
+                    "Kon channel-link voor %s niet uitschakelen", channel_id
+                )
 
     async def _record_post(self, session: AsyncSession, post: dict) -> None:
         """Verwerk één Mattermost-post via :class:`MattermostIngestService`."""

--- a/backend/bouwmeester/worker.py
+++ b/backend/bouwmeester/worker.py
@@ -186,6 +186,25 @@ async def _fcc_sync_loop(settings) -> None:  # type: ignore[no-untyped-def]
         await asyncio.sleep(settings.FCC_POLL_INTERVAL_SECONDS)
 
 
+async def _mattermost_websocket_loop(settings) -> None:  # type: ignore[no-untyped-def]
+    """Persistent Mattermost websocket voor het meelezen in gekoppelde kanalen.
+
+    Service heeft eigen reconnect/backoff binnen ``run()``. Deze loop vangt
+    alleen onverwachte exceptions op en herstart dan na een korte pauze.
+    """
+    while True:
+        try:
+            from bouwmeester.services.mattermost_websocket_service import (
+                MattermostWebsocketService,
+            )
+
+            service = MattermostWebsocketService()
+            await service.run()
+        except Exception:
+            logger.exception("Mattermost websocket loop crashed, restart in 5s")
+        await asyncio.sleep(5)
+
+
 async def main() -> None:
     settings = get_settings()
     logger.info(
@@ -196,6 +215,7 @@ async def main() -> None:
     tasks = [
         asyncio.create_task(_parlementair_loop(settings)),
         asyncio.create_task(_mattermost_link_loop(settings)),
+        asyncio.create_task(_mattermost_websocket_loop(settings)),
         asyncio.create_task(_opdracht_task_loop(settings)),
         asyncio.create_task(_fcc_sync_loop(settings)),
     ]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "pdfminer-six>=20260107",
     "python-docx>=1.2.0",
     "odfpy>=1.4.1",
+    "websockets>=13.1",
 ]
 
 [dependency-groups]

--- a/backend/tests/test_mattermost_channels.py
+++ b/backend/tests/test_mattermost_channels.py
@@ -1,0 +1,309 @@
+"""Tests voor MattermostChannelLink routes en skeleton-ingest."""
+
+import uuid
+
+import pytest
+
+from bouwmeester.models.initiatief import Initiatief
+from bouwmeester.models.lead import Lead
+from bouwmeester.models.mattermost_channel_link import (
+    SCOPE_INITIATIEF,
+    SCOPE_LEAD,
+    MattermostChannelLink,
+)
+from bouwmeester.models.mattermost_post_link import MattermostPostLink
+
+
+def _channel_id() -> str:
+    return uuid.uuid4().hex[:26]
+
+
+@pytest.fixture
+async def sample_initiatief(db_session):
+    init = Initiatief(id=uuid.uuid4(), naam="Test initiatief")
+    db_session.add(init)
+    await db_session.flush()
+    return init
+
+
+@pytest.fixture
+async def sample_lead(db_session, sample_initiatief):
+    lead = Lead(
+        id=uuid.uuid4(),
+        title="Test lead",
+        stage="inbox",
+        initiatief_id=sample_initiatief.id,
+    )
+    db_session.add(lead)
+    await db_session.flush()
+    return lead
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+async def test_create_initiatief_channel_link(client, sample_initiatief):
+    cid = _channel_id()
+    resp = await client.post(
+        f"/api/initiatieven/{sample_initiatief.id}/mattermost-channels",
+        json={
+            "channel_id": cid,
+            "channel_name": "test-kanaal",
+            "channel_display_name": "Test kanaal",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["channel_id"] == cid
+    assert body["scope_type"] == SCOPE_INITIATIEF
+    assert body["scope_id"] == str(sample_initiatief.id)
+    # Initiatief-default: suggest leads aan, auto-note uit.
+    assert body["suggest_leads_enabled"] is True
+    assert body["auto_note_enabled"] is False
+
+
+async def test_create_lead_channel_link(client, sample_lead):
+    cid = _channel_id()
+    resp = await client.post(
+        f"/api/leads/{sample_lead.id}/mattermost-channels",
+        json={
+            "channel_id": cid,
+            "channel_name": "project-kanaal",
+            "channel_display_name": "Project kanaal",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["scope_type"] == SCOPE_LEAD
+    # Lead-default: auto-note aan, suggest leads uit.
+    assert body["auto_note_enabled"] is True
+    assert body["suggest_leads_enabled"] is False
+
+
+async def test_cannot_link_same_channel_twice(client, sample_initiatief):
+    cid = _channel_id()
+    payload = {
+        "channel_id": cid,
+        "channel_name": "kanaal",
+        "channel_display_name": "Kanaal",
+    }
+    first = await client.post(
+        f"/api/initiatieven/{sample_initiatief.id}/mattermost-channels",
+        json=payload,
+    )
+    assert first.status_code == 201
+    second = await client.post(
+        f"/api/initiatieven/{sample_initiatief.id}/mattermost-channels",
+        json=payload,
+    )
+    assert second.status_code == 409
+
+
+async def test_list_channels_for_initiatief(client, sample_initiatief):
+    cid = _channel_id()
+    await client.post(
+        f"/api/initiatieven/{sample_initiatief.id}/mattermost-channels",
+        json={
+            "channel_id": cid,
+            "channel_name": "kanaal",
+            "channel_display_name": "Kanaal",
+        },
+    )
+    resp = await client.get(
+        f"/api/initiatieven/{sample_initiatief.id}/mattermost-channels"
+    )
+    assert resp.status_code == 200
+    items = resp.json()
+    assert len(items) == 1
+    assert items[0]["channel_id"] == cid
+
+
+async def test_update_channel_settings(client, sample_initiatief):
+    cid = _channel_id()
+    create = await client.post(
+        f"/api/initiatieven/{sample_initiatief.id}/mattermost-channels",
+        json={
+            "channel_id": cid,
+            "channel_name": "kanaal",
+            "channel_display_name": "Kanaal",
+        },
+    )
+    link_id = create.json()["id"]
+    resp = await client.patch(
+        f"/api/mattermost-channels/{link_id}",
+        json={"auto_note_enabled": True},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["auto_note_enabled"] is True
+
+
+async def test_delete_channel_link(client, sample_initiatief):
+    cid = _channel_id()
+    create = await client.post(
+        f"/api/initiatieven/{sample_initiatief.id}/mattermost-channels",
+        json={
+            "channel_id": cid,
+            "channel_name": "kanaal",
+            "channel_display_name": "Kanaal",
+        },
+    )
+    link_id = create.json()["id"]
+    resp = await client.delete(f"/api/mattermost-channels/{link_id}")
+    assert resp.status_code == 204
+    after = await client.get(
+        f"/api/initiatieven/{sample_initiatief.id}/mattermost-channels"
+    )
+    assert after.json() == []
+
+
+async def test_create_initiatief_channel_invalid_id(client, sample_initiatief):
+    resp = await client.post(
+        f"/api/initiatieven/{sample_initiatief.id}/mattermost-channels",
+        json={
+            "channel_id": "not-a-mm-id",
+            "channel_name": "x",
+            "channel_display_name": "X",
+        },
+    )
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Skeleton-ingest (websocket-service zonder echte websocket)
+# ---------------------------------------------------------------------------
+
+
+async def test_record_post_writes_post_link(db_session, sample_initiatief):
+    """Skeleton-`_record_post` legt een post vast voor een gekoppeld kanaal."""
+    from bouwmeester.services.mattermost_websocket_service import (
+        MattermostWebsocketService,
+    )
+
+    cid = _channel_id()
+    link = MattermostChannelLink(
+        channel_id=cid,
+        channel_name="k",
+        channel_display_name="K",
+        scope_type=SCOPE_INITIATIEF,
+        scope_id=sample_initiatief.id,
+        auto_note_enabled=False,
+        suggest_leads_enabled=True,
+    )
+    db_session.add(link)
+    await db_session.flush()
+
+    service = MattermostWebsocketService()
+    post = {
+        "id": "p" + uuid.uuid4().hex[:25],
+        "channel_id": cid,
+        "user_id": "u" + uuid.uuid4().hex[:25],
+        "create_at": 1_700_000_000_000,
+    }
+    await service._record_post(db_session, post)
+
+    from sqlalchemy import select
+
+    result = await db_session.execute(
+        select(MattermostPostLink).where(MattermostPostLink.post_id == post["id"])
+    )
+    record = result.scalar_one()
+    assert record.channel_id == cid
+    assert record.scope_type == SCOPE_INITIATIEF
+    assert record.scope_id == sample_initiatief.id
+
+
+async def test_record_post_idempotent(db_session, sample_initiatief):
+    """Tweede keer dezelfde post → geen tweede record."""
+    from sqlalchemy import select
+
+    from bouwmeester.services.mattermost_websocket_service import (
+        MattermostWebsocketService,
+    )
+
+    cid = _channel_id()
+    link = MattermostChannelLink(
+        channel_id=cid,
+        channel_name="k",
+        channel_display_name="K",
+        scope_type=SCOPE_INITIATIEF,
+        scope_id=sample_initiatief.id,
+    )
+    db_session.add(link)
+    await db_session.flush()
+
+    service = MattermostWebsocketService()
+    post = {
+        "id": "p" + uuid.uuid4().hex[:25],
+        "channel_id": cid,
+        "user_id": "u" + uuid.uuid4().hex[:25],
+        "create_at": 1_700_000_000_000,
+    }
+    await service._record_post(db_session, post)
+    await service._record_post(db_session, post)
+
+    result = await db_session.execute(
+        select(MattermostPostLink).where(MattermostPostLink.post_id == post["id"])
+    )
+    rows = list(result.scalars().all())
+    assert len(rows) == 1
+
+
+async def test_record_post_skips_unlinked_channel(db_session):
+    """Posts in een niet-gekoppeld kanaal worden niet vastgelegd."""
+    from sqlalchemy import select
+
+    from bouwmeester.services.mattermost_websocket_service import (
+        MattermostWebsocketService,
+    )
+
+    service = MattermostWebsocketService()
+    post = {
+        "id": "p" + uuid.uuid4().hex[:25],
+        "channel_id": _channel_id(),
+        "user_id": "u" + uuid.uuid4().hex[:25],
+        "create_at": 1_700_000_000_000,
+    }
+    await service._record_post(db_session, post)
+
+    result = await db_session.execute(
+        select(MattermostPostLink).where(MattermostPostLink.post_id == post["id"])
+    )
+    assert result.scalar_one_or_none() is None
+
+
+async def test_record_post_skips_bot_self(db_session, sample_initiatief):
+    """Bot's eigen posts worden niet ingelezen (anti feedback-loop)."""
+    from sqlalchemy import select
+
+    from bouwmeester.services.mattermost_websocket_service import (
+        MattermostWebsocketService,
+    )
+
+    cid = _channel_id()
+    link = MattermostChannelLink(
+        channel_id=cid,
+        channel_name="k",
+        channel_display_name="K",
+        scope_type=SCOPE_INITIATIEF,
+        scope_id=sample_initiatief.id,
+    )
+    db_session.add(link)
+    await db_session.flush()
+
+    bot_id = "b" + uuid.uuid4().hex[:25]
+    service = MattermostWebsocketService()
+    service._bot_user_id = bot_id
+
+    post = {
+        "id": "p" + uuid.uuid4().hex[:25],
+        "channel_id": cid,
+        "user_id": bot_id,
+        "create_at": 1_700_000_000_000,
+    }
+    await service._record_post(db_session, post)
+    result = await db_session.execute(
+        select(MattermostPostLink).where(MattermostPostLink.post_id == post["id"])
+    )
+    assert result.scalar_one_or_none() is None

--- a/backend/tests/test_mattermost_ingest.py
+++ b/backend/tests/test_mattermost_ingest.py
@@ -1,0 +1,404 @@
+"""Tests voor MattermostIngestService: auto-note op lead-kanalen + doc-links."""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from bouwmeester.models.initiatief import Initiatief
+from bouwmeester.models.lead import Lead
+from bouwmeester.models.lead_activity import LeadActivity
+from bouwmeester.models.lead_attachment import LeadAttachment
+from bouwmeester.models.mattermost_channel_link import (
+    SCOPE_INITIATIEF,
+    SCOPE_LEAD,
+    MattermostChannelLink,
+)
+from bouwmeester.models.mattermost_post_link import MattermostPostLink
+from bouwmeester.models.mattermost_user import MattermostUser
+from bouwmeester.services.mattermost_doc_link_extractor import (
+    derive_attachment_label,
+    extract_doc_links,
+)
+from bouwmeester.services.mattermost_ingest_service import MattermostIngestService
+
+
+def _id() -> str:
+    return uuid.uuid4().hex[:26]
+
+
+@pytest.fixture
+async def sample_initiatief(db_session):
+    init = Initiatief(id=uuid.uuid4(), naam="Test initiatief")
+    db_session.add(init)
+    await db_session.flush()
+    return init
+
+
+@pytest.fixture
+async def sample_lead(db_session, sample_initiatief):
+    lead = Lead(
+        id=uuid.uuid4(),
+        title="Test lead",
+        stage="inbox",
+        initiatief_id=sample_initiatief.id,
+    )
+    db_session.add(lead)
+    await db_session.flush()
+    return lead
+
+
+# ---------------------------------------------------------------------------
+# Doc-link-extractor
+# ---------------------------------------------------------------------------
+
+
+def test_extract_doc_links_pikt_drive_op():
+    msg = "Notulen: https://drive.google.com/file/d/abc/view"
+    links = extract_doc_links(msg)
+    assert len(links) == 1
+    assert links[0]["url"].endswith("/view")
+    assert links[0]["host"] == "drive.google.com"
+
+
+def test_extract_doc_links_pikt_pdf_op_buiten_known_host():
+    msg = "Bekijk de pdf op https://example.org/files/report.pdf voor details."
+    links = extract_doc_links(msg)
+    assert len(links) == 1
+    assert links[0]["url"].endswith("report.pdf")
+
+
+def test_extract_doc_links_negeert_gewone_artikelen():
+    msg = "Zie https://nos.nl/artikel/123-overheid voor context."
+    assert extract_doc_links(msg) == []
+
+
+def test_extract_doc_links_dedupes_en_volgorde():
+    msg = (
+        "https://drive.google.com/file/d/A "
+        "en https://drive.google.com/file/d/A nogmaals, plus "
+        "https://atlassian.net/wiki/x"
+    )
+    links = extract_doc_links(msg)
+    assert [link["url"] for link in links] == [
+        "https://drive.google.com/file/d/A",
+        "https://atlassian.net/wiki/x",
+    ]
+
+
+def test_extract_doc_links_strips_trailing_punctuation():
+    msg = "Zie (https://drive.google.com/file/d/abc), prima."
+    links = extract_doc_links(msg)
+    assert links[0]["url"] == "https://drive.google.com/file/d/abc"
+
+
+def test_derive_attachment_label_known_hosts():
+    assert derive_attachment_label("https://drive.google.com/x") == "Google Drive"
+    assert derive_attachment_label("https://team.atlassian.net/wiki/x") == "Confluence"
+    assert (
+        derive_attachment_label("https://contoso.sharepoint.com/x")
+        == "SharePoint/OneDrive"
+    )
+    assert derive_attachment_label("https://www.example.org/file.pdf") == "example.org"
+
+
+# ---------------------------------------------------------------------------
+# Auto-note op lead-kanalen
+# ---------------------------------------------------------------------------
+
+
+async def test_lead_channel_creates_auto_note(db_session, sample_lead):
+    cid = _id()
+    db_session.add(
+        MattermostChannelLink(
+            channel_id=cid,
+            channel_name="proj",
+            channel_display_name="Project",
+            scope_type=SCOPE_LEAD,
+            scope_id=sample_lead.id,
+            auto_note_enabled=True,
+            suggest_leads_enabled=False,
+        )
+    )
+    await db_session.flush()
+
+    ingest = MattermostIngestService(db_session, mm_base_url="https://mm.example.org")
+    post = {
+        "id": _id(),
+        "channel_id": cid,
+        "user_id": _id(),
+        "create_at": 1_700_000_000_000,
+        "message": "Stand van zaken: gemeente X wacht op antwoord.",
+    }
+    await ingest.ingest_post(post)
+
+    activities = (
+        (
+            await db_session.execute(
+                select(LeadActivity).where(LeadActivity.lead_id == sample_lead.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(activities) == 1
+    activity = activities[0]
+    assert activity.activity_type == "note"
+    assert "gemeente X" in activity.content
+    assert activity.metadata_["source"] == "mattermost"
+    assert activity.metadata_["mm_post_id"] == post["id"]
+    assert activity.metadata_["mm_permalink"].endswith(post["id"])
+
+    post_link = (
+        await db_session.execute(
+            select(MattermostPostLink).where(MattermostPostLink.post_id == post["id"])
+        )
+    ).scalar_one()
+    assert post_link.lead_activity_id == activity.id
+
+
+async def test_lead_channel_extracts_doc_link_attachment(db_session, sample_lead):
+    cid = _id()
+    db_session.add(
+        MattermostChannelLink(
+            channel_id=cid,
+            channel_name="proj",
+            channel_display_name="Project",
+            scope_type=SCOPE_LEAD,
+            scope_id=sample_lead.id,
+            auto_note_enabled=True,
+        )
+    )
+    await db_session.flush()
+
+    ingest = MattermostIngestService(db_session)
+    post = {
+        "id": _id(),
+        "channel_id": cid,
+        "user_id": _id(),
+        "create_at": 1_700_000_000_000,
+        "message": "Notulen: https://drive.google.com/file/d/xyz/view",
+    }
+    await ingest.ingest_post(post)
+
+    attachments = (
+        (
+            await db_session.execute(
+                select(LeadAttachment).where(LeadAttachment.lead_id == sample_lead.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(attachments) == 1
+    att = attachments[0]
+    assert att.soort == "link"
+    assert att.url == "https://drive.google.com/file/d/xyz/view"
+    assert att.source == "mattermost"
+    assert att.source_ref == post["id"]
+    assert att.bestandsnaam == "Google Drive"
+    # File-velden mogen leeg zijn voor URL-attachments.
+    assert att.pad is None
+    assert att.bestandsgrootte is None
+
+
+async def test_lead_channel_dedupes_attachment_url(db_session, sample_lead):
+    cid = _id()
+    db_session.add(
+        MattermostChannelLink(
+            channel_id=cid,
+            channel_name="proj",
+            channel_display_name="Project",
+            scope_type=SCOPE_LEAD,
+            scope_id=sample_lead.id,
+            auto_note_enabled=True,
+        )
+    )
+    await db_session.flush()
+
+    ingest = MattermostIngestService(db_session)
+    url = "https://drive.google.com/file/d/dup/view"
+    for _ in range(2):
+        post = {
+            "id": _id(),
+            "channel_id": cid,
+            "user_id": _id(),
+            "create_at": 1_700_000_000_000,
+            "message": f"Document: {url}",
+        }
+        await ingest.ingest_post(post)
+
+    attachments = (
+        (
+            await db_session.execute(
+                select(LeadAttachment).where(
+                    LeadAttachment.lead_id == sample_lead.id,
+                    LeadAttachment.url == url,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(attachments) == 1
+
+
+async def test_lead_channel_resolves_author_via_mattermost_link(
+    db_session, sample_lead, create_person
+):
+    """Als de MM-user gekoppeld is aan een Person → author_id wordt gezet."""
+    person = await create_person(naam="Geanne Test", prefix="geanne")
+    cid = _id()
+    mm_uid = _id()
+    db_session.add(
+        MattermostChannelLink(
+            channel_id=cid,
+            channel_name="proj",
+            channel_display_name="Project",
+            scope_type=SCOPE_LEAD,
+            scope_id=sample_lead.id,
+            auto_note_enabled=True,
+        )
+    )
+    db_session.add(
+        MattermostUser(
+            person_id=person.id,
+            mattermost_user_id=mm_uid,
+            mattermost_username="geanne",
+        )
+    )
+    await db_session.flush()
+
+    ingest = MattermostIngestService(db_session)
+    post = {
+        "id": _id(),
+        "channel_id": cid,
+        "user_id": mm_uid,
+        "create_at": 1_700_000_000_000,
+        "message": "Update vanuit Geanne.",
+    }
+    await ingest.ingest_post(post)
+
+    activity = (
+        await db_session.execute(
+            select(LeadActivity).where(LeadActivity.lead_id == sample_lead.id)
+        )
+    ).scalar_one()
+    assert activity.author_id == person.id
+    # Geen "via mm:@..." prefix als auteur bekend is.
+    assert "via mm:" not in activity.content
+
+
+async def test_lead_channel_unlinked_author_uses_via_prefix(db_session, sample_lead):
+    cid = _id()
+    db_session.add(
+        MattermostChannelLink(
+            channel_id=cid,
+            channel_name="proj",
+            channel_display_name="Project",
+            scope_type=SCOPE_LEAD,
+            scope_id=sample_lead.id,
+            auto_note_enabled=True,
+        )
+    )
+    await db_session.flush()
+
+    ingest = MattermostIngestService(db_session)
+    mm_uid = _id()
+    post = {
+        "id": _id(),
+        "channel_id": cid,
+        "user_id": mm_uid,
+        "create_at": 1_700_000_000_000,
+        "message": "Onbekende afzender",
+    }
+    await ingest.ingest_post(post)
+
+    activity = (
+        await db_session.execute(
+            select(LeadActivity).where(LeadActivity.lead_id == sample_lead.id)
+        )
+    ).scalar_one()
+    assert activity.author_id is None
+    assert f"via mm:@{mm_uid}" in activity.content
+
+
+async def test_lead_channel_with_auto_note_disabled_skips_activity(
+    db_session, sample_lead
+):
+    cid = _id()
+    db_session.add(
+        MattermostChannelLink(
+            channel_id=cid,
+            channel_name="proj",
+            channel_display_name="Project",
+            scope_type=SCOPE_LEAD,
+            scope_id=sample_lead.id,
+            auto_note_enabled=False,
+        )
+    )
+    await db_session.flush()
+
+    ingest = MattermostIngestService(db_session)
+    post = {
+        "id": _id(),
+        "channel_id": cid,
+        "user_id": _id(),
+        "create_at": 1_700_000_000_000,
+        "message": "Iets",
+    }
+    await ingest.ingest_post(post)
+
+    activities = (
+        (
+            await db_session.execute(
+                select(LeadActivity).where(LeadActivity.lead_id == sample_lead.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert activities == []
+    # Wel een post_link zodat we niet opnieuw verwerken.
+    post_link = (
+        await db_session.execute(
+            select(MattermostPostLink).where(MattermostPostLink.post_id == post["id"])
+        )
+    ).scalar_one()
+    assert post_link.lead_activity_id is None
+
+
+async def test_initiatief_channel_writes_only_post_link(db_session, sample_initiatief):
+    """Initiatief-kanalen krijgen pas in PR3 suggested leads. Voor nu: alleen
+    een post_link-record, geen LeadActivity, geen LeadAttachment."""
+    cid = _id()
+    db_session.add(
+        MattermostChannelLink(
+            channel_id=cid,
+            channel_name="alg",
+            channel_display_name="Algemeen",
+            scope_type=SCOPE_INITIATIEF,
+            scope_id=sample_initiatief.id,
+            auto_note_enabled=False,
+            suggest_leads_enabled=True,
+        )
+    )
+    await db_session.flush()
+
+    ingest = MattermostIngestService(db_session)
+    post = {
+        "id": _id(),
+        "channel_id": cid,
+        "user_id": _id(),
+        "create_at": 1_700_000_000_000,
+        "message": "Mogelijk een nieuwe lead?",
+    }
+    await ingest.ingest_post(post)
+
+    post_link = (
+        await db_session.execute(
+            select(MattermostPostLink).where(MattermostPostLink.post_id == post["id"])
+        )
+    ).scalar_one()
+    assert post_link.lead_activity_id is None
+    assert post_link.scope_type == SCOPE_INITIATIEF

--- a/backend/tests/test_mattermost_noise_filter.py
+++ b/backend/tests/test_mattermost_noise_filter.py
@@ -1,0 +1,169 @@
+"""Tests voor LLM-ruisfilter + thread-samenvatting in lead-kanalen."""
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select
+
+from bouwmeester.models.initiatief import Initiatief
+from bouwmeester.models.lead import Lead
+from bouwmeester.models.lead_activity import LeadActivity
+from bouwmeester.models.mattermost_channel_link import (
+    SCOPE_LEAD,
+    MattermostChannelLink,
+)
+from bouwmeester.models.mattermost_post_link import MattermostPostLink
+from bouwmeester.services.mattermost_ingest_service import MattermostIngestService
+
+
+def _id() -> str:
+    return uuid.uuid4().hex[:26]
+
+
+@pytest.fixture
+async def lead_channel(db_session):
+    init = Initiatief(id=uuid.uuid4(), naam="X")
+    db_session.add(init)
+    await db_session.flush()
+    lead = Lead(
+        id=uuid.uuid4(),
+        title="Test lead",
+        stage="inbox",
+        initiatief_id=init.id,
+    )
+    db_session.add(lead)
+    await db_session.flush()
+    cid = _id()
+    link = MattermostChannelLink(
+        channel_id=cid,
+        channel_name="proj",
+        channel_display_name="Project",
+        scope_type=SCOPE_LEAD,
+        scope_id=lead.id,
+        auto_note_enabled=True,
+    )
+    db_session.add(link)
+    await db_session.flush()
+    return lead, link
+
+
+def _patch_llm(*, is_noise: bool = False, summary: str | None = None):
+    fake = AsyncMock()
+    fake.is_mattermost_noise = AsyncMock(return_value=is_noise)
+    fake.summarize_mattermost_message = AsyncMock(return_value=summary or "")
+    return patch(
+        "bouwmeester.services.llm.factory.get_llm_service_for",
+        new=AsyncMock(return_value=fake),
+    )
+
+
+async def test_noise_message_skips_activity(db_session, lead_channel):
+    lead, link = lead_channel
+    with _patch_llm(is_noise=True):
+        ingest = MattermostIngestService(db_session)
+        post = {
+            "id": _id(),
+            "channel_id": link.channel_id,
+            "user_id": _id(),
+            "create_at": 1_700_000_000_000,
+            "message": "ja prima dat klopt",
+        }
+        await ingest.ingest_post(post)
+
+    activities = (
+        (
+            await db_session.execute(
+                select(LeadActivity).where(LeadActivity.lead_id == lead.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert activities == []
+    pl = (
+        await db_session.execute(
+            select(MattermostPostLink).where(MattermostPostLink.post_id == post["id"])
+        )
+    ).scalar_one()
+    assert pl.skipped_reason == "noise"
+
+
+async def test_short_message_is_noise_via_heuristic(db_session, lead_channel):
+    lead, link = lead_channel
+    # LLM mag niet eens worden aangeroepen — heuristiek pakt het voor < 4 chars.
+    fake = AsyncMock()
+    fake.is_mattermost_noise = AsyncMock(return_value=False)
+    fake.summarize_mattermost_message = AsyncMock(return_value="")
+    with patch(
+        "bouwmeester.services.llm.factory.get_llm_service_for",
+        new=AsyncMock(return_value=fake),
+    ):
+        ingest = MattermostIngestService(db_session)
+        post = {
+            "id": _id(),
+            "channel_id": link.channel_id,
+            "user_id": _id(),
+            "create_at": 1_700_000_000_000,
+            "message": "ok",
+        }
+        await ingest.ingest_post(post)
+
+    activities = (
+        (
+            await db_session.execute(
+                select(LeadActivity).where(LeadActivity.lead_id == lead.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert activities == []
+    fake.is_mattermost_noise.assert_not_called()
+
+
+async def test_long_message_is_summarized(db_session, lead_channel):
+    lead, link = lead_channel
+    long_msg = "Update: " + ("Dit is een uitgebreid verslag. " * 40)
+    summary = "Korte samenvatting van het verslag."
+    with _patch_llm(is_noise=False, summary=summary):
+        ingest = MattermostIngestService(db_session)
+        post = {
+            "id": _id(),
+            "channel_id": link.channel_id,
+            "user_id": _id(),
+            "create_at": 1_700_000_000_000,
+            "message": long_msg,
+        }
+        await ingest.ingest_post(post)
+
+    activity = (
+        await db_session.execute(
+            select(LeadActivity).where(LeadActivity.lead_id == lead.id)
+        )
+    ).scalar_one()
+    assert summary in (activity.content or "")
+    assert activity.metadata_["mm_original"].startswith("Update:")
+
+
+async def test_normal_message_passes_through(db_session, lead_channel):
+    lead, link = lead_channel
+    msg = "Gemeente X belde net. Willen volgende week kennismaken."
+    with _patch_llm(is_noise=False, summary=""):
+        ingest = MattermostIngestService(db_session)
+        post = {
+            "id": _id(),
+            "channel_id": link.channel_id,
+            "user_id": _id(),
+            "create_at": 1_700_000_000_000,
+            "message": msg,
+        }
+        await ingest.ingest_post(post)
+
+    activity = (
+        await db_session.execute(
+            select(LeadActivity).where(LeadActivity.lead_id == lead.id)
+        )
+    ).scalar_one()
+    assert msg in (activity.content or "")
+    assert "mm_original" not in activity.metadata_

--- a/backend/tests/test_mattermost_suggested_lead.py
+++ b/backend/tests/test_mattermost_suggested_lead.py
@@ -1,0 +1,289 @@
+"""Tests voor de suggested-lead flow + approval-actions."""
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select
+
+from bouwmeester.models.initiatief import Initiatief
+from bouwmeester.models.lead import Lead
+from bouwmeester.models.lead_activity import LeadActivity
+from bouwmeester.models.mattermost_channel_link import (
+    SCOPE_INITIATIEF,
+    MattermostChannelLink,
+)
+from bouwmeester.models.mattermost_user import MattermostUser
+from bouwmeester.models.suggested_lead import SuggestedLead
+from bouwmeester.services.llm.base import LeadCandidateClassification
+from bouwmeester.services.mattermost_ingest_service import MattermostIngestService
+from bouwmeester.services.mattermost_slash_service import MattermostSlashService
+
+
+def _id() -> str:
+    return uuid.uuid4().hex[:26]
+
+
+@pytest.fixture
+async def sample_initiatief(db_session):
+    init = Initiatief(id=uuid.uuid4(), naam="Regelrecht")
+    db_session.add(init)
+    await db_session.flush()
+    return init
+
+
+@pytest.fixture
+async def sample_channel(db_session, sample_initiatief):
+    cid = _id()
+    link = MattermostChannelLink(
+        channel_id=cid,
+        channel_name="alg",
+        channel_display_name="Algemeen",
+        scope_type=SCOPE_INITIATIEF,
+        scope_id=sample_initiatief.id,
+        auto_note_enabled=False,
+        suggest_leads_enabled=True,
+    )
+    db_session.add(link)
+    await db_session.flush()
+    return link
+
+
+def _llm_yes(title="Gemeente X", description="Wil iets met regelhulp"):
+    return AsyncMock(
+        return_value=LeadCandidateClassification(
+            is_lead=True,
+            confidence=0.82,
+            proposed_title=title,
+            proposed_description=description,
+            match_existing_lead_id=None,
+            reasoning="lijkt een nieuwe lead",
+        )
+    )
+
+
+def _llm_no():
+    return AsyncMock(
+        return_value=LeadCandidateClassification(
+            is_lead=False,
+            confidence=0.1,
+            proposed_title="",
+            proposed_description="",
+            match_existing_lead_id=None,
+            reasoning="ack-bericht",
+        )
+    )
+
+
+def _patch_llm(mock):
+    """Patch zowel get_llm_service_for als de bot-reply-call."""
+    fake_llm = AsyncMock()
+    fake_llm.classify_mattermost_lead_candidate = mock
+    return [
+        patch(
+            "bouwmeester.services.llm.factory.get_llm_service_for",
+            new=AsyncMock(return_value=fake_llm),
+        ),
+        patch.object(
+            MattermostIngestService,
+            "_post_suggestion_reply",
+            new=AsyncMock(return_value=None),
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Ingest pad
+# ---------------------------------------------------------------------------
+
+
+async def test_initiatief_channel_creates_suggested_lead(db_session, sample_channel):
+    patches = _patch_llm(_llm_yes())
+    for p in patches:
+        p.start()
+    try:
+        ingest = MattermostIngestService(db_session)
+        post = {
+            "id": _id(),
+            "channel_id": sample_channel.channel_id,
+            "user_id": _id(),
+            "create_at": 1_700_000_000_000,
+            "message": "Gemeente X wil graag bij ons aanhaken op de regelhulp.",
+        }
+        await ingest.ingest_post(post)
+    finally:
+        for p in patches:
+            p.stop()
+
+    rows = (await db_session.execute(select(SuggestedLead))).scalars().all()
+    assert len(rows) == 1
+    sug = rows[0]
+    assert sug.status == "pending"
+    assert sug.proposed_title == "Gemeente X"
+    assert sug.confidence == pytest.approx(0.82)
+    assert sug.source_post_id == post["id"]
+
+
+async def test_initiatief_channel_no_lead_when_llm_says_no(db_session, sample_channel):
+    patches = _patch_llm(_llm_no())
+    for p in patches:
+        p.start()
+    try:
+        ingest = MattermostIngestService(db_session)
+        post = {
+            "id": _id(),
+            "channel_id": sample_channel.channel_id,
+            "user_id": _id(),
+            "create_at": 1_700_000_000_000,
+            "message": "ok 👍",
+        }
+        await ingest.ingest_post(post)
+    finally:
+        for p in patches:
+            p.stop()
+
+    sugs = (await db_session.execute(select(SuggestedLead))).scalars().all()
+    assert sugs == []
+
+
+# ---------------------------------------------------------------------------
+# Approval-actions
+# ---------------------------------------------------------------------------
+
+
+async def test_create_lead_from_suggestion(
+    db_session, sample_initiatief, sample_channel, create_person
+):
+    from bouwmeester.models.resource_permission import ResourcePermission
+
+    person = await create_person(naam="Anne Reviewer", prefix="anne")
+    mm_uid = _id()
+    db_session.add(
+        MattermostUser(
+            person_id=person.id,
+            mattermost_user_id=mm_uid,
+            mattermost_username="anne",
+        )
+    )
+    db_session.add(
+        ResourcePermission(
+            person_id=person.id,
+            resource_type="initiatief",
+            resource_id=sample_initiatief.id,
+            rol="eigenaar",
+        )
+    )
+    suggested = SuggestedLead(
+        source_post_id=_id(),
+        source_channel_id=sample_channel.channel_id,
+        initiatief_id=sample_initiatief.id,
+        proposed_title="Gemeente Y",
+        proposed_description="Vraag over regelhulp",
+        raw_text="Gemeente Y vraagt om een gesprek.",
+        confidence=0.8,
+        status="pending",
+    )
+    db_session.add(suggested)
+    await db_session.flush()
+    await db_session.refresh(suggested)
+
+    with patch(
+        "bouwmeester.services.mattermost_slash_service."
+        "MattermostSlashService._update_thread_post",
+        new=AsyncMock(return_value=None),
+    ):
+        service = MattermostSlashService(db_session)
+        result = await service.handle_action(
+            mattermost_user_id=mm_uid,
+            action="create_lead_from_suggestion",
+            context={"suggested_lead_id": str(suggested.id)},
+        )
+
+    assert "ephemeral_text" in result
+
+    leads = (
+        (
+            await db_session.execute(
+                select(Lead).where(Lead.initiatief_id == sample_initiatief.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(leads) == 1
+    assert leads[0].title == "Gemeente Y"
+    assert leads[0].brought_by_id == person.id
+
+    activities = (await db_session.execute(select(LeadActivity))).scalars().all()
+    assert len(activities) == 1
+    assert "Gemeente Y" in (activities[0].content or "")
+
+    await db_session.refresh(suggested)
+    assert suggested.status == "approved_new"
+    assert suggested.approved_lead_id == leads[0].id
+    assert suggested.reviewed_by_id == person.id
+
+
+async def test_reject_suggestion(
+    db_session, sample_initiatief, sample_channel, create_person
+):
+    person = await create_person(naam="Anne", prefix="anne")
+    mm_uid = _id()
+    db_session.add(
+        MattermostUser(
+            person_id=person.id,
+            mattermost_user_id=mm_uid,
+            mattermost_username="anne",
+        )
+    )
+    suggested = SuggestedLead(
+        source_post_id=_id(),
+        source_channel_id=sample_channel.channel_id,
+        initiatief_id=sample_initiatief.id,
+        proposed_title="Lijkt geen lead",
+        raw_text="ok",
+        status="pending",
+    )
+    db_session.add(suggested)
+    await db_session.flush()
+    await db_session.refresh(suggested)
+
+    with patch(
+        "bouwmeester.services.mattermost_slash_service."
+        "MattermostSlashService._update_thread_post",
+        new=AsyncMock(return_value=None),
+    ):
+        service = MattermostSlashService(db_session)
+        await service.handle_action(
+            mattermost_user_id=mm_uid,
+            action="reject_suggestion",
+            context={"suggested_lead_id": str(suggested.id)},
+        )
+
+    await db_session.refresh(suggested)
+    assert suggested.status == "rejected"
+    assert suggested.reviewed_by_id == person.id
+
+
+async def test_approval_requires_linked_mattermost_user(
+    db_session, sample_initiatief, sample_channel
+):
+    suggested = SuggestedLead(
+        source_post_id=_id(),
+        source_channel_id=sample_channel.channel_id,
+        initiatief_id=sample_initiatief.id,
+        proposed_title="X",
+        status="pending",
+    )
+    db_session.add(suggested)
+    await db_session.flush()
+
+    service = MattermostSlashService(db_session)
+    res = await service.handle_action(
+        mattermost_user_id=_id(),
+        action="create_lead_from_suggestion",
+        context={"suggested_lead_id": str(suggested.id)},
+    )
+    assert res.get("text") == "Je account is niet gekoppeld."
+    leads = (await db_session.execute(select(Lead))).scalars().all()
+    assert leads == []

--- a/backend/tests/test_mattermost_suggested_lead.py
+++ b/backend/tests/test_mattermost_suggested_lead.py
@@ -227,6 +227,8 @@ async def test_create_lead_from_suggestion(
 async def test_reject_suggestion(
     db_session, sample_initiatief, sample_channel, create_person
 ):
+    from bouwmeester.models.resource_permission import ResourcePermission
+
     person = await create_person(naam="Anne", prefix="anne")
     mm_uid = _id()
     db_session.add(
@@ -234,6 +236,14 @@ async def test_reject_suggestion(
             person_id=person.id,
             mattermost_user_id=mm_uid,
             mattermost_username="anne",
+        )
+    )
+    db_session.add(
+        ResourcePermission(
+            person_id=person.id,
+            resource_type="initiatief",
+            resource_id=sample_initiatief.id,
+            rol="eigenaar",
         )
     )
     suggested = SuggestedLead(
@@ -284,6 +294,270 @@ async def test_approval_requires_linked_mattermost_user(
         action="create_lead_from_suggestion",
         context={"suggested_lead_id": str(suggested.id)},
     )
-    assert res.get("text") == "Je account is niet gekoppeld."
+    # Approval-actions gebruiken de MM interactive-shape ``ephemeral_text``
+    # (niet de slash-command-shape ``response_type``/``text``).
+    assert res == {"ephemeral_text": "Je account is niet gekoppeld."}
     leads = (await db_session.execute(select(Lead))).scalars().all()
     assert leads == []
+
+
+async def test_link_lead_to_suggestion(
+    db_session, sample_initiatief, sample_channel, create_person
+):
+    """Knop 'Koppel aan bestaande lead' hangt het MM-bericht als notitie
+    aan de bestaande lead en zet de suggestie op approved_linked."""
+    from bouwmeester.models.resource_permission import ResourcePermission
+
+    person = await create_person(naam="Anne", prefix="anne")
+    mm_uid = _id()
+    db_session.add(
+        MattermostUser(
+            person_id=person.id,
+            mattermost_user_id=mm_uid,
+            mattermost_username="anne",
+        )
+    )
+    db_session.add(
+        ResourcePermission(
+            person_id=person.id,
+            resource_type="initiatief",
+            resource_id=sample_initiatief.id,
+            rol="eigenaar",
+        )
+    )
+    bestaande_lead = Lead(
+        id=uuid.uuid4(),
+        title="Gemeente Z",
+        stage="verkennen",
+        initiatief_id=sample_initiatief.id,
+    )
+    db_session.add(bestaande_lead)
+    await db_session.flush()
+
+    suggested = SuggestedLead(
+        source_post_id=_id(),
+        source_channel_id=sample_channel.channel_id,
+        initiatief_id=sample_initiatief.id,
+        proposed_title="Lijkt op Gemeente Z",
+        raw_text="Update vanuit Gemeente Z over de regelhulp.",
+        match_existing_lead_id=bestaande_lead.id,
+        status="pending",
+    )
+    db_session.add(suggested)
+    await db_session.flush()
+    await db_session.refresh(suggested)
+
+    with patch(
+        "bouwmeester.services.mattermost_slash_service."
+        "MattermostSlashService._update_thread_post",
+        new=AsyncMock(return_value=None),
+    ):
+        service = MattermostSlashService(db_session)
+        result = await service.handle_action(
+            mattermost_user_id=mm_uid,
+            action="link_lead_to_suggestion",
+            context={"suggested_lead_id": str(suggested.id)},
+        )
+
+    assert result == {"ephemeral_text": "Bericht gekoppeld als notitie aan de lead."}
+
+    activities = (await db_session.execute(select(LeadActivity))).scalars().all()
+    assert len(activities) == 1
+    assert activities[0].lead_id == bestaande_lead.id
+    assert "Gemeente Z" in (activities[0].content or "")
+
+    await db_session.refresh(suggested)
+    assert suggested.status == "approved_linked"
+    assert suggested.approved_lead_id == bestaande_lead.id
+
+
+async def test_link_lead_rejects_cross_initiatief_lead(
+    db_session, sample_initiatief, sample_channel, create_person
+):
+    """Een 'match_existing_lead_id' uit een ander initiatief mag niet
+    leiden tot cross-initiatief-leak."""
+    from bouwmeester.models.initiatief import Initiatief
+    from bouwmeester.models.resource_permission import ResourcePermission
+
+    other_init = Initiatief(id=uuid.uuid4(), naam="Ander")
+    db_session.add(other_init)
+    await db_session.flush()
+    other_lead = Lead(
+        id=uuid.uuid4(),
+        title="Andere lead",
+        stage="inbox",
+        initiatief_id=other_init.id,
+    )
+    db_session.add(other_lead)
+    await db_session.flush()
+
+    person = await create_person(naam="A", prefix="a")
+    mm_uid = _id()
+    db_session.add(
+        MattermostUser(
+            person_id=person.id,
+            mattermost_user_id=mm_uid,
+            mattermost_username="a",
+        )
+    )
+    db_session.add(
+        ResourcePermission(
+            person_id=person.id,
+            resource_type="initiatief",
+            resource_id=sample_initiatief.id,
+            rol="eigenaar",
+        )
+    )
+    suggested = SuggestedLead(
+        source_post_id=_id(),
+        source_channel_id=sample_channel.channel_id,
+        initiatief_id=sample_initiatief.id,
+        proposed_title="X",
+        raw_text="Y",
+        match_existing_lead_id=other_lead.id,
+        status="pending",
+    )
+    db_session.add(suggested)
+    await db_session.flush()
+    await db_session.refresh(suggested)
+
+    with patch(
+        "bouwmeester.services.mattermost_slash_service."
+        "MattermostSlashService._update_thread_post",
+        new=AsyncMock(return_value=None),
+    ):
+        service = MattermostSlashService(db_session)
+        result = await service.handle_action(
+            mattermost_user_id=mm_uid,
+            action="link_lead_to_suggestion",
+            context={"suggested_lead_id": str(suggested.id)},
+        )
+
+    assert result == {"ephemeral_text": "Lead hoort niet bij dit initiatief."}
+    await db_session.refresh(suggested)
+    assert suggested.status == "pending"
+
+
+async def test_double_approval_is_idempotent(
+    db_session, sample_initiatief, sample_channel, create_person
+):
+    """Twee opeenvolgende approval-clicks leveren één Lead op (race-fix)."""
+    from bouwmeester.models.resource_permission import ResourcePermission
+
+    person = await create_person(naam="A", prefix="a")
+    mm_uid = _id()
+    db_session.add(
+        MattermostUser(
+            person_id=person.id,
+            mattermost_user_id=mm_uid,
+            mattermost_username="a",
+        )
+    )
+    db_session.add(
+        ResourcePermission(
+            person_id=person.id,
+            resource_type="initiatief",
+            resource_id=sample_initiatief.id,
+            rol="eigenaar",
+        )
+    )
+    suggested = SuggestedLead(
+        source_post_id=_id(),
+        source_channel_id=sample_channel.channel_id,
+        initiatief_id=sample_initiatief.id,
+        proposed_title="Eén lead",
+        raw_text="Y",
+        status="pending",
+    )
+    db_session.add(suggested)
+    await db_session.flush()
+    await db_session.refresh(suggested)
+
+    with patch(
+        "bouwmeester.services.mattermost_slash_service."
+        "MattermostSlashService._update_thread_post",
+        new=AsyncMock(return_value=None),
+    ):
+        service = MattermostSlashService(db_session)
+        await service.handle_action(
+            mattermost_user_id=mm_uid,
+            action="create_lead_from_suggestion",
+            context={"suggested_lead_id": str(suggested.id)},
+        )
+        # Tweede klik op dezelfde knop — verwacht een 'al verwerkt'-melding
+        # en geen tweede Lead.
+        result = await service.handle_action(
+            mattermost_user_id=mm_uid,
+            action="create_lead_from_suggestion",
+            context={"suggested_lead_id": str(suggested.id)},
+        )
+
+    assert result == {"ephemeral_text": "Deze suggestie is al verwerkt."}
+    leads = (
+        (
+            await db_session.execute(
+                select(Lead).where(Lead.initiatief_id == sample_initiatief.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(leads) == 1
+
+
+async def test_llm_unavailable_marks_skipped_reason(db_session, sample_channel):
+    """Als VLAM niet beschikbaar is, wordt de PostLink met
+    ``skipped_reason='llm_unavailable'`` aangemaakt zodat de post
+    later kan worden gereprocesseerd."""
+    from bouwmeester.models.mattermost_post_link import MattermostPostLink
+
+    with patch(
+        "bouwmeester.services.llm.factory.get_llm_service_for",
+        new=AsyncMock(return_value=None),
+    ):
+        ingest = MattermostIngestService(db_session)
+        post = {
+            "id": _id(),
+            "channel_id": sample_channel.channel_id,
+            "user_id": _id(),
+            "create_at": 1_700_000_000_000,
+            "message": "Mogelijk een lead.",
+        }
+        await ingest.ingest_post(post)
+
+    pl = (
+        await db_session.execute(
+            select(MattermostPostLink).where(MattermostPostLink.post_id == post["id"])
+        )
+    ).scalar_one()
+    assert pl.skipped_reason == "llm_unavailable"
+    assert pl.suggested_lead_id is None
+
+
+async def test_llm_says_no_marks_no_lead(db_session, sample_channel):
+    """LLM zegt expliciet niet-lead → skipped_reason='no_lead'."""
+    from bouwmeester.models.mattermost_post_link import MattermostPostLink
+
+    patches = _patch_llm(_llm_no())
+    for p in patches:
+        p.start()
+    try:
+        ingest = MattermostIngestService(db_session)
+        post = {
+            "id": _id(),
+            "channel_id": sample_channel.channel_id,
+            "user_id": _id(),
+            "create_at": 1_700_000_000_000,
+            "message": "ok prima",
+        }
+        await ingest.ingest_post(post)
+    finally:
+        for p in patches:
+            p.stop()
+
+    pl = (
+        await db_session.execute(
+            select(MattermostPostLink).where(MattermostPostLink.post_id == post["id"])
+        )
+    ).scalar_one()
+    assert pl.skipped_reason == "no_lead"

--- a/backend/tests/test_mattermost_websocket.py
+++ b/backend/tests/test_mattermost_websocket.py
@@ -1,0 +1,327 @@
+"""Tests voor de WS-dispatcher: user_removed / channel_deleted → disabled_at."""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from bouwmeester.models.initiatief import Initiatief
+from bouwmeester.models.mattermost_channel_link import (
+    SCOPE_INITIATIEF,
+    MattermostChannelLink,
+)
+from bouwmeester.services.mattermost_websocket_service import (
+    MattermostWebsocketService,
+    disable_channel_link,
+)
+
+
+def _id() -> str:
+    return uuid.uuid4().hex[:26]
+
+
+@pytest.fixture
+async def linked_channel(db_session):
+    init = Initiatief(id=uuid.uuid4(), naam="Test")
+    db_session.add(init)
+    await db_session.flush()
+    cid = _id()
+    link = MattermostChannelLink(
+        channel_id=cid,
+        channel_name="x",
+        channel_display_name="X",
+        scope_type=SCOPE_INITIATIEF,
+        scope_id=init.id,
+    )
+    db_session.add(link)
+    await db_session.flush()
+    return link
+
+
+# ---------------------------------------------------------------------------
+# disable_channel_link helper
+# ---------------------------------------------------------------------------
+
+
+async def test_disable_channel_link_sets_disabled_at(db_session, linked_channel):
+    ok = await disable_channel_link(db_session, linked_channel.channel_id)
+    assert ok is True
+    await db_session.refresh(linked_channel)
+    assert linked_channel.disabled_at is not None
+
+
+async def test_disable_channel_link_idempotent(db_session, linked_channel):
+    await disable_channel_link(db_session, linked_channel.channel_id)
+    first = linked_channel.disabled_at
+    ok = await disable_channel_link(db_session, linked_channel.channel_id)
+    assert ok is False
+    await db_session.refresh(linked_channel)
+    assert linked_channel.disabled_at == first
+
+
+async def test_disable_channel_link_unknown_channel(db_session):
+    ok = await disable_channel_link(db_session, _id())
+    assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# _channel_lost_channel_id parsing
+# ---------------------------------------------------------------------------
+
+
+def test_channel_lost_user_removed_other_user_ignored():
+    svc = MattermostWebsocketService()
+    svc._bot_user_id = "bot1234567890123456789012a"
+    msg = {
+        "event": "user_removed",
+        "data": {"user_id": "someone_else_____________a", "channel_id": _id()},
+    }
+    assert svc._channel_lost_channel_id("user_removed", msg) is None
+
+
+def test_channel_lost_user_removed_bot_data_payload():
+    svc = MattermostWebsocketService()
+    svc._bot_user_id = "bot1234567890123456789012a"
+    cid = _id()
+    msg = {
+        "event": "user_removed",
+        "data": {"user_id": svc._bot_user_id, "channel_id": cid},
+    }
+    assert svc._channel_lost_channel_id("user_removed", msg) == cid
+
+
+def test_channel_lost_user_removed_bot_broadcast_payload():
+    svc = MattermostWebsocketService()
+    svc._bot_user_id = "bot1234567890123456789012a"
+    cid = _id()
+    msg = {
+        "event": "user_removed",
+        "data": {"user_id": svc._bot_user_id},
+        "broadcast": {"channel_id": cid},
+    }
+    assert svc._channel_lost_channel_id("user_removed", msg) == cid
+
+
+def test_channel_lost_channel_deleted_data_payload():
+    svc = MattermostWebsocketService()
+    cid = _id()
+    msg = {"event": "channel_deleted", "data": {"channel_id": cid}}
+    assert svc._channel_lost_channel_id("channel_deleted", msg) == cid
+
+
+def test_channel_lost_channel_deleted_nested_channel_object():
+    svc = MattermostWebsocketService()
+    cid = _id()
+    msg = {"event": "channel_deleted", "data": {"channel": {"id": cid}}}
+    assert svc._channel_lost_channel_id("channel_deleted", msg) == cid
+
+
+def test_channel_lost_unknown_event():
+    svc = MattermostWebsocketService()
+    assert svc._channel_lost_channel_id("user_typing", {"data": {}}) is None
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: parse + disable
+# ---------------------------------------------------------------------------
+
+
+async def test_user_removed_for_bot_disables_link(db_session, linked_channel):
+    """Combinatie van parsing + DB-write: bot wordt uit kanaal verwijderd
+    → ``disabled_at`` wordt gezet."""
+    svc = MattermostWebsocketService()
+    svc._bot_user_id = "bot1234567890123456789012a"
+    msg = {
+        "event": "user_removed",
+        "data": {
+            "user_id": svc._bot_user_id,
+            "channel_id": linked_channel.channel_id,
+        },
+    }
+    cid = svc._channel_lost_channel_id("user_removed", msg)
+    assert cid == linked_channel.channel_id
+    await disable_channel_link(db_session, cid, event="user_removed")
+    await db_session.refresh(linked_channel)
+    assert linked_channel.disabled_at is not None
+
+
+async def test_user_removed_for_other_user_keeps_link_active(
+    db_session, linked_channel
+):
+    svc = MattermostWebsocketService()
+    svc._bot_user_id = "bot1234567890123456789012a"
+    msg = {
+        "event": "user_removed",
+        "data": {
+            "user_id": "anotherperson12345678901a",
+            "channel_id": linked_channel.channel_id,
+        },
+    }
+    assert svc._channel_lost_channel_id("user_removed", msg) is None
+    await db_session.refresh(linked_channel)
+    assert linked_channel.disabled_at is None
+
+
+# ---------------------------------------------------------------------------
+# Race-test: twee parallel approval-clicks zien het lock
+# ---------------------------------------------------------------------------
+
+
+async def test_double_approval_with_real_lock(_test_engine, create_person):
+    """Echte race-test: twee parallelle sessions klikken op dezelfde knop.
+
+    Eén krijgt de lock en maakt de Lead, de ander wacht en ziet
+    ``status != "pending"``. Resultaat: precies één Lead, één lopende
+    SuggestedLead met ``status="approved_new"``.
+
+    We omzeilen de standaard ``db_session``-fixture (die rolt aan het
+    eind alles terug en deelt één connectie) en gebruiken daadwerkelijk
+    twee concurrent ``AsyncSession``-instanties op dezelfde engine.
+    """
+    import asyncio
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from bouwmeester.models.lead import Lead
+    from bouwmeester.models.mattermost_user import MattermostUser
+    from bouwmeester.models.resource_permission import ResourcePermission
+    from bouwmeester.models.suggested_lead import SuggestedLead
+    from bouwmeester.services.mattermost_slash_service import MattermostSlashService
+
+    init_id = uuid.uuid4()
+    sug_id = uuid.uuid4()
+    person_id = uuid.uuid4()
+    mm_uid = _id()
+    cid = _id()
+
+    # Setup: één persoon met permission, één SuggestedLead in pending.
+    async with AsyncSession(_test_engine, expire_on_commit=False) as setup:
+        from bouwmeester.models.person import Person
+        from bouwmeester.models.person_email import PersonEmail
+
+        setup.add(Initiatief(id=init_id, naam="Race"))
+        await setup.flush()
+        setup.add(
+            Person(
+                id=person_id,
+                naam="A Race",
+                email="race@example.com",
+                is_active=True,
+            )
+        )
+        await setup.flush()
+        setup.add(
+            PersonEmail(person_id=person_id, email="race@example.com", is_default=True)
+        )
+        setup.add(
+            MattermostUser(
+                person_id=person_id,
+                mattermost_user_id=mm_uid,
+                mattermost_username="a",
+            )
+        )
+        setup.add(
+            ResourcePermission(
+                person_id=person_id,
+                resource_type="initiatief",
+                resource_id=init_id,
+                rol="eigenaar",
+            )
+        )
+        setup.add(
+            SuggestedLead(
+                id=sug_id,
+                source_post_id=_id(),
+                source_channel_id=cid,
+                initiatief_id=init_id,
+                proposed_title="Race lead",
+                raw_text="iets",
+                status="pending",
+            )
+        )
+        await setup.commit()
+
+    async def _click() -> dict:
+        async with AsyncSession(_test_engine, expire_on_commit=False) as s:
+            from unittest.mock import AsyncMock, patch
+
+            with patch(
+                "bouwmeester.services.mattermost_slash_service."
+                "MattermostSlashService._update_thread_post",
+                new=AsyncMock(return_value=None),
+            ):
+                service = MattermostSlashService(s)
+                result = await service.handle_action(
+                    mattermost_user_id=mm_uid,
+                    action="create_lead_from_suggestion",
+                    context={"suggested_lead_id": str(sug_id)},
+                )
+            await s.commit()
+            return result
+
+    try:
+        results = await asyncio.gather(_click(), _click())
+
+        async with AsyncSession(_test_engine, expire_on_commit=False) as verify:
+            leads = (
+                (
+                    await verify.execute(
+                        select(Lead).where(Lead.initiatief_id == init_id)
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            sug = (
+                await verify.execute(
+                    select(SuggestedLead).where(SuggestedLead.id == sug_id)
+                )
+            ).scalar_one()
+
+        # Exact één Lead, ondanks twee parallel clicks.
+        assert len(leads) == 1
+        assert sug.status == "approved_new"
+        assert sug.approved_lead_id == leads[0].id
+        # Eén response is een succesmelding, de ander zegt "al verwerkt".
+        msgs = sorted(r.get("ephemeral_text", "") for r in results)
+        assert "Lead aangemaakt" in msgs[0] or "al verwerkt" in msgs[0]
+        assert "Lead aangemaakt" in msgs[1] or "al verwerkt" in msgs[1]
+        assert any("Lead aangemaakt" in m for m in msgs)
+        assert any("al verwerkt" in m for m in msgs)
+    finally:
+        # Cleanup: verwijder de race-fixture-data zodat andere tests een
+        # schone DB hebben (we hebben buiten de standaard testtransactie
+        # geschreven).
+        async with AsyncSession(_test_engine, expire_on_commit=False) as cleanup:
+            from sqlalchemy import delete
+
+            from bouwmeester.models.lead_activity import LeadActivity
+
+            await cleanup.execute(
+                delete(LeadActivity).where(
+                    LeadActivity.lead_id.in_(
+                        select(Lead.id).where(Lead.initiatief_id == init_id)
+                    )
+                )
+            )
+            await cleanup.execute(delete(Lead).where(Lead.initiatief_id == init_id))
+            await cleanup.execute(
+                delete(SuggestedLead).where(SuggestedLead.id == sug_id)
+            )
+            await cleanup.execute(
+                delete(ResourcePermission).where(
+                    ResourcePermission.person_id == person_id
+                )
+            )
+            await cleanup.execute(
+                delete(MattermostUser).where(MattermostUser.person_id == person_id)
+            )
+            from bouwmeester.models.person import Person
+            from bouwmeester.models.person_email import PersonEmail
+
+            await cleanup.execute(
+                delete(PersonEmail).where(PersonEmail.person_id == person_id)
+            )
+            await cleanup.execute(delete(Person).where(Person.id == person_id))
+            await cleanup.execute(delete(Initiatief).where(Initiatief.id == init_id))
+            await cleanup.commit()

--- a/backend/tests/test_mattermost_websocket.py
+++ b/backend/tests/test_mattermost_websocket.py
@@ -1,7 +1,9 @@
 """Tests voor de WS-dispatcher: user_removed / channel_deleted → disabled_at."""
 
 import uuid
+from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
 from sqlalchemy import select
 
@@ -9,6 +11,10 @@ from bouwmeester.models.initiatief import Initiatief
 from bouwmeester.models.mattermost_channel_link import (
     SCOPE_INITIATIEF,
     MattermostChannelLink,
+)
+from bouwmeester.services.mattermost_service import (
+    MattermostService,
+    MattermostUnavailableError,
 )
 from bouwmeester.services.mattermost_websocket_service import (
     MattermostWebsocketService,
@@ -325,3 +331,209 @@ async def test_double_approval_with_real_lock(_test_engine, create_person):
             await cleanup.execute(delete(Person).where(Person.id == person_id))
             await cleanup.execute(delete(Initiatief).where(Initiatief.id == init_id))
             await cleanup.commit()
+
+
+# ---------------------------------------------------------------------------
+# is_bot_member_of_channel: 200 / 404 / error-onderscheid
+# ---------------------------------------------------------------------------
+
+
+def _mock_transport(status_code: int):
+    """Bouw een httpx.AsyncClient die elke request een vaste status returnt."""
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status_code, json={})
+
+    return httpx.AsyncClient(
+        transport=httpx.MockTransport(_handler),
+        base_url="http://mock-mattermost",
+        headers={"Authorization": "Bearer test"},
+    )
+
+
+async def test_is_bot_member_of_channel_returns_true_on_200(db_session):
+    service = MattermostService(db_session)
+    with (
+        patch.object(
+            service,
+            "get_bot_user_id",
+            new=AsyncMock(return_value="bot-id-26-chars-1234567890"),
+        ),
+        patch.object(
+            service, "_get_client", new=AsyncMock(return_value=_mock_transport(200))
+        ),
+    ):
+        assert await service.is_bot_member_of_channel(_id()) is True
+
+
+async def test_is_bot_member_of_channel_returns_false_on_404(db_session):
+    service = MattermostService(db_session)
+    with (
+        patch.object(
+            service,
+            "get_bot_user_id",
+            new=AsyncMock(return_value="bot-id-26-chars-1234567890"),
+        ),
+        patch.object(
+            service, "_get_client", new=AsyncMock(return_value=_mock_transport(404))
+        ),
+    ):
+        assert await service.is_bot_member_of_channel(_id()) is False
+
+
+async def test_is_bot_member_of_channel_raises_on_500(db_session):
+    """500 = MM-server-fout. Caller mag dit niet als 'geen lid' interpreteren."""
+    service = MattermostService(db_session)
+    with (
+        patch.object(
+            service,
+            "get_bot_user_id",
+            new=AsyncMock(return_value="bot-id-26-chars-1234567890"),
+        ),
+        patch.object(
+            service, "_get_client", new=AsyncMock(return_value=_mock_transport(500))
+        ),
+    ):
+        with pytest.raises(MattermostUnavailableError):
+            await service.is_bot_member_of_channel(_id())
+
+
+async def test_is_bot_member_of_channel_raises_on_network_error(db_session):
+    """Netwerk-glitch = onbekend, niet 'geen lid'."""
+    service = MattermostService(db_session)
+
+    def _handler(request):
+        raise httpx.ConnectError("connection refused")
+
+    flaky = httpx.AsyncClient(
+        transport=httpx.MockTransport(_handler),
+        base_url="http://mock-mattermost",
+    )
+    with (
+        patch.object(
+            service,
+            "get_bot_user_id",
+            new=AsyncMock(return_value="bot-id-26-chars-1234567890"),
+        ),
+        patch.object(service, "_get_client", new=AsyncMock(return_value=flaky)),
+    ):
+        with pytest.raises(MattermostUnavailableError):
+            await service.is_bot_member_of_channel(_id())
+
+
+async def test_is_bot_member_of_channel_raises_when_no_bot_user_id(db_session):
+    """Geen bot-user-id beschikbaar = MM niet geconfigureerd / bereikbaar."""
+    service = MattermostService(db_session)
+    with patch.object(service, "get_bot_user_id", new=AsyncMock(return_value=None)):
+        with pytest.raises(MattermostUnavailableError):
+            await service.is_bot_member_of_channel(_id())
+
+
+# ---------------------------------------------------------------------------
+# PATCH /api/mattermost-channels/{id} met reenable=true
+# ---------------------------------------------------------------------------
+
+
+async def test_patch_reenable_succeeds_when_bot_is_member(client, linked_channel):
+    """Bot is lid (mock 200) → disabled_at wordt None."""
+    from datetime import UTC, datetime
+
+    # Eerst link uitschakelen.
+    linked_channel.disabled_at = datetime.now(UTC)
+    # Mock zowel is_enabled als is_bot_member_of_channel.
+    with (
+        patch(
+            "bouwmeester.services.mattermost_service.MattermostService.is_enabled",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "bouwmeester.services.mattermost_service.MattermostService.is_bot_member_of_channel",
+            new=AsyncMock(return_value=True),
+        ),
+    ):
+        resp = await client.patch(
+            f"/api/mattermost-channels/{linked_channel.id}",
+            json={"reenable": True},
+        )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["disabled_at"] is None
+
+
+async def test_patch_reenable_409_when_bot_not_member(client, linked_channel):
+    """Bot is geen lid (mock 404 → False) → 409 met duidelijke melding."""
+    with (
+        patch(
+            "bouwmeester.services.mattermost_service.MattermostService.is_enabled",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "bouwmeester.services.mattermost_service.MattermostService.is_bot_member_of_channel",
+            new=AsyncMock(return_value=False),
+        ),
+    ):
+        resp = await client.patch(
+            f"/api/mattermost-channels/{linked_channel.id}",
+            json={"reenable": True},
+        )
+    assert resp.status_code == 409
+    assert "Voeg de bot eerst toe" in resp.json()["detail"]
+
+
+async def test_patch_reenable_503_on_mm_unavailable(client, linked_channel):
+    """Membership-check werpt MattermostUnavailableError → 503."""
+    with (
+        patch(
+            "bouwmeester.services.mattermost_service.MattermostService.is_enabled",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "bouwmeester.services.mattermost_service.MattermostService.is_bot_member_of_channel",
+            new=AsyncMock(side_effect=MattermostUnavailableError("netwerk")),
+        ),
+    ):
+        resp = await client.patch(
+            f"/api/mattermost-channels/{linked_channel.id}",
+            json={"reenable": True},
+        )
+    assert resp.status_code == 503
+    assert "tijdelijk niet bereikbaar" in resp.json()["detail"]
+
+
+async def test_patch_reenable_503_when_mm_disabled(client, linked_channel):
+    """is_enabled=False → 503 'niet geconfigureerd'."""
+    with patch(
+        "bouwmeester.services.mattermost_service.MattermostService.is_enabled",
+        new=AsyncMock(return_value=False),
+    ):
+        resp = await client.patch(
+            f"/api/mattermost-channels/{linked_channel.id}",
+            json={"reenable": True},
+        )
+    assert resp.status_code == 503
+    assert "niet geconfigureerd" in resp.json()["detail"]
+
+
+async def test_patch_without_reenable_does_not_check_bot(client, linked_channel):
+    """Settings-PATCH zonder reenable mag MM niet aanroepen."""
+    membership = AsyncMock(return_value=False)
+    with (
+        patch(
+            "bouwmeester.services.mattermost_service.MattermostService.is_bot_member_of_channel",
+            new=membership,
+        ),
+    ):
+        resp = await client.patch(
+            f"/api/mattermost-channels/{linked_channel.id}",
+            json={"auto_note_enabled": True},
+        )
+    assert resp.status_code == 200
+    membership.assert_not_called()
+
+
+async def test_patch_reenable_false_rejected_by_pydantic(client, linked_channel):
+    """Literal[True]: alleen ``true`` of weglaten — false geeft 422."""
+    resp = await client.patch(
+        f"/api/mattermost-channels/{linked_channel.id}",
+        json={"reenable": False},
+    )
+    assert resp.status_code == 422

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.15'",
@@ -148,6 +148,7 @@ dependencies = [
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "uvicorn", extra = ["standard"] },
     { name = "webauthn" },
+    { name = "websockets" },
 ]
 
 [package.dev-dependencies]
@@ -183,6 +184,7 @@ requires-dist = [
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.49" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.44.0" },
     { name = "webauthn", specifier = ">=2.7.1" },
+    { name = "websockets", specifier = ">=13.1" },
 ]
 
 [package.metadata.requires-dev]

--- a/frontend/src/api/mattermostChannels.ts
+++ b/frontend/src/api/mattermostChannels.ts
@@ -38,7 +38,8 @@ export interface MattermostChannelLinkCreate {
 export interface MattermostChannelLinkUpdate {
   auto_note_enabled?: boolean;
   suggest_leads_enabled?: boolean;
-  reenable?: boolean;
+  /** Alleen ``true`` is geldig; backend rejecteert ``false``. */
+  reenable?: true;
 }
 
 export async function listInitiatiefChannels(

--- a/frontend/src/api/mattermostChannels.ts
+++ b/frontend/src/api/mattermostChannels.ts
@@ -38,6 +38,7 @@ export interface MattermostChannelLinkCreate {
 export interface MattermostChannelLinkUpdate {
   auto_note_enabled?: boolean;
   suggest_leads_enabled?: boolean;
+  reenable?: boolean;
 }
 
 export async function listInitiatiefChannels(

--- a/frontend/src/api/mattermostChannels.ts
+++ b/frontend/src/api/mattermostChannels.ts
@@ -1,0 +1,100 @@
+import { apiDelete, apiGet, apiPatch, apiPost } from './client';
+
+export interface MattermostChannelLink {
+  id: string;
+  channel_id: string;
+  channel_name: string;
+  channel_display_name: string;
+  team_id: string | null;
+  scope_type: 'initiatief' | 'lead';
+  scope_id: string;
+  auto_note_enabled: boolean;
+  suggest_leads_enabled: boolean;
+  last_seen_post_at: number | null;
+  disabled_at: string | null;
+  created_by_id: string | null;
+  created_at: string;
+  updated_at: string | null;
+}
+
+export interface MattermostChannelSearchResult {
+  channel_id: string;
+  channel_name: string;
+  channel_display_name: string;
+  team_id: string | null;
+  member_count: number | null;
+  is_bot_member: boolean;
+}
+
+export interface MattermostChannelLinkCreate {
+  channel_id: string;
+  channel_name: string;
+  channel_display_name: string;
+  team_id?: string | null;
+  auto_note_enabled?: boolean;
+  suggest_leads_enabled?: boolean;
+}
+
+export interface MattermostChannelLinkUpdate {
+  auto_note_enabled?: boolean;
+  suggest_leads_enabled?: boolean;
+}
+
+export async function listInitiatiefChannels(
+  initiatiefId: string,
+): Promise<MattermostChannelLink[]> {
+  return apiGet<MattermostChannelLink[]>(
+    `/api/initiatieven/${initiatiefId}/mattermost-channels`,
+  );
+}
+
+export async function listLeadChannels(
+  leadId: string,
+): Promise<MattermostChannelLink[]> {
+  return apiGet<MattermostChannelLink[]>(
+    `/api/leads/${leadId}/mattermost-channels`,
+  );
+}
+
+export async function createInitiatiefChannelLink(
+  initiatiefId: string,
+  data: MattermostChannelLinkCreate,
+): Promise<MattermostChannelLink> {
+  return apiPost<MattermostChannelLink>(
+    `/api/initiatieven/${initiatiefId}/mattermost-channels`,
+    data,
+  );
+}
+
+export async function createLeadChannelLink(
+  leadId: string,
+  data: MattermostChannelLinkCreate,
+): Promise<MattermostChannelLink> {
+  return apiPost<MattermostChannelLink>(
+    `/api/leads/${leadId}/mattermost-channels`,
+    data,
+  );
+}
+
+export async function updateChannelLink(
+  linkId: string,
+  data: MattermostChannelLinkUpdate,
+): Promise<MattermostChannelLink> {
+  return apiPatch<MattermostChannelLink>(
+    `/api/mattermost-channels/${linkId}`,
+    data,
+  );
+}
+
+export async function deleteChannelLink(linkId: string): Promise<void> {
+  return apiDelete(`/api/mattermost-channels/${linkId}`);
+}
+
+export async function searchMattermostChannels(
+  q: string,
+): Promise<MattermostChannelSearchResult[]> {
+  return apiGet<MattermostChannelSearchResult[]>(
+    '/api/mattermost-channels/search',
+    { q },
+  );
+}

--- a/frontend/src/components/initiatieven/InitiatiefDetailModal.tsx
+++ b/frontend/src/components/initiatieven/InitiatiefDetailModal.tsx
@@ -51,6 +51,7 @@ import type {
   InitiatiefUpdatePost,
 } from '@/types';
 import { StakeholderTab } from '@/components/stakeholders/StakeholderTab';
+import { MattermostChannelsSection } from '@/components/mattermost/MattermostChannelsSection';
 
 interface InitiatiefDetailModalProps {
   initiatiefId: string;
@@ -465,6 +466,13 @@ export function InitiatiefDetailModal({
                 scopeType="initiatief"
                 scopeId={detail.id}
                 readOnly={!canEdit}
+              />
+            </div>
+
+            {/* Mattermost-kanalen */}
+            <div>
+              <MattermostChannelsSection
+                scope={{ type: 'initiatief', id: detail.id }}
               />
             </div>
 

--- a/frontend/src/components/initiatieven/InitiatiefDetailModal.tsx
+++ b/frontend/src/components/initiatieven/InitiatiefDetailModal.tsx
@@ -57,12 +57,15 @@ interface InitiatiefDetailModalProps {
   initiatiefId: string;
   open: boolean;
   onClose: () => void;
+  /** z-index van deze modal (default 50). Geneste modals krijgen +10. */
+  zIndex?: number;
 }
 
 export function InitiatiefDetailModal({
   initiatiefId,
   open,
   onClose,
+  zIndex = 50,
 }: InitiatiefDetailModalProps) {
   const { data: detail, isLoading } = useInitiatief(open ? initiatiefId : undefined);
 
@@ -257,6 +260,7 @@ export function InitiatiefDetailModal({
         onClose={handleClose}
         title={detail?.naam || 'Initiatief'}
         size="lg"
+        zIndex={zIndex}
         footer={footer}
         headerIcon={
           detail?.kleur ? (
@@ -473,7 +477,7 @@ export function InitiatiefDetailModal({
             <div>
               <MattermostChannelsSection
                 scope={{ type: 'initiatief', id: detail.id }}
-                parentZIndex={50}
+                parentZIndex={zIndex}
               />
             </div>
 

--- a/frontend/src/components/initiatieven/InitiatiefDetailModal.tsx
+++ b/frontend/src/components/initiatieven/InitiatiefDetailModal.tsx
@@ -473,6 +473,7 @@ export function InitiatiefDetailModal({
             <div>
               <MattermostChannelsSection
                 scope={{ type: 'initiatief', id: detail.id }}
+                parentZIndex={50}
               />
             </div>
 

--- a/frontend/src/components/leads/LeadDetailPanel.tsx
+++ b/frontend/src/components/leads/LeadDetailPanel.tsx
@@ -851,7 +851,7 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
                           {att.bestandsnaam ?? att.url}
                         </a>
                       ) : (
-                        <span className="flex-1 truncate text-text">{att.bestandsnaam}</span>
+                        <span className="flex-1 truncate text-text">{att.bestandsnaam ?? '(naamloos)'}</span>
                       )}
                       {att.source === 'mattermost' && (
                         <span className="text-[10px] uppercase tracking-wider text-text-secondary px-1.5 py-0.5 rounded bg-gray-100">
@@ -884,13 +884,13 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
                       <button
                         onClick={() => setLightboxSrc({
                           src: getLeadAttachmentDownloadUrl(lead.id, att.id),
-                          alt: att.bestandsnaam,
+                          alt: att.bestandsnaam ?? 'bijlage',
                         })}
                         className="relative group mt-2 ml-2 block"
                       >
                         <img
                           src={getLeadAttachmentDownloadUrl(lead.id, att.id)}
-                          alt={att.bestandsnaam}
+                          alt={att.bestandsnaam ?? 'bijlage'}
                           className="rounded-lg border border-border max-h-48 object-contain"
                         />
                         <div className="absolute inset-0 rounded-lg bg-black/0 group-hover:bg-black/20 transition-colors flex items-center justify-center">
@@ -1141,7 +1141,10 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
 
           {/* Mattermost-kanalen */}
           <DetailSection title="Mattermost" separated>
-            <MattermostChannelsSection scope={{ type: 'lead', id: lead.id }} />
+            <MattermostChannelsSection
+              scope={{ type: 'lead', id: lead.id }}
+              parentZIndex={zIndex}
+            />
           </DetailSection>
         </div>
       )}

--- a/frontend/src/components/leads/LeadDetailPanel.tsx
+++ b/frontend/src/components/leads/LeadDetailPanel.tsx
@@ -26,6 +26,7 @@ import { RichTextEditor } from '@/components/common/RichTextEditor';
 import { RichTextDisplay } from '@/components/common/RichTextDisplay';
 import { LinkLeadNodeModal } from './LinkLeadNodeModal';
 import { AddLeadContactModal } from './AddLeadContactModal';
+import { MattermostChannelsSection } from '@/components/mattermost/MattermostChannelsSection';
 import { Badge } from '@/components/common/Badge';
 import { DetailSection } from '@/components/common/DetailSection';
 import { DetailMetadataGrid } from '@/components/common/DetailMetadataGrid';
@@ -834,13 +835,34 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
                 {lead.attachments.map((att) => (
                   <div key={att.id}>
                     <div className={`flex items-center gap-2 text-sm rounded-lg px-2 py-1.5 hover:bg-gray-50 ${!att.bestand_beschikbaar ? 'opacity-50' : ''}`}>
-                      <Paperclip className="h-3.5 w-3.5 text-text-secondary shrink-0" />
-                      <span className="flex-1 truncate text-text">{att.bestandsnaam}</span>
-                      {!att.bestand_beschikbaar ? (
-                        <span className="text-xs text-red-500">Bestand niet beschikbaar</span>
+                      {att.soort === 'link' ? (
+                        <ExternalLink className="h-3.5 w-3.5 text-text-secondary shrink-0" />
                       ) : (
+                        <Paperclip className="h-3.5 w-3.5 text-text-secondary shrink-0" />
+                      )}
+                      {att.soort === 'link' && att.url ? (
+                        <a
+                          href={att.url}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="flex-1 truncate text-primary-700 hover:underline"
+                          title={att.url}
+                        >
+                          {att.bestandsnaam ?? att.url}
+                        </a>
+                      ) : (
+                        <span className="flex-1 truncate text-text">{att.bestandsnaam}</span>
+                      )}
+                      {att.source === 'mattermost' && (
+                        <span className="text-[10px] uppercase tracking-wider text-text-secondary px-1.5 py-0.5 rounded bg-gray-100">
+                          via mm
+                        </span>
+                      )}
+                      {att.soort === 'file' && !att.bestand_beschikbaar ? (
+                        <span className="text-xs text-red-500">Bestand niet beschikbaar</span>
+                      ) : att.soort === 'file' ? (
                         <>
-                          <span className="text-xs text-text-secondary">{Math.round(att.bestandsgrootte / 1024)} KB</span>
+                          <span className="text-xs text-text-secondary">{Math.round((att.bestandsgrootte ?? 0) / 1024)} KB</span>
                           <a
                             href={getLeadAttachmentDownloadUrl(lead.id, att.id)}
                             className="p-1 text-text-secondary hover:text-primary-600 transition-colors"
@@ -849,7 +871,7 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
                             <Download className="h-3.5 w-3.5" />
                           </a>
                         </>
-                      )}
+                      ) : null}
                       <button
                         onClick={() => deleteAttachment.mutate({ leadId: lead.id, attachmentId: att.id })}
                         className="p-1 text-text-secondary hover:text-red-500 transition-colors"
@@ -858,7 +880,7 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
                         <X className="h-3.5 w-3.5" />
                       </button>
                     </div>
-                    {att.bestand_beschikbaar && att.content_type?.startsWith('image/') && (
+                    {att.soort === 'file' && att.bestand_beschikbaar && att.content_type?.startsWith('image/') && (
                       <button
                         onClick={() => setLightboxSrc({
                           src: getLeadAttachmentDownloadUrl(lead.id, att.id),
@@ -1047,6 +1069,26 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
                         <Badge variant="gray">
                           {LEAD_ACTIVITY_TYPE_LABELS[activity.activity_type]}
                         </Badge>
+                        {activity.metadata_?.source === 'mattermost' && (
+                          (() => {
+                            const permalink = activity.metadata_?.mm_permalink;
+                            const badge = (
+                              <span className="inline-flex items-center gap-1 text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-blue-50 text-blue-700">
+                                via Mattermost
+                              </span>
+                            );
+                            return typeof permalink === 'string' ? (
+                              <a
+                                href={permalink}
+                                target="_blank"
+                                rel="noreferrer"
+                                title="Open in Mattermost"
+                              >
+                                {badge}
+                              </a>
+                            ) : badge;
+                          })()
+                        )}
                         <span>{timeAgo(activity.created_at)}</span>
                         {canDelete && (
                           <button
@@ -1095,6 +1137,11 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
             ) : (
               <p className="text-sm text-text-secondary">Nog geen activiteiten</p>
             )}
+          </DetailSection>
+
+          {/* Mattermost-kanalen */}
+          <DetailSection title="Mattermost" separated>
+            <MattermostChannelsSection scope={{ type: 'lead', id: lead.id }} />
           </DetailSection>
         </div>
       )}

--- a/frontend/src/components/mattermost/MattermostChannelsSection.tsx
+++ b/frontend/src/components/mattermost/MattermostChannelsSection.tsx
@@ -1,0 +1,281 @@
+import { useMemo, useState } from 'react';
+import { ExternalLink, Hash, Link2, Plus, Search, Trash2 } from 'lucide-react';
+import { Button } from '@/components/common/Button';
+import { Modal } from '@/components/common/Modal';
+import { LoadingSpinner } from '@/components/common/LoadingSpinner';
+import { useDebounce } from '@/hooks/useDebounce';
+import {
+  useCreateInitiatiefChannelLink,
+  useCreateLeadChannelLink,
+  useDeleteChannelLink,
+  useInitiatiefChannels,
+  useLeadChannels,
+  useSearchMattermostChannels,
+  useUpdateChannelLink,
+} from '@/hooks/useMattermostChannels';
+import type {
+  MattermostChannelLink,
+  MattermostChannelSearchResult,
+} from '@/api/mattermostChannels';
+
+type Scope =
+  | { type: 'initiatief'; id: string }
+  | { type: 'lead'; id: string };
+
+interface Props {
+  scope: Scope;
+}
+
+export function MattermostChannelsSection({ scope }: Props) {
+  const initiatiefQuery = useInitiatiefChannels(
+    scope.type === 'initiatief' ? scope.id : undefined,
+  );
+  const leadQuery = useLeadChannels(
+    scope.type === 'lead' ? scope.id : undefined,
+  );
+  const query = scope.type === 'initiatief' ? initiatiefQuery : leadQuery;
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  const updateMutation = useUpdateChannelLink(scope);
+  const deleteMutation = useDeleteChannelLink(scope);
+
+  return (
+    <div className="rounded-2xl border border-border bg-white p-4">
+      <div className="flex items-center justify-between mb-3">
+        <h4 className="text-sm font-semibold flex items-center gap-1.5">
+          <Hash className="h-4 w-4 text-text-secondary" />
+          Mattermost-kanalen
+        </h4>
+        <Button
+          variant="secondary"
+          size="sm"
+          icon={<Plus className="h-3.5 w-3.5" />}
+          onClick={() => setPickerOpen(true)}
+        >
+          Kanaal koppelen
+        </Button>
+      </div>
+
+      {query.isLoading && <LoadingSpinner className="py-6" />}
+      {query.isError && (
+        <p className="text-xs text-red-700 px-1 py-2">
+          Kon kanalen niet ophalen.
+        </p>
+      )}
+      {query.data && query.data.length === 0 && (
+        <p className="text-xs text-text-secondary px-1 py-2">
+          {scope.type === 'initiatief'
+            ? 'Nog geen kanalen gekoppeld. Bouwmeester leest mee in gekoppelde kanalen en stelt nieuwe leads voor.'
+            : 'Nog geen kanaal gekoppeld. Berichten in gekoppelde kanalen worden notities op deze lead.'}
+        </p>
+      )}
+      {query.data && query.data.length > 0 && (
+        <ul className="divide-y divide-border rounded-xl border border-border">
+          {query.data.map((link) => (
+            <ChannelRow
+              key={link.id}
+              link={link}
+              onToggleAutoNote={(value) =>
+                updateMutation.mutate({
+                  linkId: link.id,
+                  data: { auto_note_enabled: value },
+                })
+              }
+              onToggleSuggest={(value) =>
+                updateMutation.mutate({
+                  linkId: link.id,
+                  data: { suggest_leads_enabled: value },
+                })
+              }
+              onDelete={() => deleteMutation.mutate(link.id)}
+            />
+          ))}
+        </ul>
+      )}
+
+      <ChannelPickerModal
+        open={pickerOpen}
+        onClose={() => setPickerOpen(false)}
+        scope={scope}
+      />
+    </div>
+  );
+}
+
+function ChannelRow({
+  link,
+  onToggleAutoNote,
+  onToggleSuggest,
+  onDelete,
+}: {
+  link: MattermostChannelLink;
+  onToggleAutoNote: (value: boolean) => void;
+  onToggleSuggest: (value: boolean) => void;
+  onDelete: () => void;
+}) {
+  return (
+    <li className="px-3 py-2.5 flex items-start justify-between gap-3">
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2 text-sm">
+          <Hash className="h-3.5 w-3.5 text-text-secondary shrink-0" />
+          <span className="font-medium truncate">
+            {link.channel_display_name}
+          </span>
+          {link.disabled_at && (
+            <span className="text-xs text-red-700 px-1.5 py-0.5 rounded bg-red-50">
+              uitgeschakeld
+            </span>
+          )}
+        </div>
+        <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-xs text-text-secondary">
+          <label className="inline-flex items-center gap-1 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={link.auto_note_enabled}
+              onChange={(e) => onToggleAutoNote(e.target.checked)}
+            />
+            Berichten als notities
+          </label>
+          <label className="inline-flex items-center gap-1 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={link.suggest_leads_enabled}
+              onChange={(e) => onToggleSuggest(e.target.checked)}
+            />
+            Leads voorstellen
+          </label>
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={onDelete}
+        className="text-text-secondary hover:text-red-600 p-1.5 rounded-md hover:bg-red-50"
+        aria-label="Ontkoppelen"
+      >
+        <Trash2 className="h-4 w-4" />
+      </button>
+    </li>
+  );
+}
+
+function ChannelPickerModal({
+  open,
+  onClose,
+  scope,
+}: {
+  open: boolean;
+  onClose: () => void;
+  scope: Scope;
+}) {
+  const [q, setQ] = useState('');
+  const debounced = useDebounce(q, 250);
+  const search = useSearchMattermostChannels(debounced);
+  const createInit = useCreateInitiatiefChannelLink(
+    scope.type === 'initiatief' ? scope.id : undefined,
+  );
+  const createLead = useCreateLeadChannelLink(
+    scope.type === 'lead' ? scope.id : undefined,
+  );
+  const createMutation = scope.type === 'initiatief' ? createInit : createLead;
+  const errorMsg = useMemo(() => {
+    if (search.isError) {
+      const err = search.error as { message?: string } | undefined;
+      return err?.message ?? 'Kon Mattermost niet bereiken.';
+    }
+    return null;
+  }, [search.isError, search.error]);
+
+  const handlePick = (ch: MattermostChannelSearchResult) => {
+    createMutation.mutate(
+      {
+        channel_id: ch.channel_id,
+        channel_name: ch.channel_name,
+        channel_display_name: ch.channel_display_name,
+        team_id: ch.team_id,
+      },
+      {
+        onSuccess: () => {
+          setQ('');
+          onClose();
+        },
+      },
+    );
+  };
+
+  return (
+    <Modal open={open} onClose={onClose} title="Kanaal koppelen">
+      <div className="space-y-3">
+        <p className="text-xs text-text-secondary">
+          Zoek een kanaal waar de Bouwmeester-bot al lid van is. Niet
+          gevonden? Voeg de bot eerst toe aan dat kanaal in Mattermost.
+        </p>
+        <div className="relative">
+          <Search className="h-4 w-4 absolute left-2.5 top-1/2 -translate-y-1/2 text-text-secondary" />
+          <input
+            type="text"
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Zoek op kanaalnaam"
+            className="w-full pl-8 pr-3 py-2 text-sm rounded-xl border border-border focus:outline-none focus:ring-2 focus:ring-primary-500"
+            autoFocus
+          />
+        </div>
+        {errorMsg && (
+          <p className="text-xs text-red-700">{errorMsg}</p>
+        )}
+        {search.isLoading && <LoadingSpinner className="py-4" />}
+        {search.data && search.data.length === 0 && debounced.length >= 2 && (
+          <p className="text-xs text-text-secondary py-2">
+            Geen kanalen gevonden voor "{debounced}".
+          </p>
+        )}
+        {search.data && search.data.length > 0 && (
+          <ul className="divide-y divide-border rounded-xl border border-border max-h-72 overflow-y-auto">
+            {search.data.map((ch) => (
+              <li
+                key={ch.channel_id}
+                className="px-3 py-2 flex items-center justify-between gap-2 hover:bg-gray-50"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-1.5 text-sm font-medium truncate">
+                    <Hash className="h-3.5 w-3.5 text-text-secondary" />
+                    {ch.channel_display_name}
+                  </div>
+                  <div className="text-xs text-text-secondary truncate">
+                    {ch.channel_name}
+                  </div>
+                </div>
+                <Button
+                  size="sm"
+                  variant="primary"
+                  icon={<Link2 className="h-3.5 w-3.5" />}
+                  onClick={() => handlePick(ch)}
+                  disabled={createMutation.isPending}
+                >
+                  Koppelen
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+        {createMutation.isError && (
+          <p className="text-xs text-red-700">
+            Koppelen mislukt:{' '}
+            {(createMutation.error as { message?: string } | undefined)
+              ?.message ?? 'onbekende fout'}
+          </p>
+        )}
+        <div className="flex justify-end pt-2">
+          <a
+            href="https://docs.mattermost.com/welcome/managing-members.html"
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1 text-xs text-text-secondary hover:text-primary-700"
+          >
+            <ExternalLink className="h-3 w-3" /> Bot toevoegen aan kanaal
+          </a>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/components/mattermost/MattermostChannelsSection.tsx
+++ b/frontend/src/components/mattermost/MattermostChannelsSection.tsx
@@ -24,9 +24,13 @@ type Scope =
 
 interface Props {
   scope: Scope;
+  /** z-index van de parent-modal (lead/initiatief detail). De picker
+   *  opent met +10 bovenop deze waarde zodat hij niet achter de
+   *  parent-modal verdwijnt. */
+  parentZIndex?: number;
 }
 
-export function MattermostChannelsSection({ scope }: Props) {
+export function MattermostChannelsSection({ scope, parentZIndex }: Props) {
   const initiatiefQuery = useInitiatiefChannels(
     scope.type === 'initiatief' ? scope.id : undefined,
   );
@@ -97,6 +101,7 @@ export function MattermostChannelsSection({ scope }: Props) {
         open={pickerOpen}
         onClose={() => setPickerOpen(false)}
         scope={scope}
+        zIndex={(parentZIndex ?? 50) + 10}
       />
     </div>
   );
@@ -162,10 +167,12 @@ function ChannelPickerModal({
   open,
   onClose,
   scope,
+  zIndex,
 }: {
   open: boolean;
   onClose: () => void;
   scope: Scope;
+  zIndex: number;
 }) {
   const [q, setQ] = useState('');
   const debounced = useDebounce(q, 250);
@@ -203,7 +210,7 @@ function ChannelPickerModal({
   };
 
   return (
-    <Modal open={open} onClose={onClose} title="Kanaal koppelen">
+    <Modal open={open} onClose={onClose} title="Kanaal koppelen" zIndex={zIndex}>
       <div className="space-y-3">
         <p className="text-xs text-text-secondary">
           Zoek een kanaal waar de Bouwmeester-bot al lid van is. Niet

--- a/frontend/src/hooks/queryKeys.ts
+++ b/frontend/src/hooks/queryKeys.ts
@@ -185,6 +185,16 @@ export const queryKeys = {
     lists: () => ['initiatieven', 'list'] as const,
     list: (params?: { search?: string }) => ['initiatieven', 'list', params] as const,
     detail: (id: string | undefined) => ['initiatieven', 'detail', id] as const,
+    mattermostChannels: (id: string | undefined) =>
+      ['initiatieven', 'detail', id, 'mattermost-channels'] as const,
+  },
+
+  // --- Mattermost-channels ---
+  mattermostChannels: {
+    all: ['mattermost-channels'] as const,
+    search: (q: string) => ['mattermost-channels', 'search', q] as const,
+    forLead: (leadId: string | undefined) =>
+      ['leads', 'detail', leadId, 'mattermost-channels'] as const,
   },
 
   // --- Leads ---

--- a/frontend/src/hooks/useMattermostChannels.ts
+++ b/frontend/src/hooks/useMattermostChannels.ts
@@ -1,0 +1,110 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  createInitiatiefChannelLink,
+  createLeadChannelLink,
+  deleteChannelLink,
+  listInitiatiefChannels,
+  listLeadChannels,
+  searchMattermostChannels,
+  updateChannelLink,
+  type MattermostChannelLinkCreate,
+  type MattermostChannelLinkUpdate,
+} from '@/api/mattermostChannels';
+import { queryKeys } from '@/hooks/queryKeys';
+
+export function useInitiatiefChannels(initiatiefId: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.initiatieven.mattermostChannels(initiatiefId),
+    queryFn: () => listInitiatiefChannels(initiatiefId!),
+    enabled: !!initiatiefId,
+  });
+}
+
+export function useLeadChannels(leadId: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.mattermostChannels.forLead(leadId),
+    queryFn: () => listLeadChannels(leadId!),
+    enabled: !!leadId,
+  });
+}
+
+export function useSearchMattermostChannels(q: string) {
+  return useQuery({
+    queryKey: queryKeys.mattermostChannels.search(q),
+    queryFn: () => searchMattermostChannels(q),
+    enabled: q.length >= 2,
+    staleTime: 30_000,
+  });
+}
+
+export function useCreateInitiatiefChannelLink(initiatiefId: string | undefined) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: MattermostChannelLinkCreate) =>
+      createInitiatiefChannelLink(initiatiefId!, data),
+    onSuccess: () => {
+      qc.invalidateQueries({
+        queryKey: queryKeys.initiatieven.mattermostChannels(initiatiefId),
+      });
+    },
+  });
+}
+
+export function useCreateLeadChannelLink(leadId: string | undefined) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: MattermostChannelLinkCreate) =>
+      createLeadChannelLink(leadId!, data),
+    onSuccess: () => {
+      qc.invalidateQueries({
+        queryKey: queryKeys.mattermostChannels.forLead(leadId),
+      });
+    },
+  });
+}
+
+export function useUpdateChannelLink(
+  scope: { type: 'initiatief'; id: string } | { type: 'lead'; id: string } | null,
+) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      linkId,
+      data,
+    }: {
+      linkId: string;
+      data: MattermostChannelLinkUpdate;
+    }) => updateChannelLink(linkId, data),
+    onSuccess: () => {
+      if (scope?.type === 'initiatief') {
+        qc.invalidateQueries({
+          queryKey: queryKeys.initiatieven.mattermostChannels(scope.id),
+        });
+      } else if (scope?.type === 'lead') {
+        qc.invalidateQueries({
+          queryKey: queryKeys.mattermostChannels.forLead(scope.id),
+        });
+      }
+    },
+  });
+}
+
+export function useDeleteChannelLink(
+  scope: { type: 'initiatief'; id: string } | { type: 'lead'; id: string } | null,
+) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (linkId: string) => deleteChannelLink(linkId),
+    onSuccess: () => {
+      if (scope?.type === 'initiatief') {
+        qc.invalidateQueries({
+          queryKey: queryKeys.initiatieven.mattermostChannels(scope.id),
+        });
+      } else if (scope?.type === 'lead') {
+        qc.invalidateQueries({
+          queryKey: queryKeys.mattermostChannels.forLead(scope.id),
+        });
+      }
+    },
+  });
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1680,9 +1680,13 @@ export interface LeadExterneOrgSummary {
 export interface LeadAttachment {
   id: string;
   lead_id: string;
-  bestandsnaam: string;
-  content_type: string;
-  bestandsgrootte: number;
+  soort: 'file' | 'link';
+  bestandsnaam: string | null;
+  content_type: string | null;
+  bestandsgrootte: number | null;
+  url: string | null;
+  source: 'upload' | 'mattermost';
+  source_ref: string | null;
   bestand_beschikbaar: boolean;
   created_at: string;
 }


### PR DESCRIPTION
## Wat zit erin

Eén PR die Bouwmeester laat meelezen in gekoppelde Mattermost-kanalen. Geen tweede plek om iets in te voeren — het werk blijft in Mattermost.

### Datamodel
- `MattermostChannelLink` — kanaal ↔ initiatief óf lead (1-op-1, unique)
- `MattermostPostLink` — idempotency + audit per verwerkte post
- `SuggestedLead` — LLM-suggesties met status pending/approved_new/approved_linked/rejected
- `LeadAttachment` uitgebreid met `soort` (file|link), `url`, `source`, `source_ref`. Bestaande velden nullable. Migratie zet bestaande records op `soort=file`/`source=upload`.

### Persistente websocket
- `MattermostWebsocketService` in worker: auth via `authentication_challenge`, heartbeat-detectie, exponential backoff, recovery via REST `since=last_seen_post_at`
- Skipt bot-eigen posts (anti feedback-loop)
- Dispatcht naar `MattermostIngestService` per `posted`-event

### Auto-note voor lead/projectkanalen
- Bericht in een lead-gekoppeld kanaal → `LeadActivity` (type=note) op die lead
- Doc-link-extractor pikt URLs uit Drive, Confluence, SharePoint, Dropbox, Notion, Figma, Miro plus `.pdf/.docx/.pptx/...` op → `LeadAttachment(soort=link)` met "via mm"-badge in de UI
- Dedupe per URL per lead
- Author-resolutie via bestaande `mattermost_user`-koppeling; zonder koppeling staat er "via mm:@username"

### Suggested leads voor initiatief-kanalen
- VLAM (CONFIDENTIAL) classificeert berichten met context van recente leads in het initiatief
- Bot reageert in de thread met een attachment + knoppen `[Maak lead]` `[Koppel aan bestaande]` `[Negeer]`
- Approval-handlers in `mattermost.py`:
  - permission-check via `InitiatiefContext` (eigenaar/contributor/admin)
  - na approval wordt de thread-post geüpdatet met groen/blauw/grijs vinkje
  - bij "koppel aan bestaande" gebruiken we de LLM-suggested match — dialog-flow voor handmatige selectie kan in een follow-up

### Ruisfilter + samenvatting
- `is_mattermost_noise` skipt ack/emoji-only/lege berichten als auto-note
- Heuristiek vooraf: < 4 chars zonder LLM-call
- Lange berichten (>600 chars) worden samengevat; origineel bewaard in `metadata_.mm_original`

### Slash-commands
- `/bouwmeester koppel initiatief <slug-of-naam>`
- `/bouwmeester koppel lead <id-of-titel>`
- `/bouwmeester ontkoppel`
- `/bouwmeester kanaal` toont huidige koppeling
- Visibility-checks via `build_initiatief_context`

### Routes
- `GET/POST /api/initiatieven/{id}/mattermost-channels`
- `GET/POST /api/leads/{id}/mattermost-channels`
- `GET /api/mattermost-channels/search?q=…` (alleen kanalen waar bot lid is)
- `PATCH /api/mattermost-channels/{link_id}` (toggles)
- `DELETE /api/mattermost-channels/{link_id}`

### Frontend
- `MattermostChannelsSection` — herbruikbaar component voor initiatief- en lead-detail. Zoekt kanalen, koppelt, toont toggles en ontkoppel-knop
- LeadDetailPanel toont:
  - "via Mattermost"-badge in activiteit met permalink
  - URL-bijlagen met externe-link-icon en "via mm"-badge

### Tests
- 57 tests groen verdeeld over `test_mattermost_channels`, `test_mattermost_ingest`, `test_mattermost_suggested_lead`, `test_mattermost_noise_filter`, plus regressies in `test_mattermost`, `test_lead_activity`, `test_route_authorization_inventory`
- LLM-calls gemockt, MM-API-calls gepatched

## Test plan
- [x] Backend: pytest (57 tests)
- [x] Frontend: tsc clean + vite build
- [ ] Migratie: opwaarts en omlaag op een lege db
- [ ] Handmatig in MM:
  - [ ] kanaal koppelen aan initiatief, een waarschijnlijke lead-bericht plaatsen → bot-reply met knoppen, approval maakt lead aan
  - [ ] kanaal koppelen aan lead, document-link plaatsen → LeadActivity + LeadAttachment(soort=link)
  - [ ] "ok 👍" plaatsen → ruisfilter pakt het op, geen note
  - [ ] worker stoppen+starten → recovery via since