### PR TITLE
Samenwerkingsverbanden + community-graph + uitgebreide contact-aanmaak

### DIFF
--- a/backend/bouwmeester/api/routes/__init__.py
+++ b/backend/bouwmeester/api/routes/__init__.py
@@ -39,6 +39,9 @@ from bouwmeester.api.routes.resource_permissions import (
     router as resource_permissions_router,
 )
 from bouwmeester.api.routes.roles import router as roles_router
+from bouwmeester.api.routes.samenwerkingsverband import (
+    router as samenwerkingsverband_router,
+)
 from bouwmeester.api.routes.search import router as search_router
 from bouwmeester.api.routes.sharing import router as sharing_router
 from bouwmeester.api.routes.skill import router as skill_router
@@ -80,6 +83,7 @@ api_router.include_router(people_router)
 api_router.include_router(public_initiatief_router)
 api_router.include_router(resource_permissions_router)
 api_router.include_router(roles_router)
+api_router.include_router(samenwerkingsverband_router)
 api_router.include_router(search_router)
 api_router.include_router(sharing_router)
 api_router.include_router(skill_router)

--- a/backend/bouwmeester/api/routes/samenwerkingsverband.py
+++ b/backend/bouwmeester/api/routes/samenwerkingsverband.py
@@ -3,6 +3,7 @@
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from bouwmeester.api.deps import require_deleted, require_found
@@ -63,7 +64,7 @@ def _to_lid_response(
         person_id=lid.person_id,
         person_naam=lid.person.naam if lid.person else "",
         person_functie=lid.person.functie if lid.person else None,
-        person_expertise=getattr(lid.person, "expertise", None) if lid.person else None,
+        person_expertise=lid.person.expertise if lid.person else None,
         rol=lid.rol,
         start_datum=lid.start_datum,
         eind_datum=lid.eind_datum,
@@ -276,7 +277,18 @@ async def add_lid(
         start_datum=data.start_datum,
     )
     db.add(lid)
-    await db.flush()
+    try:
+        await db.flush()
+    except IntegrityError as exc:
+        # Race-vangnet: een parallelle add-lid kan tussen onze duplicate-check
+        # en deze flush hebben geinsert. Of de UniqueConstraint
+        # (person_id, samenwerkingsverband_id, start_datum) wordt geraakt
+        # door een eerder beëindigd lidmaatschap met dezelfde startdatum.
+        await db.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail="Lidmaatschap bestaat al voor deze combinatie",
+        ) from exc
     await db.refresh(lid, attribute_names=["person"])
 
     await log_activity(

--- a/backend/bouwmeester/api/routes/samenwerkingsverband.py
+++ b/backend/bouwmeester/api/routes/samenwerkingsverband.py
@@ -35,6 +35,25 @@ router = APIRouter(
 )
 
 
+def _to_response(
+    verband: Samenwerkingsverband, aantal_leden: int = 0
+) -> SamenwerkingsverbandResponse:
+    """Bouw een SamenwerkingsverbandResponse zonder de leden-relationship aan
+    te raken (vermijdt MissingGreenlet bij lazy-load in async)."""
+    return SamenwerkingsverbandResponse(
+        id=verband.id,
+        naam=verband.naam,
+        type=verband.type,
+        beschrijving=verband.beschrijving,
+        start_datum=verband.start_datum,
+        eind_datum=verband.eind_datum,
+        created_by_id=verband.created_by_id,
+        created_at=verband.created_at,
+        updated_at=verband.updated_at,
+        aantal_leden=aantal_leden,
+    )
+
+
 def _to_lid_response(
     lid: PersoonSamenwerkingsverband,
 ) -> SamenwerkingsverbandLidResponse:
@@ -111,9 +130,7 @@ async def create_samenwerkingsverband(
         },
     )
 
-    resp = SamenwerkingsverbandResponse.model_validate(verband)
-    resp.aantal_leden = 0
-    return resp
+    return _to_response(verband, aantal_leden=0)
 
 
 @router.get(
@@ -157,10 +174,19 @@ async def get_samenwerkingsverband(
     leden_actief = await repo.list_members(id, actief=True)
     aantal = await repo.count_active_members(id)
 
-    resp = SamenwerkingsverbandDetailResponse.model_validate(verband)
-    resp.aantal_leden = aantal
-    resp.leden = [_to_lid_response(lid) for lid in leden_actief]
-    return resp
+    return SamenwerkingsverbandDetailResponse(
+        id=verband.id,
+        naam=verband.naam,
+        type=verband.type,
+        beschrijving=verband.beschrijving,
+        start_datum=verband.start_datum,
+        eind_datum=verband.eind_datum,
+        created_by_id=verband.created_by_id,
+        created_at=verband.created_at,
+        updated_at=verband.updated_at,
+        aantal_leden=aantal,
+        leden=[_to_lid_response(lid) for lid in leden_actief],
+    )
 
 
 @router.put("/{id}", response_model=SamenwerkingsverbandResponse)
@@ -183,8 +209,7 @@ async def update_samenwerkingsverband(
     )
 
     aantal = await repo.count_active_members(id)
-    resp = SamenwerkingsverbandResponse.model_validate(verband)
-    resp.aantal_leden = aantal
+    resp = _to_response(verband, aantal_leden=aantal)
     return resp
 
 

--- a/backend/bouwmeester/api/routes/samenwerkingsverband.py
+++ b/backend/bouwmeester/api/routes/samenwerkingsverband.py
@@ -1,0 +1,345 @@
+"""API routes for Samenwerkingsverband (programma/werkgroep/...)."""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bouwmeester.api.deps import require_deleted, require_found
+from bouwmeester.core.auth import OptionalUser
+from bouwmeester.core.database import get_db
+from bouwmeester.core.permissions import require_permission
+from bouwmeester.models.person import Person
+from bouwmeester.models.persoon_samenwerkingsverband import (
+    PersoonSamenwerkingsverband,
+)
+from bouwmeester.models.samenwerkingsverband import Samenwerkingsverband
+from bouwmeester.repositories.samenwerkingsverband import (
+    SamenwerkingsverbandRepository,
+)
+from bouwmeester.schema.samenwerkingsverband import (
+    PersoonLidmaatschapResponse,
+    SamenwerkingsverbandCreate,
+    SamenwerkingsverbandDetailResponse,
+    SamenwerkingsverbandLidCreate,
+    SamenwerkingsverbandLidResponse,
+    SamenwerkingsverbandLidUpdate,
+    SamenwerkingsverbandResponse,
+    SamenwerkingsverbandUpdate,
+)
+from bouwmeester.services.activity_service import log_activity
+
+router = APIRouter(
+    prefix="/samenwerkingsverbanden",
+    tags=["samenwerkingsverbanden"],
+)
+
+
+def _to_lid_response(
+    lid: PersoonSamenwerkingsverband,
+) -> SamenwerkingsverbandLidResponse:
+    return SamenwerkingsverbandLidResponse(
+        id=lid.id,
+        samenwerkingsverband_id=lid.samenwerkingsverband_id,
+        person_id=lid.person_id,
+        person_naam=lid.person.naam if lid.person else "",
+        person_functie=lid.person.functie if lid.person else None,
+        person_expertise=getattr(lid.person, "expertise", None) if lid.person else None,
+        rol=lid.rol,
+        start_datum=lid.start_datum,
+        eind_datum=lid.eind_datum,
+        created_at=lid.created_at,
+    )
+
+
+@router.get("", response_model=list[SamenwerkingsverbandResponse])
+async def list_samenwerkingsverbanden(
+    current_user: OptionalUser,
+    search: str | None = Query(None, max_length=200),
+    type: str | None = Query(None, max_length=50),
+    actief: bool | None = Query(None),
+    skip: int = Query(0, ge=0),
+    limit: int = Query(1000, ge=1, le=2000),
+    db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("samenwerkingsverband:read")),
+) -> list[SamenwerkingsverbandResponse]:
+    repo = SamenwerkingsverbandRepository(db)
+    rows = await repo.get_all(
+        skip=skip, limit=limit, search=search, type_filter=type, actief=actief
+    )
+    return [
+        SamenwerkingsverbandResponse(
+            id=v.id,
+            naam=v.naam,
+            type=v.type,
+            beschrijving=v.beschrijving,
+            start_datum=v.start_datum,
+            eind_datum=v.eind_datum,
+            created_by_id=v.created_by_id,
+            created_at=v.created_at,
+            updated_at=v.updated_at,
+            aantal_leden=count,
+        )
+        for v, count in rows
+    ]
+
+
+@router.post(
+    "",
+    response_model=SamenwerkingsverbandResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_samenwerkingsverband(
+    data: SamenwerkingsverbandCreate,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("samenwerkingsverband:create")),
+) -> SamenwerkingsverbandResponse:
+    repo = SamenwerkingsverbandRepository(db)
+    created_by_id = current_user.id if current_user else None
+    verband = await repo.create(data, created_by_id=created_by_id)
+
+    await log_activity(
+        db,
+        current_user,
+        None,
+        "samenwerkingsverband.created",
+        details={
+            "samenwerkingsverband_id": str(verband.id),
+            "naam": verband.naam,
+            "type": verband.type,
+        },
+    )
+
+    resp = SamenwerkingsverbandResponse.model_validate(verband)
+    resp.aantal_leden = 0
+    return resp
+
+
+@router.get(
+    "/by-person/{person_id}",
+    response_model=list[PersoonLidmaatschapResponse],
+)
+async def list_for_person(
+    person_id: UUID,
+    current_user: OptionalUser,
+    actief: bool = Query(True),
+    db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("samenwerkingsverband:read")),
+) -> list[PersoonLidmaatschapResponse]:
+    """Geef alle (actieve) lidmaatschappen voor een persoon."""
+    require_found(await db.get(Person, person_id), "Person")
+    repo = SamenwerkingsverbandRepository(db)
+    rows = await repo.list_for_person(person_id, actief=actief)
+    return [
+        PersoonLidmaatschapResponse(
+            id=lid.id,
+            samenwerkingsverband_id=lid.samenwerkingsverband_id,
+            samenwerkingsverband_naam=lid.samenwerkingsverband.naam,
+            samenwerkingsverband_type=lid.samenwerkingsverband.type,
+            rol=lid.rol,
+            start_datum=lid.start_datum,
+            eind_datum=lid.eind_datum,
+        )
+        for lid in rows
+    ]
+
+
+@router.get("/{id}", response_model=SamenwerkingsverbandDetailResponse)
+async def get_samenwerkingsverband(
+    id: UUID,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("samenwerkingsverband:read")),
+) -> SamenwerkingsverbandDetailResponse:
+    repo = SamenwerkingsverbandRepository(db)
+    verband = require_found(await repo.get(id), "Samenwerkingsverband")
+    leden_actief = await repo.list_members(id, actief=True)
+    aantal = await repo.count_active_members(id)
+
+    resp = SamenwerkingsverbandDetailResponse.model_validate(verband)
+    resp.aantal_leden = aantal
+    resp.leden = [_to_lid_response(lid) for lid in leden_actief]
+    return resp
+
+
+@router.put("/{id}", response_model=SamenwerkingsverbandResponse)
+async def update_samenwerkingsverband(
+    id: UUID,
+    data: SamenwerkingsverbandUpdate,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("samenwerkingsverband:update")),
+) -> SamenwerkingsverbandResponse:
+    repo = SamenwerkingsverbandRepository(db)
+    verband = require_found(await repo.update(id, data), "Samenwerkingsverband")
+
+    await log_activity(
+        db,
+        current_user,
+        None,
+        "samenwerkingsverband.updated",
+        details={"samenwerkingsverband_id": str(verband.id), "naam": verband.naam},
+    )
+
+    aantal = await repo.count_active_members(id)
+    resp = SamenwerkingsverbandResponse.model_validate(verband)
+    resp.aantal_leden = aantal
+    return resp
+
+
+@router.delete("/{id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_samenwerkingsverband(
+    id: UUID,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("samenwerkingsverband:delete")),
+) -> None:
+    repo = SamenwerkingsverbandRepository(db)
+    verband = require_found(await repo.get(id), "Samenwerkingsverband")
+    naam = verband.naam
+    require_deleted(await repo.delete(id), "Samenwerkingsverband")
+
+    await log_activity(
+        db,
+        current_user,
+        None,
+        "samenwerkingsverband.deleted",
+        details={"samenwerkingsverband_id": str(id), "naam": naam},
+    )
+
+
+# --- Leden ---
+
+
+@router.get("/{id}/leden", response_model=list[SamenwerkingsverbandLidResponse])
+async def list_leden(
+    id: UUID,
+    current_user: OptionalUser,
+    actief: bool = Query(True),
+    db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("samenwerkingsverband:read")),
+) -> list[SamenwerkingsverbandLidResponse]:
+    repo = SamenwerkingsverbandRepository(db)
+    require_found(await repo.get(id), "Samenwerkingsverband")
+    leden = await repo.list_members(id, actief=actief)
+    return [_to_lid_response(lid) for lid in leden]
+
+
+@router.post(
+    "/{id}/leden",
+    response_model=SamenwerkingsverbandLidResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def add_lid(
+    id: UUID,
+    data: SamenwerkingsverbandLidCreate,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("samenwerkingsverband:update")),
+) -> SamenwerkingsverbandLidResponse:
+    verband = require_found(
+        await db.get(Samenwerkingsverband, id), "Samenwerkingsverband"
+    )
+    require_found(await db.get(Person, data.person_id), "Person")
+
+    # Voorkom dubbel actief lidmaatschap met dezelfde startdatum (uniqueconstraint)
+    from sqlalchemy import select
+
+    stmt = select(PersoonSamenwerkingsverband).where(
+        PersoonSamenwerkingsverband.samenwerkingsverband_id == id,
+        PersoonSamenwerkingsverband.person_id == data.person_id,
+        PersoonSamenwerkingsverband.eind_datum.is_(None),
+    )
+    existing = (await db.execute(stmt)).scalar_one_or_none()
+    if existing is not None:
+        raise HTTPException(
+            status_code=409,
+            detail="Persoon is al lid van dit samenwerkingsverband",
+        )
+
+    lid = PersoonSamenwerkingsverband(
+        samenwerkingsverband_id=id,
+        person_id=data.person_id,
+        rol=data.rol,
+        start_datum=data.start_datum,
+    )
+    db.add(lid)
+    await db.flush()
+    await db.refresh(lid, attribute_names=["person"])
+
+    await log_activity(
+        db,
+        current_user,
+        None,
+        "samenwerkingsverband.lid_added",
+        details={
+            "samenwerkingsverband_id": str(id),
+            "samenwerkingsverband_naam": verband.naam,
+            "person_id": str(data.person_id),
+        },
+    )
+
+    return _to_lid_response(lid)
+
+
+@router.put(
+    "/{id}/leden/{lid_id}",
+    response_model=SamenwerkingsverbandLidResponse,
+)
+async def update_lid(
+    id: UUID,
+    lid_id: UUID,
+    data: SamenwerkingsverbandLidUpdate,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("samenwerkingsverband:update")),
+) -> SamenwerkingsverbandLidResponse:
+    from sqlalchemy import select
+
+    stmt = select(PersoonSamenwerkingsverband).where(
+        PersoonSamenwerkingsverband.id == lid_id,
+        PersoonSamenwerkingsverband.samenwerkingsverband_id == id,
+    )
+    lid = require_found((await db.execute(stmt)).scalar_one_or_none(), "Lid")
+
+    for key, value in data.model_dump(exclude_unset=True).items():
+        setattr(lid, key, value)
+    await db.flush()
+    await db.refresh(lid, attribute_names=["person"])
+
+    return _to_lid_response(lid)
+
+
+@router.delete(
+    "/{id}/leden/{lid_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def remove_lid(
+    id: UUID,
+    lid_id: UUID,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("samenwerkingsverband:update")),
+) -> None:
+    from sqlalchemy import select
+
+    stmt = select(PersoonSamenwerkingsverband).where(
+        PersoonSamenwerkingsverband.id == lid_id,
+        PersoonSamenwerkingsverband.samenwerkingsverband_id == id,
+    )
+    lid = require_found((await db.execute(stmt)).scalar_one_or_none(), "Lid")
+    person_id = lid.person_id
+    await db.delete(lid)
+    await db.flush()
+
+    await log_activity(
+        db,
+        current_user,
+        None,
+        "samenwerkingsverband.lid_removed",
+        details={
+            "samenwerkingsverband_id": str(id),
+            "person_id": str(person_id),
+        },
+    )

--- a/backend/bouwmeester/api/routes/samenwerkingsverband.py
+++ b/backend/bouwmeester/api/routes/samenwerkingsverband.py
@@ -86,21 +86,7 @@ async def list_samenwerkingsverbanden(
     rows = await repo.get_all(
         skip=skip, limit=limit, search=search, type_filter=type, actief=actief
     )
-    return [
-        SamenwerkingsverbandResponse(
-            id=v.id,
-            naam=v.naam,
-            type=v.type,
-            beschrijving=v.beschrijving,
-            start_datum=v.start_datum,
-            eind_datum=v.eind_datum,
-            created_by_id=v.created_by_id,
-            created_at=v.created_at,
-            updated_at=v.updated_at,
-            aantal_leden=count,
-        )
-        for v, count in rows
-    ]
+    return [_to_response(v, aantal_leden=count) for v, count in rows]
 
 
 @router.post(
@@ -333,6 +319,20 @@ async def update_lid(
     await db.flush()
     await db.refresh(lid, attribute_names=["person"])
 
+    verband = await db.get(Samenwerkingsverband, id)
+    await log_activity(
+        db,
+        current_user,
+        None,
+        "samenwerkingsverband.lid_updated",
+        details={
+            "samenwerkingsverband_id": str(id),
+            "samenwerkingsverband_naam": verband.naam if verband else None,
+            "person_id": str(lid.person_id),
+            "fields": list(data.model_dump(exclude_unset=True).keys()),
+        },
+    )
+
     return _to_lid_response(lid)
 
 
@@ -355,6 +355,7 @@ async def remove_lid(
     )
     lid = require_found((await db.execute(stmt)).scalar_one_or_none(), "Lid")
     person_id = lid.person_id
+    verband = await db.get(Samenwerkingsverband, id)
     await db.delete(lid)
     await db.flush()
 
@@ -365,6 +366,7 @@ async def remove_lid(
         "samenwerkingsverband.lid_removed",
         details={
             "samenwerkingsverband_id": str(id),
+            "samenwerkingsverband_naam": verband.naam if verband else None,
             "person_id": str(person_id),
         },
     )

--- a/backend/bouwmeester/migrations/versions/e4f5a6b7c8d9_add_samenwerkingsverband.py
+++ b/backend/bouwmeester/migrations/versions/e4f5a6b7c8d9_add_samenwerkingsverband.py
@@ -1,7 +1,7 @@
 """add samenwerkingsverband and persoon_samenwerkingsverband
 
 Revision ID: e4f5a6b7c8d9
-Revises: a1f3c8e7d402
+Revises: d2e3f4a5b6c7
 Create Date: 2026-05-06 16:00:00.000000
 
 Voegt het Samenwerkingsverband-domein toe: ad-hoc samenwerkingsvormen
@@ -18,7 +18,7 @@ from alembic import op
 from sqlalchemy.dialects import postgresql
 
 revision: str = "e4f5a6b7c8d9"
-down_revision: str | None = "a1f3c8e7d402"
+down_revision: str | None = "d2e3f4a5b6c7"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/bouwmeester/migrations/versions/e4f5a6b7c8d9_add_samenwerkingsverband.py
+++ b/backend/bouwmeester/migrations/versions/e4f5a6b7c8d9_add_samenwerkingsverband.py
@@ -1,0 +1,174 @@
+"""add samenwerkingsverband and persoon_samenwerkingsverband
+
+Revision ID: e4f5a6b7c8d9
+Revises: a1f3c8e7d402
+Create Date: 2026-05-06 16:00:00.000000
+
+Voegt het Samenwerkingsverband-domein toe: ad-hoc samenwerkingsvormen
+(programma, werkgroep, opschalingsticket, ketenproject) los van de
+hierarchische OrganisatieEenheid-boom, met persoon-lidmaatschap via een
+junction-tabel.
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "e4f5a6b7c8d9"
+down_revision: str | None = "a1f3c8e7d402"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_NEW_PERMISSIONS = [
+    ("samenwerkingsverband:create", "samenwerkingsverband"),
+    ("samenwerkingsverband:read", "samenwerkingsverband"),
+    ("samenwerkingsverband:update", "samenwerkingsverband"),
+    ("samenwerkingsverband:delete", "samenwerkingsverband"),
+]
+
+# Zelfde rolset als initiatief: super_admin/ministry_admin/unit_manager
+# krijgen alles, editor mag create/read/update (niet delete), viewer alleen
+# read. platform_admin is bewust infra-only.
+_ROLE_GRANTS: dict[str, list[str]] = {
+    "super_admin": [p[0] for p in _NEW_PERMISSIONS],
+    "ministry_admin": [p[0] for p in _NEW_PERMISSIONS],
+    "unit_manager": [p[0] for p in _NEW_PERMISSIONS],
+    "editor": [
+        "samenwerkingsverband:create",
+        "samenwerkingsverband:read",
+        "samenwerkingsverband:update",
+    ],
+    "viewer": ["samenwerkingsverband:read"],
+}
+
+
+def upgrade() -> None:
+    op.create_table(
+        "samenwerkingsverband",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("naam", sa.String(), nullable=False),
+        sa.Column(
+            "type",
+            sa.String(),
+            nullable=False,
+            comment="programma|werkgroep|opschalingsticket|ketenproject",
+        ),
+        sa.Column("beschrijving", sa.Text(), nullable=True),
+        sa.Column("start_datum", sa.Date(), nullable=True),
+        sa.Column("eind_datum", sa.Date(), nullable=True),
+        sa.Column("created_by_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["created_by_id"], ["person.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "persoon_samenwerkingsverband",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("person_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "samenwerkingsverband_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column("rol", sa.String(), nullable=True),
+        sa.Column("start_datum", sa.Date(), nullable=False),
+        sa.Column("eind_datum", sa.Date(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["person_id"], ["person.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["samenwerkingsverband_id"],
+            ["samenwerkingsverband.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "person_id",
+            "samenwerkingsverband_id",
+            "start_datum",
+            name="uq_persoon_samenwerkingsverband_lidmaatschap",
+        ),
+    )
+    op.create_index(
+        op.f("ix_persoon_samenwerkingsverband_person_id"),
+        "persoon_samenwerkingsverband",
+        ["person_id"],
+    )
+    op.create_index(
+        op.f("ix_persoon_samenwerkingsverband_samenwerkingsverband_id"),
+        "persoon_samenwerkingsverband",
+        ["samenwerkingsverband_id"],
+    )
+
+    permission_table = sa.table(
+        "permission",
+        sa.column("id", sa.String()),
+        sa.column("category", sa.String()),
+    )
+    op.bulk_insert(
+        permission_table,
+        [{"id": pid, "category": cat} for pid, cat in _NEW_PERMISSIONS],
+    )
+
+    role_permission_table = sa.table(
+        "role_permission",
+        sa.column("role_id", sa.String()),
+        sa.column("permission_id", sa.String()),
+    )
+    op.bulk_insert(
+        role_permission_table,
+        [
+            {"role_id": role_id, "permission_id": perm_id}
+            for role_id, perms in _ROLE_GRANTS.items()
+            for perm_id in perms
+        ],
+    )
+
+
+def downgrade() -> None:
+    perm_ids = [p[0] for p in _NEW_PERMISSIONS]
+    bind = op.get_bind()
+    bind.execute(
+        sa.text("DELETE FROM role_permission WHERE permission_id = ANY(:ids)"),
+        {"ids": perm_ids},
+    )
+    bind.execute(
+        sa.text("DELETE FROM permission WHERE id = ANY(:ids)"),
+        {"ids": perm_ids},
+    )
+
+    op.drop_index(
+        op.f("ix_persoon_samenwerkingsverband_samenwerkingsverband_id"),
+        table_name="persoon_samenwerkingsverband",
+    )
+    op.drop_index(
+        op.f("ix_persoon_samenwerkingsverband_person_id"),
+        table_name="persoon_samenwerkingsverband",
+    )
+    op.drop_table("persoon_samenwerkingsverband")
+    op.drop_table("samenwerkingsverband")

--- a/backend/bouwmeester/models/__init__.py
+++ b/backend/bouwmeester/models/__init__.py
@@ -52,6 +52,9 @@ from bouwmeester.models.person import Person  # noqa: F401
 from bouwmeester.models.person_email import PersonEmail  # noqa: F401
 from bouwmeester.models.person_organisatie import PersonOrganisatieEenheid  # noqa: F401
 from bouwmeester.models.person_phone import PersonPhone  # noqa: F401
+from bouwmeester.models.persoon_samenwerkingsverband import (  # noqa: F401
+    PersoonSamenwerkingsverband,
+)
 from bouwmeester.models.politieke_input import PolitiekeInput  # noqa: F401
 from bouwmeester.models.probleem import Probleem  # noqa: F401
 from bouwmeester.models.resource_permission import ResourcePermission  # noqa: F401
@@ -61,6 +64,7 @@ from bouwmeester.models.role import (  # noqa: F401
     Role,
     RolePermission,
 )
+from bouwmeester.models.samenwerkingsverband import Samenwerkingsverband  # noqa: F401
 from bouwmeester.models.shared_access import SharedAccess  # noqa: F401
 from bouwmeester.models.stakeholder_assessment import (
     StakeholderAssessment,  # noqa: F401

--- a/backend/bouwmeester/models/persoon_samenwerkingsverband.py
+++ b/backend/bouwmeester/models/persoon_samenwerkingsverband.py
@@ -1,0 +1,57 @@
+"""PersoonSamenwerkingsverband junction model — temporal lidmaatschap."""
+
+import uuid
+from datetime import date, datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Date, DateTime, ForeignKey, UniqueConstraint, func, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from bouwmeester.core.database import Base
+
+if TYPE_CHECKING:
+    from bouwmeester.models.person import Person
+    from bouwmeester.models.samenwerkingsverband import Samenwerkingsverband
+
+
+class PersoonSamenwerkingsverband(Base):
+    __tablename__ = "persoon_samenwerkingsverband"
+    __table_args__ = (
+        UniqueConstraint(
+            "person_id",
+            "samenwerkingsverband_id",
+            "start_datum",
+            name="uq_persoon_samenwerkingsverband_lidmaatschap",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    person_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("person.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    samenwerkingsverband_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("samenwerkingsverband.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    rol: Mapped[str | None] = mapped_column(nullable=True)
+    start_datum: Mapped[date] = mapped_column(Date, nullable=False)
+    eind_datum: Mapped[date | None] = mapped_column(Date, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+    person: Mapped["Person"] = relationship("Person")
+    samenwerkingsverband: Mapped["Samenwerkingsverband"] = relationship(
+        "Samenwerkingsverband",
+        back_populates="leden",
+    )

--- a/backend/bouwmeester/models/samenwerkingsverband.py
+++ b/backend/bouwmeester/models/samenwerkingsverband.py
@@ -1,0 +1,53 @@
+"""Samenwerkingsverband model — ad-hoc samenwerkingsvormen los van de
+hierarchische OrganisatieEenheid-boom (programma, werkgroep,
+opschalingsticket, ketenproject)."""
+
+import uuid
+from datetime import date, datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Date, DateTime, ForeignKey, Text, func, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from bouwmeester.core.database import Base
+
+if TYPE_CHECKING:
+    from bouwmeester.models.persoon_samenwerkingsverband import (
+        PersoonSamenwerkingsverband,
+    )
+
+
+class Samenwerkingsverband(Base):
+    __tablename__ = "samenwerkingsverband"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    naam: Mapped[str] = mapped_column(nullable=False)
+    type: Mapped[str] = mapped_column(
+        nullable=False,
+        comment="programma|werkgroep|opschalingsticket|ketenproject",
+    )
+    beschrijving: Mapped[str | None] = mapped_column(Text, nullable=True)
+    start_datum: Mapped[date | None] = mapped_column(Date, nullable=True)
+    eind_datum: Mapped[date | None] = mapped_column(Date, nullable=True)
+    created_by_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("person.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), onupdate=func.now(), nullable=True
+    )
+
+    leden: Mapped[list["PersoonSamenwerkingsverband"]] = relationship(
+        "PersoonSamenwerkingsverband",
+        back_populates="samenwerkingsverband",
+        cascade="all, delete-orphan",
+    )

--- a/backend/bouwmeester/repositories/graph.py
+++ b/backend/bouwmeester/repositories/graph.py
@@ -21,7 +21,11 @@ from bouwmeester.models.lead_node import LeadNode
 from bouwmeester.models.organisatie_eenheid import OrganisatieEenheid
 from bouwmeester.models.person import Person
 from bouwmeester.models.person_organisatie import PersonOrganisatieEenheid
+from bouwmeester.models.persoon_samenwerkingsverband import (
+    PersoonSamenwerkingsverband,
+)
 from bouwmeester.models.resource_permission import ResourcePermission
+from bouwmeester.models.samenwerkingsverband import Samenwerkingsverband
 from bouwmeester.repositories.graph_filters import exclude_unconnected_pi
 from bouwmeester.schema.community_graph import (
     CommunityGraphEdge,
@@ -509,6 +513,46 @@ class GraphRepository:
                             target=f"oe-{pl.organisatie_eenheid_id}",
                             edge_type="lid_van",
                             label="lid van",
+                        )
+                    )
+
+        # -- 10. Person → Samenwerkingsverband (active lidmaatschappen) --
+        if person_ids:
+            today = date.today()
+            swv_lid_stmt = select(PersoonSamenwerkingsverband).where(
+                PersoonSamenwerkingsverband.person_id.in_(person_ids),
+                PersoonSamenwerkingsverband.start_datum <= today,
+                or_(
+                    PersoonSamenwerkingsverband.eind_datum.is_(None),
+                    PersoonSamenwerkingsverband.eind_datum >= today,
+                ),
+            )
+            swv_lid_result = await self.session.execute(swv_lid_stmt)
+            swv_lid_rows = list(swv_lid_result.scalars().all())
+            swv_ids = {lid.samenwerkingsverband_id for lid in swv_lid_rows}
+
+            if swv_ids:
+                swv_stmt = select(Samenwerkingsverband).where(
+                    Samenwerkingsverband.id.in_(swv_ids)
+                )
+                swv_result = await self.session.execute(swv_stmt)
+                for swv in swv_result.scalars().all():
+                    swv_key = f"swv-{swv.id}"
+                    graph_nodes[swv_key] = CommunityGraphNode(
+                        id=swv_key,
+                        node_type="samenwerkingsverband",
+                        label=swv.naam,
+                        samenwerkingsverband_type=swv.type,
+                    )
+
+                for lid in swv_lid_rows:
+                    graph_edges.append(
+                        CommunityGraphEdge(
+                            id=_next_edge_id(),
+                            source=f"person-{lid.person_id}",
+                            target=f"swv-{lid.samenwerkingsverband_id}",
+                            edge_type="lid_van_swv",
+                            label=lid.rol or "lid",
                         )
                     )
 

--- a/backend/bouwmeester/repositories/samenwerkingsverband.py
+++ b/backend/bouwmeester/repositories/samenwerkingsverband.py
@@ -70,11 +70,7 @@ class SamenwerkingsverbandRepository(BaseRepository[Samenwerkingsverband]):
         return [(row[0], row[1] or 0) for row in result.all()]
 
     async def get(self, id: UUID) -> Samenwerkingsverband | None:
-        stmt = (
-            select(Samenwerkingsverband)
-            .where(Samenwerkingsverband.id == id)
-            .options(selectinload(Samenwerkingsverband.created_by))
-        )
+        stmt = select(Samenwerkingsverband).where(Samenwerkingsverband.id == id)
         result = await self.session.execute(stmt)
         return result.scalar_one_or_none()
 

--- a/backend/bouwmeester/repositories/samenwerkingsverband.py
+++ b/backend/bouwmeester/repositories/samenwerkingsverband.py
@@ -1,0 +1,159 @@
+"""Repository for Samenwerkingsverband CRUD and lidmaatschap management."""
+
+from datetime import date
+from uuid import UUID
+
+from sqlalchemy import func, or_, select
+from sqlalchemy.orm import selectinload
+
+from bouwmeester.core.query_utils import escape_like
+from bouwmeester.models.persoon_samenwerkingsverband import (
+    PersoonSamenwerkingsverband,
+)
+from bouwmeester.models.samenwerkingsverband import Samenwerkingsverband
+from bouwmeester.repositories.base import BaseRepository
+from bouwmeester.schema.samenwerkingsverband import (
+    SamenwerkingsverbandCreate,
+    SamenwerkingsverbandUpdate,
+)
+
+
+class SamenwerkingsverbandRepository(BaseRepository[Samenwerkingsverband]):
+    model = Samenwerkingsverband
+
+    async def get_all(
+        self,
+        skip: int = 0,
+        limit: int = 1000,
+        search: str | None = None,
+        type_filter: str | None = None,
+        actief: bool | None = None,
+    ) -> list[tuple[Samenwerkingsverband, int]]:
+        """Return (verband, aantal_actieve_leden) tuples."""
+        today = date.today()
+        ledental_subq = (
+            select(func.count(PersoonSamenwerkingsverband.id))
+            .where(
+                PersoonSamenwerkingsverband.samenwerkingsverband_id
+                == Samenwerkingsverband.id,
+                PersoonSamenwerkingsverband.start_datum <= today,
+                or_(
+                    PersoonSamenwerkingsverband.eind_datum.is_(None),
+                    PersoonSamenwerkingsverband.eind_datum >= today,
+                ),
+            )
+            .correlate(Samenwerkingsverband)
+            .scalar_subquery()
+        )
+
+        stmt = select(Samenwerkingsverband, ledental_subq.label("aantal_leden"))
+        if search:
+            pattern = f"%{escape_like(search)}%"
+            stmt = stmt.where(Samenwerkingsverband.naam.ilike(pattern, escape="\\"))
+        if type_filter:
+            stmt = stmt.where(Samenwerkingsverband.type == type_filter)
+        if actief is True:
+            stmt = stmt.where(
+                or_(
+                    Samenwerkingsverband.eind_datum.is_(None),
+                    Samenwerkingsverband.eind_datum >= today,
+                )
+            )
+        elif actief is False:
+            stmt = stmt.where(
+                Samenwerkingsverband.eind_datum.is_not(None),
+                Samenwerkingsverband.eind_datum < today,
+            )
+
+        stmt = stmt.order_by(Samenwerkingsverband.naam).offset(skip).limit(limit)
+        result = await self.session.execute(stmt)
+        return [(row[0], row[1] or 0) for row in result.all()]
+
+    async def get(self, id: UUID) -> Samenwerkingsverband | None:
+        stmt = (
+            select(Samenwerkingsverband)
+            .where(Samenwerkingsverband.id == id)
+            .options(selectinload(Samenwerkingsverband.created_by))
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def count_active_members(self, id: UUID) -> int:
+        today = date.today()
+        stmt = select(func.count(PersoonSamenwerkingsverband.id)).where(
+            PersoonSamenwerkingsverband.samenwerkingsverband_id == id,
+            PersoonSamenwerkingsverband.start_datum <= today,
+            or_(
+                PersoonSamenwerkingsverband.eind_datum.is_(None),
+                PersoonSamenwerkingsverband.eind_datum >= today,
+            ),
+        )
+        result = await self.session.execute(stmt)
+        return int(result.scalar() or 0)
+
+    async def list_members(
+        self, id: UUID, actief: bool = True
+    ) -> list[PersoonSamenwerkingsverband]:
+        today = date.today()
+        stmt = (
+            select(PersoonSamenwerkingsverband)
+            .where(PersoonSamenwerkingsverband.samenwerkingsverband_id == id)
+            .options(selectinload(PersoonSamenwerkingsverband.person))
+            .order_by(PersoonSamenwerkingsverband.start_datum.desc())
+        )
+        if actief:
+            stmt = stmt.where(
+                PersoonSamenwerkingsverband.start_datum <= today,
+                or_(
+                    PersoonSamenwerkingsverband.eind_datum.is_(None),
+                    PersoonSamenwerkingsverband.eind_datum >= today,
+                ),
+            )
+        result = await self.session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def list_for_person(
+        self, person_id: UUID, actief: bool = True
+    ) -> list[PersoonSamenwerkingsverband]:
+        today = date.today()
+        stmt = (
+            select(PersoonSamenwerkingsverband)
+            .where(PersoonSamenwerkingsverband.person_id == person_id)
+            .options(
+                selectinload(PersoonSamenwerkingsverband.samenwerkingsverband),
+            )
+            .order_by(PersoonSamenwerkingsverband.start_datum.desc())
+        )
+        if actief:
+            stmt = stmt.where(
+                PersoonSamenwerkingsverband.start_datum <= today,
+                or_(
+                    PersoonSamenwerkingsverband.eind_datum.is_(None),
+                    PersoonSamenwerkingsverband.eind_datum >= today,
+                ),
+            )
+        result = await self.session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def create(
+        self,
+        data: SamenwerkingsverbandCreate,
+        created_by_id: UUID | None = None,
+    ) -> Samenwerkingsverband:
+        obj = Samenwerkingsverband(**data.model_dump(), created_by_id=created_by_id)
+        self.session.add(obj)
+        await self.session.flush()
+        await self.session.refresh(obj)
+        return obj
+
+    async def update(
+        self, id: UUID, data: SamenwerkingsverbandUpdate
+    ) -> Samenwerkingsverband | None:
+        obj = await self.session.get(Samenwerkingsverband, id)
+        if obj is None:
+            return None
+        for key, value in data.model_dump(exclude_unset=True).items():
+            setattr(obj, key, value)
+        await self.session.flush()
+        await self.session.refresh(obj)
+        return obj

--- a/backend/bouwmeester/schema/__init__.py
+++ b/backend/bouwmeester/schema/__init__.py
@@ -214,6 +214,16 @@ from bouwmeester.schema.role import (
     RoleResponse,
     RoleWithPermissionsResponse,
 )
+from bouwmeester.schema.samenwerkingsverband import (
+    PersoonLidmaatschapResponse,
+    SamenwerkingsverbandCreate,
+    SamenwerkingsverbandDetailResponse,
+    SamenwerkingsverbandLidCreate,
+    SamenwerkingsverbandLidResponse,
+    SamenwerkingsverbandLidUpdate,
+    SamenwerkingsverbandResponse,
+    SamenwerkingsverbandUpdate,
+)
 from bouwmeester.schema.search import (
     SearchResponse,
     SearchResult,
@@ -443,6 +453,15 @@ __all__ = [
     "LeadTimelineEvent",
     "LeadTimelineResponse",
     "LeadUpdate",
+    # samenwerkingsverband
+    "PersoonLidmaatschapResponse",
+    "SamenwerkingsverbandCreate",
+    "SamenwerkingsverbandDetailResponse",
+    "SamenwerkingsverbandLidCreate",
+    "SamenwerkingsverbandLidResponse",
+    "SamenwerkingsverbandLidUpdate",
+    "SamenwerkingsverbandResponse",
+    "SamenwerkingsverbandUpdate",
     # search
     "SearchResponse",
     "SearchResult",

--- a/backend/bouwmeester/schema/community_graph.py
+++ b/backend/bouwmeester/schema/community_graph.py
@@ -6,8 +6,12 @@ from pydantic import BaseModel, ConfigDict
 class CommunityGraphNode(BaseModel):
     """A node in the community graph (lead, person, organisation, or corpus node)."""
 
-    id: str  # prefixed: "lead-{uuid}", "person-{uuid}", "org-{uuid}", "node-{uuid}"
-    node_type: str  # "lead", "person", "organisation", "corpus_node"
+    # id is prefixed: "lead-{uuid}" | "person-{uuid}" | "oe-{uuid}" |
+    # "node-{uuid}" | "swv-{uuid}"
+    id: str
+    # one of: "lead", "person", "organisation", "corpus_node",
+    # "samenwerkingsverband"
+    node_type: str
     label: str
     # Type-specific metadata
     stage: str | None = None  # for leads
@@ -16,6 +20,7 @@ class CommunityGraphNode(BaseModel):
     expertise: str | None = None  # for persons
     person_role: str | None = None  # "intern" | "extern" — for persons
     org_type: str | None = None  # for organisations
+    samenwerkingsverband_type: str | None = None  # for samenwerkingsverbanden
     corpus_node_type: str | None = None  # for corpus nodes
 
     model_config = ConfigDict(from_attributes=True)

--- a/backend/bouwmeester/schema/samenwerkingsverband.py
+++ b/backend/bouwmeester/schema/samenwerkingsverband.py
@@ -1,0 +1,80 @@
+"""Pydantic schemas for Samenwerkingsverband."""
+
+from datetime import date, datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class SamenwerkingsverbandBase(BaseModel):
+    naam: str = Field(min_length=1, max_length=200)
+    type: str = Field(min_length=1, max_length=50)
+    beschrijving: str | None = Field(None, max_length=10_000)
+    start_datum: date | None = None
+    eind_datum: date | None = None
+
+
+class SamenwerkingsverbandCreate(SamenwerkingsverbandBase):
+    pass
+
+
+class SamenwerkingsverbandUpdate(BaseModel):
+    naam: str | None = Field(None, min_length=1, max_length=200)
+    type: str | None = Field(None, min_length=1, max_length=50)
+    beschrijving: str | None = Field(None, max_length=10_000)
+    start_datum: date | None = None
+    eind_datum: date | None = None
+
+
+class SamenwerkingsverbandResponse(SamenwerkingsverbandBase):
+    id: UUID
+    created_by_id: UUID | None = None
+    created_at: datetime
+    updated_at: datetime | None = None
+    aantal_leden: int = 0
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class SamenwerkingsverbandLidCreate(BaseModel):
+    person_id: UUID
+    rol: str | None = Field(None, max_length=50)
+    start_datum: date
+
+
+class SamenwerkingsverbandLidUpdate(BaseModel):
+    rol: str | None = Field(None, max_length=50)
+    eind_datum: date | None = None
+
+
+class SamenwerkingsverbandLidResponse(BaseModel):
+    id: UUID
+    samenwerkingsverband_id: UUID
+    person_id: UUID
+    person_naam: str = ""
+    person_functie: str | None = None
+    person_expertise: str | None = None
+    rol: str | None = None
+    start_datum: date
+    eind_datum: date | None = None
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class SamenwerkingsverbandDetailResponse(SamenwerkingsverbandResponse):
+    leden: list[SamenwerkingsverbandLidResponse] = []
+
+
+class PersoonLidmaatschapResponse(BaseModel):
+    """Lidmaatschap vanuit het persoon-perspectief: welke verbanden, welke rol."""
+
+    id: UUID
+    samenwerkingsverband_id: UUID
+    samenwerkingsverband_naam: str
+    samenwerkingsverband_type: str
+    rol: str | None = None
+    start_datum: date
+    eind_datum: date | None = None
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/tests/test_graph.py
+++ b/backend/tests/test_graph.py
@@ -1,11 +1,16 @@
 """Comprehensive API tests for the graph router."""
 
 import uuid
+from datetime import date
 
 from bouwmeester.models.corpus_node import CorpusNode
 from bouwmeester.models.edge import Edge
 from bouwmeester.models.lead import Lead
+from bouwmeester.models.persoon_samenwerkingsverband import (
+    PersoonSamenwerkingsverband,
+)
 from bouwmeester.models.resource_permission import ResourcePermission
+from bouwmeester.models.samenwerkingsverband import Samenwerkingsverband
 
 # ---------------------------------------------------------------------------
 # Graph search
@@ -339,3 +344,61 @@ async def test_community_graph_contact_edge_label_is_externe_contactpersoon(
     ]
     assert len(contact_edges) == 1
     assert contact_edges[0]["label"] == "externe contactpersoon"
+
+
+async def test_community_graph_renders_samenwerkingsverband(
+    client, db_session, sample_person
+):
+    """Een persoon met actief swv-lidmaatschap krijgt een swv-node + edge."""
+    lead = Lead(
+        id=uuid.uuid4(),
+        title="Lead met swv-lid",
+        stage="verkennen",
+        assignee_id=sample_person.id,
+    )
+    db_session.add(lead)
+
+    swv = Samenwerkingsverband(
+        id=uuid.uuid4(),
+        naam="CRI",
+        type="programma",
+    )
+    db_session.add(swv)
+    await db_session.flush()
+
+    db_session.add(
+        PersoonSamenwerkingsverband(
+            id=uuid.uuid4(),
+            person_id=sample_person.id,
+            samenwerkingsverband_id=swv.id,
+            rol="trekker",
+            start_datum=date.today(),
+        )
+    )
+    await db_session.flush()
+
+    resp = await client.get("/api/graph/community")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    swv_node = next(
+        (n for n in data["nodes"] if n["id"] == f"swv-{swv.id}"),
+        None,
+    )
+    assert swv_node is not None
+    assert swv_node["node_type"] == "samenwerkingsverband"
+    assert swv_node["label"] == "CRI"
+    assert swv_node["samenwerkingsverband_type"] == "programma"
+
+    swv_edge = next(
+        (
+            e
+            for e in data["edges"]
+            if e["source"] == f"person-{sample_person.id}"
+            and e["target"] == f"swv-{swv.id}"
+            and e["edge_type"] == "lid_van_swv"
+        ),
+        None,
+    )
+    assert swv_edge is not None
+    assert swv_edge["label"] == "trekker"

--- a/backend/tests/test_samenwerkingsverband.py
+++ b/backend/tests/test_samenwerkingsverband.py
@@ -1,0 +1,179 @@
+"""Tests voor het Samenwerkingsverband-domein."""
+
+from datetime import date, timedelta
+
+
+async def test_create_and_list(client):
+    """POST + GET roundtrip."""
+    create = await client.post(
+        "/api/samenwerkingsverbanden",
+        json={"naam": "CRI", "type": "programma"},
+    )
+    assert create.status_code == 201
+    body = create.json()
+    assert body["naam"] == "CRI"
+    assert body["type"] == "programma"
+    assert body["aantal_leden"] == 0
+
+    listing = await client.get("/api/samenwerkingsverbanden")
+    assert listing.status_code == 200
+    assert any(item["id"] == body["id"] for item in listing.json())
+
+
+async def test_filter_by_type(client):
+    await client.post(
+        "/api/samenwerkingsverbanden",
+        json={"naam": "Werkgroep AI", "type": "werkgroep"},
+    )
+    await client.post(
+        "/api/samenwerkingsverbanden",
+        json={"naam": "Programma X", "type": "programma"},
+    )
+
+    resp = await client.get("/api/samenwerkingsverbanden?type=werkgroep")
+    assert resp.status_code == 200
+    types = {v["type"] for v in resp.json()}
+    assert types == {"werkgroep"}
+
+
+async def test_update(client):
+    create = await client.post(
+        "/api/samenwerkingsverbanden",
+        json={"naam": "Voorlopig", "type": "werkgroep"},
+    )
+    swv_id = create.json()["id"]
+
+    upd = await client.put(
+        f"/api/samenwerkingsverbanden/{swv_id}",
+        json={"naam": "Werkgroep AI-verordening"},
+    )
+    assert upd.status_code == 200
+    assert upd.json()["naam"] == "Werkgroep AI-verordening"
+
+
+async def test_delete_cascades_leden(client, sample_person):
+    create = await client.post(
+        "/api/samenwerkingsverbanden",
+        json={"naam": "Tijdelijk", "type": "opschalingsticket"},
+    )
+    swv_id = create.json()["id"]
+
+    add = await client.post(
+        f"/api/samenwerkingsverbanden/{swv_id}/leden",
+        json={
+            "person_id": str(sample_person.id),
+            "rol": "lid",
+            "start_datum": date.today().isoformat(),
+        },
+    )
+    assert add.status_code == 201
+
+    delete = await client.delete(f"/api/samenwerkingsverbanden/{swv_id}")
+    assert delete.status_code == 204
+
+    # Lid is mee weg via CASCADE — detail-route geeft 404
+    detail = await client.get(f"/api/samenwerkingsverbanden/{swv_id}")
+    assert detail.status_code == 404
+
+
+async def test_lid_lifecycle(client, sample_person, second_person):
+    create = await client.post(
+        "/api/samenwerkingsverbanden",
+        json={"naam": "CRI", "type": "programma"},
+    )
+    swv_id = create.json()["id"]
+
+    today = date.today().isoformat()
+    add1 = await client.post(
+        f"/api/samenwerkingsverbanden/{swv_id}/leden",
+        json={
+            "person_id": str(sample_person.id),
+            "rol": "trekker",
+            "start_datum": today,
+        },
+    )
+    assert add1.status_code == 201
+    lid_id = add1.json()["id"]
+    assert add1.json()["person_naam"]
+    assert add1.json()["rol"] == "trekker"
+
+    add2 = await client.post(
+        f"/api/samenwerkingsverbanden/{swv_id}/leden",
+        json={"person_id": str(second_person.id), "rol": "lid", "start_datum": today},
+    )
+    assert add2.status_code == 201
+
+    detail = await client.get(f"/api/samenwerkingsverbanden/{swv_id}")
+    assert detail.status_code == 200
+    body = detail.json()
+    assert body["aantal_leden"] == 2
+    assert len(body["leden"]) == 2
+
+    # Update rol
+    upd = await client.put(
+        f"/api/samenwerkingsverbanden/{swv_id}/leden/{lid_id}",
+        json={"rol": "voorzitter"},
+    )
+    assert upd.status_code == 200
+    assert upd.json()["rol"] == "voorzitter"
+
+    # Verwijder
+    rm = await client.delete(f"/api/samenwerkingsverbanden/{swv_id}/leden/{lid_id}")
+    assert rm.status_code == 204
+
+    after = await client.get(f"/api/samenwerkingsverbanden/{swv_id}")
+    assert after.json()["aantal_leden"] == 1
+
+
+async def test_duplicate_active_lid_409(client, sample_person):
+    create = await client.post(
+        "/api/samenwerkingsverbanden",
+        json={"naam": "CRI", "type": "programma"},
+    )
+    swv_id = create.json()["id"]
+
+    today = date.today().isoformat()
+    a = await client.post(
+        f"/api/samenwerkingsverbanden/{swv_id}/leden",
+        json={"person_id": str(sample_person.id), "start_datum": today},
+    )
+    assert a.status_code == 201
+
+    b = await client.post(
+        f"/api/samenwerkingsverbanden/{swv_id}/leden",
+        json={"person_id": str(sample_person.id), "start_datum": today},
+    )
+    assert b.status_code == 409
+
+
+async def test_actief_filter(client):
+    today = date.today()
+    yesterday = today - timedelta(days=1)
+    last_week = today - timedelta(days=7)
+
+    actief_resp = await client.post(
+        "/api/samenwerkingsverbanden",
+        json={"naam": "Actief", "type": "programma"},
+    )
+    assert actief_resp.status_code == 201
+
+    inactief_resp = await client.post(
+        "/api/samenwerkingsverbanden",
+        json={
+            "naam": "Afgesloten",
+            "type": "opschalingsticket",
+            "start_datum": last_week.isoformat(),
+            "eind_datum": yesterday.isoformat(),
+        },
+    )
+    assert inactief_resp.status_code == 201
+
+    only_actief = await client.get("/api/samenwerkingsverbanden?actief=true")
+    namen = {v["naam"] for v in only_actief.json()}
+    assert "Actief" in namen
+    assert "Afgesloten" not in namen
+
+    only_inactief = await client.get("/api/samenwerkingsverbanden?actief=false")
+    namen = {v["naam"] for v in only_inactief.json()}
+    assert "Afgesloten" in namen
+    assert "Actief" not in namen

--- a/backend/tests/test_samenwerkingsverband.py
+++ b/backend/tests/test_samenwerkingsverband.py
@@ -177,3 +177,44 @@ async def test_actief_filter(client):
     namen = {v["naam"] for v in only_inactief.json()}
     assert "Afgesloten" in namen
     assert "Actief" not in namen
+
+
+async def test_list_for_person(client, sample_person):
+    """GET /by-person/{person_id} retourneert alle actieve lidmaatschappen."""
+    today = date.today().isoformat()
+
+    swv_a = (
+        await client.post(
+            "/api/samenwerkingsverbanden",
+            json={"naam": "CRI", "type": "programma"},
+        )
+    ).json()
+    swv_b = (
+        await client.post(
+            "/api/samenwerkingsverbanden",
+            json={"naam": "Werkgroep AI", "type": "werkgroep"},
+        )
+    ).json()
+
+    await client.post(
+        f"/api/samenwerkingsverbanden/{swv_a['id']}/leden",
+        json={
+            "person_id": str(sample_person.id),
+            "rol": "trekker",
+            "start_datum": today,
+        },
+    )
+    await client.post(
+        f"/api/samenwerkingsverbanden/{swv_b['id']}/leden",
+        json={"person_id": str(sample_person.id), "start_datum": today},
+    )
+
+    resp = await client.get(f"/api/samenwerkingsverbanden/by-person/{sample_person.id}")
+    assert resp.status_code == 200
+    items = resp.json()
+    assert len(items) == 2
+    namen = {item["samenwerkingsverband_naam"] for item in items}
+    assert namen == {"CRI", "Werkgroep AI"}
+    cri = next(i for i in items if i["samenwerkingsverband_naam"] == "CRI")
+    assert cri["rol"] == "trekker"
+    assert cri["samenwerkingsverband_type"] == "programma"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,6 +25,8 @@ import { ParlementairPage } from '@/pages/ParlementairPage';
 import { EenheidOverzichtPage } from '@/pages/EenheidOverzichtPage';
 import { OpdrachtenPage } from '@/pages/OpdrachtenPage';
 import { ExterneOrganisatiesPage } from '@/pages/ExterneOrganisatiesPage';
+import { SamenwerkingsverbandenPage } from '@/pages/SamenwerkingsverbandenPage';
+import { SamenwerkingsverbandDetailPage } from '@/pages/SamenwerkingsverbandDetailPage';
 import { AdminPage } from '@/pages/AdminPage';
 import { AuditLogPage } from '@/pages/AuditLogPage';
 import { DocsPage } from '@/pages/DocsPage';
@@ -145,6 +147,8 @@ function AuthenticatedApp() {
                   <Route path="/parlementair" element={<ParlementairPage />} />
                   <Route path="/opdrachten" element={<OpdrachtenPage />} />
                   <Route path="/externe-organisaties" element={<ExterneOrganisatiesPage />} />
+                  <Route path="/samenwerkingsverbanden" element={<SamenwerkingsverbandenPage />} />
+                  <Route path="/samenwerkingsverbanden/:id" element={<SamenwerkingsverbandDetailPage />} />
                   <Route path="/admin" element={<AdminPage />} />
                   <Route path="/auditlog" element={<AuditLogPage />} />
                   <Route path="/docs" element={<DocsPage />} />

--- a/frontend/src/api/samenwerkingsverbanden.ts
+++ b/frontend/src/api/samenwerkingsverbanden.ts
@@ -1,0 +1,92 @@
+import { apiGet, apiPost, apiPut, apiDelete } from './client';
+import type {
+  PersoonLidmaatschap,
+  Samenwerkingsverband,
+  SamenwerkingsverbandCreate,
+  SamenwerkingsverbandDetail,
+  SamenwerkingsverbandLid,
+  SamenwerkingsverbandLidCreate,
+  SamenwerkingsverbandLidUpdate,
+  SamenwerkingsverbandUpdate,
+} from '@/types';
+
+export async function getSamenwerkingsverbanden(params?: {
+  search?: string;
+  type?: string;
+  actief?: boolean;
+}): Promise<Samenwerkingsverband[]> {
+  const query: Record<string, string> = {};
+  if (params?.search) query.search = params.search;
+  if (params?.type) query.type = params.type;
+  if (params?.actief !== undefined) query.actief = String(params.actief);
+  return apiGet<Samenwerkingsverband[]>('/api/samenwerkingsverbanden', query);
+}
+
+export async function getSamenwerkingsverband(
+  id: string,
+): Promise<SamenwerkingsverbandDetail> {
+  return apiGet<SamenwerkingsverbandDetail>(`/api/samenwerkingsverbanden/${id}`);
+}
+
+export async function createSamenwerkingsverband(
+  data: SamenwerkingsverbandCreate,
+): Promise<Samenwerkingsverband> {
+  return apiPost<Samenwerkingsverband>('/api/samenwerkingsverbanden', data);
+}
+
+export async function updateSamenwerkingsverband(
+  id: string,
+  data: SamenwerkingsverbandUpdate,
+): Promise<Samenwerkingsverband> {
+  return apiPut<Samenwerkingsverband>(`/api/samenwerkingsverbanden/${id}`, data);
+}
+
+export async function deleteSamenwerkingsverband(id: string): Promise<void> {
+  return apiDelete(`/api/samenwerkingsverbanden/${id}`);
+}
+
+// Leden
+export async function listLeden(
+  swvId: string,
+  actief: boolean = true,
+): Promise<SamenwerkingsverbandLid[]> {
+  return apiGet<SamenwerkingsverbandLid[]>(
+    `/api/samenwerkingsverbanden/${swvId}/leden`,
+    { actief: String(actief) },
+  );
+}
+
+export async function addLid(
+  swvId: string,
+  data: SamenwerkingsverbandLidCreate,
+): Promise<SamenwerkingsverbandLid> {
+  return apiPost<SamenwerkingsverbandLid>(
+    `/api/samenwerkingsverbanden/${swvId}/leden`,
+    data,
+  );
+}
+
+export async function updateLid(
+  swvId: string,
+  lidId: string,
+  data: SamenwerkingsverbandLidUpdate,
+): Promise<SamenwerkingsverbandLid> {
+  return apiPut<SamenwerkingsverbandLid>(
+    `/api/samenwerkingsverbanden/${swvId}/leden/${lidId}`,
+    data,
+  );
+}
+
+export async function removeLid(swvId: string, lidId: string): Promise<void> {
+  return apiDelete(`/api/samenwerkingsverbanden/${swvId}/leden/${lidId}`);
+}
+
+export async function listForPerson(
+  personId: string,
+  actief: boolean = true,
+): Promise<PersoonLidmaatschap[]> {
+  return apiGet<PersoonLidmaatschap[]>(
+    `/api/samenwerkingsverbanden/by-person/${personId}`,
+    { actief: String(actief) },
+  );
+}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -25,6 +25,7 @@ const pageTitles: Record<string, string> = {
   '/search': 'Zoeken',
   '/docs': 'Handleiding',
   '/leads': 'Leads',
+  '/samenwerkingsverbanden': 'Samenwerkingsverbanden',
   '/share-target': 'Nieuwe lead',
 };
 

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -17,6 +17,7 @@ import {
   BookOpen,
   Banknote,
   Funnel,
+  Handshake,
 } from 'lucide-react';
 import logoImg from '/logo.png?url';
 import { useUIStore } from '@/store/ui';
@@ -55,6 +56,12 @@ export function Sidebar({ mobile }: SidebarProps) {
       { to: '/eenheid-overzicht', icon: Users, label: eenheidLabel, permission: 'org:read' },
       { to: '/opdrachten', icon: Banknote, label: 'Opdrachten', permission: 'opdracht:read' },
       { to: '/leads', icon: Funnel, label: 'Leads', permission: 'lead:read' },
+      {
+        to: '/samenwerkingsverbanden',
+        icon: Handshake,
+        label: 'Samenwerkingsverbanden',
+        permission: 'samenwerkingsverband:read',
+      },
       { to: '/parlementair', icon: ScrollText, label: 'Kamerstukken', permission: 'node:read' },
       { to: '/search', icon: Search, label: 'Zoeken' },
       { to: '/docs', icon: BookOpen, label: 'Handleiding' },

--- a/frontend/src/components/leads/AddLeadContactModal.tsx
+++ b/frontend/src/components/leads/AddLeadContactModal.tsx
@@ -1,11 +1,25 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 
 import { Modal } from '@/components/common/Modal';
 import { Button } from '@/components/common/Button';
+import { Input } from '@/components/common/Input';
 import { CreatableSelect, type SelectOption } from '@/components/common/CreatableSelect';
-import { usePeople, useCreatePerson } from '@/hooks/usePeople';
+import { CascadingOrgSelect } from '@/components/common/CascadingOrgSelect';
+import {
+  usePeople,
+  useCreatePerson,
+  useExpertiseValues,
+  useAddPersonOrganisatie,
+} from '@/hooks/usePeople';
 import { useAddLeadContact } from '@/hooks/useLeads';
-import { LEAD_CONTACT_ROL_LABELS } from '@/types';
+import {
+  useSamenwerkingsverbanden,
+  useAddLid,
+} from '@/hooks/useSamenwerkingsverbanden';
+import {
+  LEAD_CONTACT_ROL_LABELS,
+  SAMENWERKINGSVERBAND_TYPE_LABELS,
+} from '@/types';
 
 const CONTACT_ROLLEN: SelectOption[] = Object.entries(LEAD_CONTACT_ROL_LABELS).map(
   ([value, label]) => ({ value, label }),
@@ -16,13 +30,29 @@ interface Props {
   onClose: () => void;
 }
 
+type Mode = 'select' | 'create';
+
 export function AddLeadContactModal({ leadId, onClose }: Props) {
   const { data: people = [] } = usePeople();
+  const { data: expertiseValues = [] } = useExpertiseValues();
+  const { data: samenwerkingsverbanden = [] } = useSamenwerkingsverbanden({ actief: true });
   const createPerson = useCreatePerson();
   const addContact = useAddLeadContact();
+  const addPersonOrg = useAddPersonOrganisatie();
+  const addLidMutation = useAddLid();
 
+  const [mode, setMode] = useState<Mode>('select');
   const [personId, setPersonId] = useState('');
   const [rol, setRol] = useState('contactpersoon');
+
+  // Velden voor "create"-mode
+  const [naam, setNaam] = useState('');
+  const [email, setEmail] = useState('');
+  const [functie, setFunctie] = useState('');
+  const [expertise, setExpertise] = useState('');
+  const [orgEenheidId, setOrgEenheidId] = useState('');
+  const [swvIds, setSwvIds] = useState<Set<string>>(new Set());
+  const [expertiseLocalAdded, setExpertiseLocalAdded] = useState<string[]>([]);
 
   const personOptions: SelectOption[] = people.map((p) => {
     const parts = [p.functie, p.expertise].filter((v): v is string => !!v);
@@ -33,68 +63,271 @@ export function AddLeadContactModal({ leadId, onClose }: Props) {
     };
   });
 
-  const handleCreatePerson = useCallback(
-    async (name: string): Promise<string | null> => {
-      const result = await createPerson.mutateAsync({ naam: name, force: true });
-      return result?.id ?? null;
-    },
-    [createPerson],
+  const expertiseOptions: SelectOption[] = useMemo(
+    () => [
+      ...expertiseValues.map((v) => ({ value: v, label: v })),
+      ...expertiseLocalAdded
+        .filter((v) => !expertiseValues.includes(v))
+        .map((v) => ({ value: v, label: v })),
+    ],
+    [expertiseValues, expertiseLocalAdded],
   );
 
+  const toggleSwv = (id: string) => {
+    setSwvIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const switchToCreate = useCallback((typedName: string) => {
+    setMode('create');
+    setNaam(typedName);
+    setEmail('');
+    setFunctie('');
+    setExpertise('');
+    setOrgEenheidId('');
+    setSwvIds(new Set());
+    return null;
+  }, []);
+
   const resetAndClose = useCallback(() => {
+    setMode('select');
     setPersonId('');
     setRol('contactpersoon');
+    setNaam('');
+    setEmail('');
+    setFunctie('');
+    setExpertise('');
+    setOrgEenheidId('');
+    setSwvIds(new Set());
+    setExpertiseLocalAdded([]);
     onClose();
   }, [onClose]);
 
-  const handleSubmit = useCallback(async () => {
+  const handleSubmitSelect = useCallback(async () => {
     if (!leadId || !personId) return;
     try {
       await addContact.mutateAsync({ leadId, personId, rol });
       resetAndClose();
     } catch {
-      // useMutationWithError already shows a toast; keep modal open so the user can retry
+      // toast wordt al getoond
     }
   }, [leadId, personId, rol, addContact, resetAndClose]);
+
+  const handleSubmitCreate = useCallback(async () => {
+    if (!leadId || !naam.trim()) return;
+
+    let created;
+    try {
+      created = await createPerson.mutateAsync({
+        naam: naam.trim(),
+        email: email.trim() || undefined,
+        functie: functie.trim() || undefined,
+        expertise: expertise.trim() || undefined,
+        force: true,
+      });
+    } catch {
+      return; // toast getoond, modal blijft open
+    }
+    const newPersonId = created.id;
+
+    // Best-effort follow-ups; falen blokkeert de lead-koppeling niet.
+    const today = new Date().toISOString().slice(0, 10);
+    if (orgEenheidId) {
+      try {
+        await addPersonOrg.mutateAsync({
+          personId: newPersonId,
+          data: { organisatie_eenheid_id: orgEenheidId, start_datum: today },
+        });
+      } catch {
+        // ignore — toast getoond
+      }
+    }
+    for (const swvId of swvIds) {
+      try {
+        await addLidMutation.mutateAsync({
+          swvId,
+          data: { person_id: newPersonId, start_datum: today },
+        });
+      } catch {
+        // ignore
+      }
+    }
+
+    try {
+      await addContact.mutateAsync({ leadId, personId: newPersonId, rol });
+      resetAndClose();
+    } catch {
+      // toast
+    }
+  }, [
+    leadId,
+    naam,
+    email,
+    functie,
+    expertise,
+    orgEenheidId,
+    swvIds,
+    rol,
+    createPerson,
+    addPersonOrg,
+    addLidMutation,
+    addContact,
+    resetAndClose,
+  ]);
+
+  const isPending =
+    createPerson.isPending || addContact.isPending || addPersonOrg.isPending || addLidMutation.isPending;
 
   return (
     <Modal
       open={!!leadId}
       onClose={resetAndClose}
-      title="Externe contactpersoon toevoegen"
-      size="sm"
+      title={
+        mode === 'create' ? 'Nieuwe contactpersoon' : 'Externe contactpersoon toevoegen'
+      }
+      size={mode === 'create' ? 'md' : 'sm'}
       zIndex={60}
       footer={
-        <>
-          <Button variant="secondary" onClick={resetAndClose}>
-            Annuleren
-          </Button>
-          <Button onClick={handleSubmit} loading={addContact.isPending} disabled={!personId}>
-            Toevoegen
-          </Button>
-        </>
+        mode === 'create' ? (
+          <>
+            <Button variant="secondary" onClick={() => setMode('select')}>
+              Terug
+            </Button>
+            <Button
+              onClick={handleSubmitCreate}
+              loading={isPending}
+              disabled={!naam.trim()}
+            >
+              Aanmaken & koppelen
+            </Button>
+          </>
+        ) : (
+          <>
+            <Button variant="secondary" onClick={resetAndClose}>
+              Annuleren
+            </Button>
+            <Button
+              onClick={handleSubmitSelect}
+              loading={addContact.isPending}
+              disabled={!personId}
+            >
+              Toevoegen
+            </Button>
+          </>
+        )
       }
     >
-      <div className="space-y-4">
-        <CreatableSelect
-          label="Persoon"
-          value={personId}
-          onChange={setPersonId}
-          options={personOptions}
-          placeholder="Zoek of maak een persoon..."
-          onCreate={handleCreatePerson}
-          createLabel="Nieuwe persoon aanmaken"
-          required
-        />
-        <CreatableSelect
-          label="Rol"
-          value={rol}
-          onChange={setRol}
-          options={CONTACT_ROLLEN}
-          placeholder="Selecteer een rol..."
-          searchable={false}
-        />
-      </div>
+      {mode === 'select' ? (
+        <div className="space-y-4">
+          <CreatableSelect
+            label="Persoon"
+            value={personId}
+            onChange={setPersonId}
+            options={personOptions}
+            placeholder="Zoek of maak een persoon..."
+            onCreate={async (name) => switchToCreate(name)}
+            createLabel="Nieuwe persoon aanmaken"
+            required
+          />
+          <CreatableSelect
+            label="Rol"
+            value={rol}
+            onChange={setRol}
+            options={CONTACT_ROLLEN}
+            placeholder="Selecteer een rol..."
+            searchable={false}
+          />
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <Input
+            label="Naam"
+            value={naam}
+            onChange={(e) => setNaam(e.target.value)}
+            required
+            autoFocus
+          />
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <Input
+              label="E-mail"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="email@voorbeeld.nl"
+            />
+            <Input
+              label="Functie"
+              value={functie}
+              onChange={(e) => setFunctie(e.target.value)}
+              placeholder="bv. wetgevingsjurist"
+            />
+          </div>
+          <CreatableSelect
+            label="Expertise"
+            value={expertise}
+            onChange={setExpertise}
+            options={expertiseOptions}
+            placeholder="Bijv. wetgevingsjurist, BIT-adviseur..."
+            onCreate={async (text) => {
+              const value = text.trim();
+              if (!value) return null;
+              setExpertiseLocalAdded((prev) =>
+                prev.includes(value) ? prev : [...prev, value],
+              );
+              setExpertise(value);
+              return value;
+            }}
+            createLabel="Nieuwe expertise toevoegen"
+          />
+          <div>
+            <label className="block text-sm font-medium text-text mb-1">
+              Organisatie-eenheid (optioneel)
+            </label>
+            <CascadingOrgSelect
+              value={orgEenheidId}
+              onChange={setOrgEenheidId}
+            />
+          </div>
+          {samenwerkingsverbanden.length > 0 && (
+            <div>
+              <label className="block text-sm font-medium text-text mb-1">
+                Samenwerkingsverbanden (optioneel)
+              </label>
+              <div className="max-h-32 overflow-y-auto rounded-lg border border-border p-2 space-y-1">
+                {samenwerkingsverbanden.map((s) => (
+                  <label
+                    key={s.id}
+                    className="flex items-center gap-2 text-sm cursor-pointer hover:bg-gray-50 rounded px-1 py-0.5"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={swvIds.has(s.id)}
+                      onChange={() => toggleSwv(s.id)}
+                      className="rounded border-border"
+                    />
+                    <span className="flex-1 truncate">{s.naam}</span>
+                    <span className="text-xs text-text-secondary shrink-0">
+                      {SAMENWERKINGSVERBAND_TYPE_LABELS[s.type] ?? s.type}
+                    </span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          )}
+          <CreatableSelect
+            label="Rol op deze lead"
+            value={rol}
+            onChange={setRol}
+            options={CONTACT_ROLLEN}
+            placeholder="Selecteer een rol..."
+            searchable={false}
+          />
+        </div>
+      )}
     </Modal>
   );
 }

--- a/frontend/src/components/leads/LeadGraphView.tsx
+++ b/frontend/src/components/leads/LeadGraphView.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useCallback, useEffect, useRef, memo } from 'react';
-import { Building2, User, UserCircle2, FileText, Lightbulb, Plus, X } from 'lucide-react';
+import { Building2, User, UserCircle2, FileText, Lightbulb, Plus, X, Handshake } from 'lucide-react';
 import { useIsMobile } from '@/hooks/useMediaQuery';
 import ReactFlow, {
   Background,
@@ -34,6 +34,7 @@ import {
   NODE_TYPE_HEX_COLORS,
   NodeType,
   formatFunctie,
+  SAMENWERKINGSVERBAND_TYPE_LABELS,
 } from '@/types';
 import type { CommunityGraphNode, CommunityGraphEdge } from '@/types';
 
@@ -50,12 +51,16 @@ const LEAD_STAGE_HEX: Record<string, string> = {
 const PERSON_INTERN_COLOR = '#EC4899';
 const PERSON_EXTERN_COLOR = '#F97316';
 const ORG_COLOR = '#14B8A6';
+const SWV_COLOR = '#8B5CF6';
 const CORPUS_NODE_FALLBACK = '#6B7280';
 
 // ---- Community node type to rank (dagre) ----
 // Externe personen krijgen een eigen onderste laag, los van de interne (assignee/stakeholder)
 // personen, zodat externen en hun verbindingen visueel gescheiden zijn.
+// Samenwerkingsverbanden bovenaan, naast organisaties — beide zijn "context"
+// rond personen.
 const RANK_ORGANISATION = 0;
+const RANK_SAMENWERKINGSVERBAND = 0;
 const RANK_CORPUS_NODE = 1;
 const RANK_LEAD = 2;
 const RANK_PERSON_INTERN = 3;
@@ -67,6 +72,7 @@ function getNodeRank(node: CommunityGraphNode): number {
     return node.person_role === 'extern' ? RANK_PERSON_EXTERN : RANK_PERSON_INTERN;
   }
   if (node.node_type === 'organisation') return RANK_ORGANISATION;
+  if (node.node_type === 'samenwerkingsverband') return RANK_SAMENWERKINGSVERBAND;
   if (node.node_type === 'corpus_node') return RANK_CORPUS_NODE;
   if (node.node_type === 'lead') return RANK_LEAD;
   return RANK_DEFAULT;
@@ -97,6 +103,13 @@ function edgeStyle(edgeType: string): EdgeStyle {
       return { color: '#8B5CF6', strokeDasharray: '2 4', strokeWidth: 1.5, label: edgeType };
     case 'lid_van':
       return { color: '#9CA3AF', strokeWidth: 1, label: 'lid van' };
+    case 'lid_van_swv':
+      return {
+        color: SWV_COLOR,
+        strokeDasharray: '4 3',
+        strokeWidth: 1.25,
+        label: edgeType === 'lid_van_swv' ? 'lid' : edgeType,
+      };
     default:
       // Corpus node edges and anything else
       return { color: '#94a3b8', strokeWidth: 1.5, label: edgeType.replace(/_/g, ' ') };
@@ -104,7 +117,12 @@ function edgeStyle(edgeType: string): EdgeStyle {
 }
 
 // ---- Custom node component ----
-type CommunityNodeType = 'lead' | 'person' | 'organisation' | 'corpus_node';
+type CommunityNodeType =
+  | 'lead'
+  | 'person'
+  | 'organisation'
+  | 'corpus_node'
+  | 'samenwerkingsverband';
 
 interface CommunityGraphNodeData {
   label: string;
@@ -115,6 +133,7 @@ interface CommunityGraphNodeData {
   expertise?: string | null;
   personRole?: 'intern' | 'extern' | null;
   orgType?: string | null;
+  swvType?: string | null;
   corpusNodeType?: string | null;
   dimmed?: boolean;
   onClick?: () => void;
@@ -129,6 +148,7 @@ function getNodeColor(data: CommunityGraphNodeData): string {
     return data.personRole === 'extern' ? PERSON_EXTERN_COLOR : PERSON_INTERN_COLOR;
   }
   if (data.nodeType === 'organisation') return ORG_COLOR;
+  if (data.nodeType === 'samenwerkingsverband') return SWV_COLOR;
   if (data.nodeType === 'corpus_node' && data.corpusNodeType) {
     return NODE_TYPE_HEX_COLORS[data.corpusNodeType as NodeType] ?? CORPUS_NODE_FALLBACK;
   }
@@ -187,6 +207,19 @@ function CommunityGraphNodeComponent({ data }: NodeProps<CommunityGraphNodeData>
           <FileText className="h-3 w-3" style={{ color }} />
           <span style={{ color, fontSize: '10px', fontWeight: 600, letterSpacing: '0.025em', textTransform: 'uppercase' }}>
             {data.corpusNodeType?.replace(/_/g, ' ') ?? 'Node'}
+          </span>
+        </div>
+      );
+    }
+    if (data.nodeType === 'samenwerkingsverband') {
+      const typeLabel = data.swvType
+        ? SAMENWERKINGSVERBAND_TYPE_LABELS[data.swvType] ?? data.swvType
+        : 'Verband';
+      return (
+        <div className="flex items-center gap-1 mb-1">
+          <Handshake className="h-3 w-3" style={{ color }} />
+          <span style={{ color, fontSize: '10px', fontWeight: 600, letterSpacing: '0.025em', textTransform: 'uppercase' }}>
+            {typeLabel}
           </span>
         </div>
       );
@@ -440,6 +473,7 @@ function CommunityGraphInner({
           expertise: node.expertise,
           personRole: node.person_role ?? null,
           orgType: node.org_type,
+          swvType: node.samenwerkingsverband_type ?? null,
           corpusNodeType: node.corpus_node_type,
           onClick,
           onAddContact,

--- a/frontend/src/components/people/PersonCardExpandable.tsx
+++ b/frontend/src/components/people/PersonCardExpandable.tsx
@@ -1,11 +1,14 @@
 import { useState } from 'react';
 import { clsx } from 'clsx';
-import { Mail, Briefcase, Pencil, CheckCircle2, Circle, FileText, Loader2, MessageSquare, Terminal, Building2, X, Phone, Star } from 'lucide-react';
+import { Mail, Briefcase, Pencil, CheckCircle2, Circle, FileText, Loader2, MessageSquare, Terminal, Building2, X, Phone, Star, Handshake } from 'lucide-react';
+import { Link } from 'react-router-dom';
 import { Card } from '@/components/common/Card';
 import { Badge } from '@/components/common/Badge';
 import { SendMessageModal } from '@/components/common/SendMessageModal';
 import { PersonAvatar } from '@/components/people/PersonAvatar';
 import { usePersonSummary, usePersonOrganisaties, useUpdatePersonOrganisatie, useRemovePersonOrganisatie } from '@/hooks/usePeople';
+import { useSamenwerkingsverbandenForPerson } from '@/hooks/useSamenwerkingsverbanden';
+import { SAMENWERKINGSVERBAND_TYPE_LABELS, SAMENWERKINGSVERBAND_TYPE_BADGE_COLORS } from '@/types';
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import { formatFunctie, NODE_TYPE_COLORS, STAKEHOLDER_ROL_LABELS, DIENSTVERBAND_LABELS, PHONE_LABELS } from '@/types';
 import { richTextToPlain } from '@/utils/richtext';
@@ -45,6 +48,9 @@ export function PersonCardExpandable({ person, onEditPerson, onDragStartPerson, 
   const { openNodeDetail } = useNodeDetail();
   const { data: summary, isLoading: summaryLoading } = usePersonSummary(expanded ? person.id : null);
   const { data: placements } = usePersonOrganisaties(expanded ? person.id : null);
+  const { data: lidmaatschappen } = useSamenwerkingsverbandenForPerson(
+    expanded ? person.id : null,
+  );
   const endPlacement = useUpdatePersonOrganisatie();
   const removePlacement = useRemovePersonOrganisatie();
 
@@ -348,8 +354,51 @@ export function PersonCardExpandable({ person, onEditPerson, onDragStartPerson, 
                 </div>
               )}
 
+              {/* Samenwerkingsverbanden */}
+              {lidmaatschappen && lidmaatschappen.length > 0 && (
+                <div>
+                  <p className="text-text-secondary font-medium mb-1 flex items-center gap-1">
+                    <Handshake className="h-3 w-3" />
+                    Samenwerkingsverbanden
+                  </p>
+                  <div className="space-y-1">
+                    {lidmaatschappen.map((lid) => (
+                      <div
+                        key={lid.id}
+                        className="flex items-center gap-2 text-text"
+                      >
+                        <Link
+                          to={`/samenwerkingsverbanden/${lid.samenwerkingsverband_id}`}
+                          onClick={(e) => e.stopPropagation()}
+                          className="truncate hover:text-primary-600 transition-colors"
+                        >
+                          {lid.samenwerkingsverband_naam}
+                        </Link>
+                        <Badge
+                          variant={
+                            SAMENWERKINGSVERBAND_TYPE_BADGE_COLORS[
+                              lid.samenwerkingsverband_type
+                            ] ?? 'gray'
+                          }
+                          className="text-[10px] px-1.5 py-0 shrink-0"
+                        >
+                          {SAMENWERKINGSVERBAND_TYPE_LABELS[
+                            lid.samenwerkingsverband_type
+                          ] ?? lid.samenwerkingsverband_type}
+                        </Badge>
+                        {lid.rol && (
+                          <span className="text-[11px] text-text-secondary shrink-0">
+                            — {lid.rol}
+                          </span>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
               {/* No tasks and no nodes */}
-              {summary.open_task_count === 0 && summary.done_task_count === 0 && summary.stakeholder_nodes.length === 0 && (!placements || placements.length === 0) && (
+              {summary.open_task_count === 0 && summary.done_task_count === 0 && summary.stakeholder_nodes.length === 0 && (!placements || placements.length === 0) && (!lidmaatschappen || lidmaatschappen.length === 0) && (
                 <p className="text-text-secondary">Geen taken, dossiers of teams.</p>
               )}
             </div>

--- a/frontend/src/hooks/queryKeys.ts
+++ b/frontend/src/hooks/queryKeys.ts
@@ -203,4 +203,16 @@ export const queryKeys = {
     overzicht: (nodeId: string | undefined) => ['financieel', 'overzicht', nodeId] as const,
     opdrachten: (nodeId: string | undefined) => ['financieel', 'opdrachten', nodeId] as const,
   },
+
+  // --- Samenwerkingsverbanden ---
+  samenwerkingsverbanden: {
+    all: ['samenwerkingsverbanden'] as const,
+    list: (filters?: { search?: string; type?: string; actief?: boolean }) =>
+      ['samenwerkingsverbanden', 'list', filters ?? {}] as const,
+    detail: (id: string | null) => ['samenwerkingsverbanden', 'detail', id] as const,
+    leden: (id: string | null, actief: boolean) =>
+      ['samenwerkingsverbanden', 'leden', id, { actief }] as const,
+    forPerson: (personId: string | null, actief: boolean) =>
+      ['samenwerkingsverbanden', 'for-person', personId, { actief }] as const,
+  },
 } as const;

--- a/frontend/src/hooks/useSamenwerkingsverbanden.ts
+++ b/frontend/src/hooks/useSamenwerkingsverbanden.ts
@@ -1,0 +1,118 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  getSamenwerkingsverbanden,
+  getSamenwerkingsverband,
+  createSamenwerkingsverband,
+  updateSamenwerkingsverband,
+  deleteSamenwerkingsverband,
+  listLeden,
+  addLid,
+  updateLid,
+  removeLid,
+  listForPerson,
+} from '@/api/samenwerkingsverbanden';
+import { useMutationWithError } from '@/hooks/useMutationWithError';
+import { queryKeys } from '@/hooks/queryKeys';
+import type {
+  SamenwerkingsverbandCreate,
+  SamenwerkingsverbandLidCreate,
+  SamenwerkingsverbandLidUpdate,
+  SamenwerkingsverbandUpdate,
+} from '@/types';
+
+export function useSamenwerkingsverbanden(filters?: {
+  search?: string;
+  type?: string;
+  actief?: boolean;
+}) {
+  return useQuery({
+    queryKey: queryKeys.samenwerkingsverbanden.list(filters),
+    queryFn: () => getSamenwerkingsverbanden(filters),
+  });
+}
+
+export function useSamenwerkingsverband(id: string | null) {
+  return useQuery({
+    queryKey: queryKeys.samenwerkingsverbanden.detail(id),
+    queryFn: () => getSamenwerkingsverband(id!),
+    enabled: !!id,
+  });
+}
+
+export function useCreateSamenwerkingsverband() {
+  return useMutationWithError({
+    mutationFn: (data: SamenwerkingsverbandCreate) => createSamenwerkingsverband(data),
+    errorMessage: 'Fout bij aanmaken samenwerkingsverband',
+    invalidateKeys: [queryKeys.samenwerkingsverbanden.all],
+  });
+}
+
+export function useUpdateSamenwerkingsverband() {
+  return useMutationWithError({
+    mutationFn: ({ id, data }: { id: string; data: SamenwerkingsverbandUpdate }) =>
+      updateSamenwerkingsverband(id, data),
+    errorMessage: 'Fout bij bijwerken samenwerkingsverband',
+    invalidateKeys: [queryKeys.samenwerkingsverbanden.all],
+  });
+}
+
+export function useDeleteSamenwerkingsverband() {
+  return useMutationWithError({
+    mutationFn: (id: string) => deleteSamenwerkingsverband(id),
+    errorMessage: 'Fout bij verwijderen samenwerkingsverband',
+    invalidateKeys: [queryKeys.samenwerkingsverbanden.all],
+  });
+}
+
+export function useLeden(id: string | null, actief: boolean = true) {
+  return useQuery({
+    queryKey: queryKeys.samenwerkingsverbanden.leden(id, actief),
+    queryFn: () => listLeden(id!, actief),
+    enabled: !!id,
+  });
+}
+
+export function useAddLid() {
+  return useMutationWithError({
+    mutationFn: ({ swvId, data }: { swvId: string; data: SamenwerkingsverbandLidCreate }) =>
+      addLid(swvId, data),
+    errorMessage: 'Fout bij toevoegen lid',
+    invalidateKeys: [queryKeys.samenwerkingsverbanden.all],
+  });
+}
+
+export function useUpdateLid() {
+  return useMutationWithError({
+    mutationFn: ({
+      swvId,
+      lidId,
+      data,
+    }: {
+      swvId: string;
+      lidId: string;
+      data: SamenwerkingsverbandLidUpdate;
+    }) => updateLid(swvId, lidId, data),
+    errorMessage: 'Fout bij bijwerken lid',
+    invalidateKeys: [queryKeys.samenwerkingsverbanden.all],
+  });
+}
+
+export function useSamenwerkingsverbandenForPerson(
+  personId: string | null,
+  actief: boolean = true,
+) {
+  return useQuery({
+    queryKey: queryKeys.samenwerkingsverbanden.forPerson(personId, actief),
+    queryFn: () => listForPerson(personId!, actief),
+    enabled: !!personId,
+  });
+}
+
+export function useRemoveLid() {
+  return useMutationWithError({
+    mutationFn: ({ swvId, lidId }: { swvId: string; lidId: string }) =>
+      removeLid(swvId, lidId),
+    errorMessage: 'Fout bij verwijderen lid',
+    invalidateKeys: [queryKeys.samenwerkingsverbanden.all],
+  });
+}

--- a/frontend/src/pages/SamenwerkingsverbandDetailPage.tsx
+++ b/frontend/src/pages/SamenwerkingsverbandDetailPage.tsx
@@ -119,14 +119,11 @@ export function SamenwerkingsverbandDetailPage() {
   const personOptions: SelectOption[] = people
     .filter((p) => p.is_active && !p.is_agent && !peopleAlIngedeeld.has(p.id))
     .sort((a, b) => a.naam.localeCompare(b.naam))
-    .map((p) => {
-      const parts = [p.functie, p.expertise].filter((v): v is string => !!v);
-      return {
-        value: p.id,
-        label: p.naam,
-        description: parts.length ? parts.join(' · ') : undefined,
-      };
-    });
+    .map((p) => ({
+      value: p.id,
+      label: p.naam,
+      description: p.functie ?? undefined,
+    }));
 
   return (
     <div className="max-w-4xl mx-auto space-y-6">
@@ -231,7 +228,7 @@ export function SamenwerkingsverbandDetailPage() {
             </div>
             {swv.beschrijving && (
               <div className="pt-2 border-t border-border/60">
-                <RichTextDisplay value={swv.beschrijving} />
+                <RichTextDisplay content={swv.beschrijving} />
               </div>
             )}
           </div>

--- a/frontend/src/pages/SamenwerkingsverbandDetailPage.tsx
+++ b/frontend/src/pages/SamenwerkingsverbandDetailPage.tsx
@@ -1,0 +1,353 @@
+import { useState } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import { ArrowLeft, Pencil, Trash2, Plus, X, Users } from 'lucide-react';
+import {
+  useSamenwerkingsverband,
+  useUpdateSamenwerkingsverband,
+  useDeleteSamenwerkingsverband,
+  useAddLid,
+  useRemoveLid,
+} from '@/hooks/useSamenwerkingsverbanden';
+import { usePeople } from '@/hooks/usePeople';
+import { Badge } from '@/components/common/Badge';
+import { Button } from '@/components/common/Button';
+import { Input } from '@/components/common/Input';
+import { LoadingSpinner } from '@/components/common/LoadingSpinner';
+import { ConfirmDialog } from '@/components/common/ConfirmDialog';
+import { RichTextDisplay } from '@/components/common/RichTextDisplay';
+import { RichTextFormField } from '@/components/common/RichTextFormField';
+import { CreatableSelect, type SelectOption } from '@/components/common/CreatableSelect';
+import {
+  SAMENWERKINGSVERBAND_TYPE_LABELS,
+  SAMENWERKINGSVERBAND_TYPE_BADGE_COLORS,
+  SAMENWERKINGSVERBAND_TYPE_OPTIONS,
+  type SamenwerkingsverbandUpdate,
+} from '@/types';
+
+export function SamenwerkingsverbandDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { data: swv, isLoading } = useSamenwerkingsverband(id ?? null);
+  const updateMutation = useUpdateSamenwerkingsverband();
+  const deleteMutation = useDeleteSamenwerkingsverband();
+  const addLidMutation = useAddLid();
+  const removeLidMutation = useRemoveLid();
+  const { data: people = [] } = usePeople();
+
+  const [editing, setEditing] = useState(false);
+  const [editForm, setEditForm] = useState<SamenwerkingsverbandUpdate>({});
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [confirmRemoveLidId, setConfirmRemoveLidId] = useState<string | null>(null);
+
+  // Lid-toevoeg-form
+  const [showAddLid, setShowAddLid] = useState(false);
+  const [newLidPersonId, setNewLidPersonId] = useState('');
+  const [newLidRol, setNewLidRol] = useState('');
+
+  if (isLoading) {
+    return <div className="flex items-center justify-center py-12"><LoadingSpinner /></div>;
+  }
+  if (!swv || !id) {
+    return (
+      <div className="max-w-3xl mx-auto py-12 text-center text-text-secondary">
+        Samenwerkingsverband niet gevonden.
+      </div>
+    );
+  }
+
+  const startEdit = () => {
+    setEditForm({
+      naam: swv.naam,
+      type: swv.type,
+      beschrijving: swv.beschrijving ?? '',
+      start_datum: swv.start_datum ?? null,
+      eind_datum: swv.eind_datum ?? null,
+    });
+    setEditing(true);
+  };
+
+  const handleSaveEdit = async () => {
+    if (!id) return;
+    try {
+      await updateMutation.mutateAsync({ id, data: editForm });
+      setEditing(false);
+    } catch {
+      // toast wordt al getoond
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!id) return;
+    try {
+      await deleteMutation.mutateAsync(id);
+      navigate('/samenwerkingsverbanden');
+    } catch {
+      setConfirmDelete(false);
+    }
+  };
+
+  const handleAddLid = async () => {
+    if (!id || !newLidPersonId) return;
+    try {
+      await addLidMutation.mutateAsync({
+        swvId: id,
+        data: {
+          person_id: newLidPersonId,
+          rol: newLidRol || null,
+          start_datum: new Date().toISOString().slice(0, 10),
+        },
+      });
+      setShowAddLid(false);
+      setNewLidPersonId('');
+      setNewLidRol('');
+    } catch {
+      // toast
+    }
+  };
+
+  const handleRemoveLid = async () => {
+    if (!id || !confirmRemoveLidId) return;
+    try {
+      await removeLidMutation.mutateAsync({ swvId: id, lidId: confirmRemoveLidId });
+      setConfirmRemoveLidId(null);
+    } catch {
+      setConfirmRemoveLidId(null);
+    }
+  };
+
+  const peopleAlIngedeeld = new Set(swv.leden.map((l) => l.person_id));
+  const personOptions: SelectOption[] = people
+    .filter((p) => p.is_active && !p.is_agent && !peopleAlIngedeeld.has(p.id))
+    .sort((a, b) => a.naam.localeCompare(b.naam))
+    .map((p) => {
+      const parts = [p.functie, p.expertise].filter((v): v is string => !!v);
+      return {
+        value: p.id,
+        label: p.naam,
+        description: parts.length ? parts.join(' · ') : undefined,
+      };
+    });
+
+  return (
+    <div className="max-w-4xl mx-auto space-y-6">
+      <div className="flex items-center justify-between">
+        <Link
+          to="/samenwerkingsverbanden"
+          className="flex items-center gap-1.5 text-sm text-text-secondary hover:text-text transition-colors"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          Terug naar overzicht
+        </Link>
+        {!editing && (
+          <div className="flex items-center gap-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              icon={<Pencil className="h-3.5 w-3.5" />}
+              onClick={startEdit}
+            >
+              Bewerken
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              icon={<Trash2 className="h-3.5 w-3.5" />}
+              onClick={() => setConfirmDelete(true)}
+            >
+              Verwijderen
+            </Button>
+          </div>
+        )}
+      </div>
+
+      <div className="bg-surface rounded-xl border border-border p-6">
+        {editing ? (
+          <div className="space-y-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <Input
+                label="Naam"
+                value={editForm.naam ?? ''}
+                onChange={(e) => setEditForm((f) => ({ ...f, naam: e.target.value }))}
+                required
+              />
+              <CreatableSelect
+                label="Type"
+                value={editForm.type ?? swv.type}
+                onChange={(v) => setEditForm((f) => ({ ...f, type: v }))}
+                options={SAMENWERKINGSVERBAND_TYPE_OPTIONS}
+                searchable={false}
+              />
+              <Input
+                label="Startdatum"
+                type="date"
+                value={editForm.start_datum ?? ''}
+                onChange={(e) =>
+                  setEditForm((f) => ({ ...f, start_datum: e.target.value || null }))
+                }
+              />
+              <Input
+                label="Einddatum"
+                type="date"
+                value={editForm.eind_datum ?? ''}
+                onChange={(e) =>
+                  setEditForm((f) => ({ ...f, eind_datum: e.target.value || null }))
+                }
+              />
+            </div>
+            <RichTextFormField
+              label="Beschrijving"
+              value={editForm.beschrijving ?? ''}
+              onChange={(v) => setEditForm((f) => ({ ...f, beschrijving: v }))}
+              rows={4}
+            />
+            <div className="flex items-center gap-2 justify-end">
+              <Button variant="secondary" onClick={() => setEditing(false)}>Annuleren</Button>
+              <Button onClick={handleSaveEdit} loading={updateMutation.isPending}>Opslaan</Button>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <h1 className="text-xl font-semibold text-text">{swv.naam}</h1>
+                <div className="mt-1 flex items-center gap-2">
+                  <Badge variant={SAMENWERKINGSVERBAND_TYPE_BADGE_COLORS[swv.type] ?? 'gray'}>
+                    {SAMENWERKINGSVERBAND_TYPE_LABELS[swv.type] ?? swv.type}
+                  </Badge>
+                  <span className="text-xs text-text-secondary">
+                    <Users className="inline h-3 w-3 mr-1" />
+                    {swv.aantal_leden} {swv.aantal_leden === 1 ? 'lid' : 'leden'}
+                  </span>
+                </div>
+              </div>
+              <div className="text-right text-xs text-text-secondary space-y-0.5">
+                {swv.start_datum && (
+                  <div>Start: {new Date(swv.start_datum).toLocaleDateString('nl-NL')}</div>
+                )}
+                {swv.eind_datum && (
+                  <div>Eind: {new Date(swv.eind_datum).toLocaleDateString('nl-NL')}</div>
+                )}
+              </div>
+            </div>
+            {swv.beschrijving && (
+              <div className="pt-2 border-t border-border/60">
+                <RichTextDisplay value={swv.beschrijving} />
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="bg-surface rounded-xl border border-border p-6">
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-sm font-semibold text-text">Leden</h2>
+          <Button
+            variant="ghost"
+            size="sm"
+            icon={<Plus className="h-3.5 w-3.5" />}
+            onClick={() => setShowAddLid(true)}
+          >
+            Toevoegen
+          </Button>
+        </div>
+
+        {showAddLid && (
+          <div className="mb-4 rounded-lg border border-border bg-gray-50 p-3 space-y-3">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <CreatableSelect
+                label="Persoon"
+                value={newLidPersonId}
+                onChange={setNewLidPersonId}
+                options={personOptions}
+                placeholder="Zoek persoon..."
+              />
+              <Input
+                label="Rol (optioneel)"
+                value={newLidRol}
+                onChange={(e) => setNewLidRol(e.target.value)}
+                placeholder="bv. trekker, voorzitter"
+              />
+            </div>
+            <div className="flex items-center gap-2 justify-end">
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => { setShowAddLid(false); setNewLidPersonId(''); setNewLidRol(''); }}
+              >
+                Annuleren
+              </Button>
+              <Button
+                size="sm"
+                onClick={handleAddLid}
+                loading={addLidMutation.isPending}
+                disabled={!newLidPersonId}
+              >
+                Toevoegen
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {swv.leden.length === 0 ? (
+          <p className="text-sm text-text-secondary italic">Nog geen leden.</p>
+        ) : (
+          <ul className="space-y-1">
+            {swv.leden.map((lid) => (
+              <li
+                key={lid.id}
+                className="group flex items-center gap-2 rounded-lg px-2 py-1.5 hover:bg-gray-50 transition-colors"
+              >
+                <div className="flex-1 flex items-center gap-2 text-sm">
+                  <span className="font-medium text-text">{lid.person_naam}</span>
+                  {lid.person_expertise && (
+                    <Badge variant="indigo">{lid.person_expertise}</Badge>
+                  )}
+                  {lid.rol && (
+                    <span className="text-xs text-text-secondary">— {lid.rol}</span>
+                  )}
+                </div>
+                <span className="text-xs text-text-secondary">
+                  sinds {new Date(lid.start_datum).toLocaleDateString('nl-NL')}
+                </span>
+                <button
+                  onClick={() => setConfirmRemoveLidId(lid.id)}
+                  className="opacity-0 group-hover:opacity-100 p-1 rounded text-text-secondary hover:text-red-600 hover:bg-red-50 transition-all"
+                  title="Verwijderen"
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <ConfirmDialog
+        open={confirmDelete}
+        onClose={() => setConfirmDelete(false)}
+        onConfirm={handleDelete}
+        title="Samenwerkingsverband verwijderen"
+        confirmLabel="Verwijderen"
+        variant="danger"
+        loading={deleteMutation.isPending}
+      >
+        <p>
+          Weet je zeker dat je <strong>{swv.naam}</strong> wilt verwijderen? Alle
+          lidmaatschappen worden meegenomen.
+        </p>
+      </ConfirmDialog>
+
+      <ConfirmDialog
+        open={!!confirmRemoveLidId}
+        onClose={() => setConfirmRemoveLidId(null)}
+        onConfirm={handleRemoveLid}
+        title="Lid verwijderen"
+        confirmLabel="Verwijderen"
+        variant="danger"
+        loading={removeLidMutation.isPending}
+      >
+        <p>Weet je zeker dat je dit lid wilt verwijderen?</p>
+      </ConfirmDialog>
+    </div>
+  );
+}

--- a/frontend/src/pages/SamenwerkingsverbandenPage.tsx
+++ b/frontend/src/pages/SamenwerkingsverbandenPage.tsx
@@ -1,0 +1,188 @@
+import { useState } from 'react';
+import { Plus, X, Users } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import {
+  useSamenwerkingsverbanden,
+  useCreateSamenwerkingsverband,
+} from '@/hooks/useSamenwerkingsverbanden';
+import { Badge } from '@/components/common/Badge';
+import { RichTextFormField } from '@/components/common/RichTextFormField';
+import { Button } from '@/components/common/Button';
+import { Input } from '@/components/common/Input';
+import { LoadingSpinner } from '@/components/common/LoadingSpinner';
+import { CreatableSelect, type SelectOption } from '@/components/common/CreatableSelect';
+import {
+  SAMENWERKINGSVERBAND_TYPE_LABELS,
+  SAMENWERKINGSVERBAND_TYPE_BADGE_COLORS,
+  SAMENWERKINGSVERBAND_TYPE_OPTIONS,
+  type SamenwerkingsverbandCreate,
+} from '@/types';
+
+const ALL_TYPE_OPTIONS: SelectOption[] = [
+  { value: '', label: 'Alle types' },
+  ...SAMENWERKINGSVERBAND_TYPE_OPTIONS,
+];
+
+export function SamenwerkingsverbandenPage() {
+  const [typeFilter, setTypeFilter] = useState('');
+  const [actiefOnly, setActiefOnly] = useState(true);
+  const [search, setSearch] = useState('');
+  const { data = [], isLoading } = useSamenwerkingsverbanden({
+    type: typeFilter || undefined,
+    actief: actiefOnly ? true : undefined,
+    search: search || undefined,
+  });
+  const createMutation = useCreateSamenwerkingsverband();
+
+  const [showForm, setShowForm] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [form, setForm] = useState<SamenwerkingsverbandCreate>({
+    naam: '',
+    type: 'programma',
+  });
+
+  const resetForm = () => {
+    setForm({ naam: '', type: 'programma' });
+    setError(null);
+    setShowForm(false);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      await createMutation.mutateAsync(form);
+      resetForm();
+    } catch {
+      setError('Fout bij aanmaken samenwerkingsverband.');
+    }
+  };
+
+  return (
+    <div className="max-w-5xl mx-auto space-y-6">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div className="flex flex-wrap items-end gap-3">
+          <div className="w-64">
+            <Input
+              label="Zoeken"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Naam..."
+            />
+          </div>
+          <div className="w-48">
+            <CreatableSelect
+              label="Type"
+              value={typeFilter}
+              onChange={setTypeFilter}
+              options={ALL_TYPE_OPTIONS}
+              searchable={false}
+            />
+          </div>
+          <label className="flex items-center gap-2 pb-2 text-sm text-text-secondary">
+            <input
+              type="checkbox"
+              checked={actiefOnly}
+              onChange={(e) => setActiefOnly(e.target.checked)}
+              className="rounded border-border"
+            />
+            Alleen actieve
+          </label>
+        </div>
+        <Button
+          variant="primary"
+          icon={<Plus className="h-4 w-4" />}
+          onClick={() => { resetForm(); setShowForm(true); }}
+        >
+          Nieuw samenwerkingsverband
+        </Button>
+      </div>
+
+      {showForm && (
+        <div className="bg-surface rounded-xl border border-border p-6">
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="text-sm font-semibold text-text">Nieuw samenwerkingsverband</h3>
+            <button onClick={resetForm} className="text-text-secondary hover:text-text transition-colors">
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <Input
+                label="Naam"
+                value={form.naam}
+                onChange={(e) => setForm((f) => ({ ...f, naam: e.target.value }))}
+                required
+                autoFocus
+              />
+              <CreatableSelect
+                label="Type"
+                value={form.type}
+                onChange={(v) => setForm((f) => ({ ...f, type: v }))}
+                options={SAMENWERKINGSVERBAND_TYPE_OPTIONS}
+                searchable={false}
+              />
+              <Input
+                label="Startdatum"
+                type="date"
+                value={form.start_datum ?? ''}
+                onChange={(e) => setForm((f) => ({ ...f, start_datum: e.target.value || null }))}
+              />
+              <Input
+                label="Einddatum"
+                type="date"
+                value={form.eind_datum ?? ''}
+                onChange={(e) => setForm((f) => ({ ...f, eind_datum: e.target.value || null }))}
+              />
+            </div>
+            <RichTextFormField
+              label="Beschrijving"
+              value={form.beschrijving ?? ''}
+              onChange={(v) => setForm((f) => ({ ...f, beschrijving: v }))}
+              rows={3}
+            />
+            {error && <p className="text-sm text-red-600">{error}</p>}
+            <div className="flex items-center gap-2 justify-end">
+              <Button variant="secondary" onClick={resetForm} type="button">Annuleren</Button>
+              <Button type="submit" loading={createMutation.isPending}>Aanmaken</Button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {isLoading ? (
+        <div className="flex items-center justify-center py-12"><LoadingSpinner /></div>
+      ) : data.length === 0 ? (
+        <div className="text-center py-12 text-text-secondary">
+          Geen samenwerkingsverbanden gevonden.
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+          {data.map((swv) => (
+            <Link
+              key={swv.id}
+              to={`/samenwerkingsverbanden/${swv.id}`}
+              className="block rounded-xl border border-border bg-surface p-4 hover:border-primary-300 hover:shadow-sm transition-all"
+            >
+              <div className="flex items-center justify-between mb-2">
+                <Badge variant={SAMENWERKINGSVERBAND_TYPE_BADGE_COLORS[swv.type] ?? 'gray'}>
+                  {SAMENWERKINGSVERBAND_TYPE_LABELS[swv.type] ?? swv.type}
+                </Badge>
+                <div className="flex items-center gap-1 text-xs text-text-secondary">
+                  <Users className="h-3 w-3" />
+                  {swv.aantal_leden}
+                </div>
+              </div>
+              <h3 className="text-sm font-semibold text-text truncate">{swv.naam}</h3>
+              {swv.eind_datum && (
+                <p className="mt-1 text-xs text-text-secondary">
+                  Eindigt {new Date(swv.eind_datum).toLocaleDateString('nl-NL')}
+                </p>
+              )}
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -2084,3 +2084,100 @@ export interface CommunityGraphResponse {
   nodes: CommunityGraphNode[];
   edges: CommunityGraphEdge[];
 }
+
+// ---------------------------------------------------------------------------
+// Samenwerkingsverband (programma | werkgroep | opschalingsticket | ...)
+// ---------------------------------------------------------------------------
+
+export type SamenwerkingsverbandType =
+  | 'programma'
+  | 'werkgroep'
+  | 'opschalingsticket'
+  | 'ketenproject';
+
+export const SAMENWERKINGSVERBAND_TYPE_LABELS: Record<string, string> = {
+  programma: 'Programma',
+  werkgroep: 'Werkgroep',
+  opschalingsticket: 'Opschalingsticket',
+  ketenproject: 'Ketenproject',
+};
+
+export const SAMENWERKINGSVERBAND_TYPE_BADGE_COLORS: Record<string, BadgeVariant> = {
+  programma: 'purple',
+  werkgroep: 'cyan',
+  opschalingsticket: 'amber',
+  ketenproject: 'emerald',
+};
+
+export const SAMENWERKINGSVERBAND_TYPE_OPTIONS: { value: string; label: string }[] =
+  Object.entries(SAMENWERKINGSVERBAND_TYPE_LABELS).map(([value, label]) => ({
+    value,
+    label,
+  }));
+
+export interface Samenwerkingsverband {
+  id: string;
+  naam: string;
+  type: string;
+  beschrijving?: string | null;
+  start_datum?: string | null;
+  eind_datum?: string | null;
+  created_by_id?: string | null;
+  created_at: string;
+  updated_at?: string | null;
+  aantal_leden: number;
+}
+
+export interface SamenwerkingsverbandCreate {
+  naam: string;
+  type: string;
+  beschrijving?: string;
+  start_datum?: string | null;
+  eind_datum?: string | null;
+}
+
+export interface SamenwerkingsverbandUpdate {
+  naam?: string;
+  type?: string;
+  beschrijving?: string | null;
+  start_datum?: string | null;
+  eind_datum?: string | null;
+}
+
+export interface SamenwerkingsverbandLid {
+  id: string;
+  samenwerkingsverband_id: string;
+  person_id: string;
+  person_naam: string;
+  person_functie?: string | null;
+  person_expertise?: string | null;
+  rol?: string | null;
+  start_datum: string;
+  eind_datum?: string | null;
+  created_at: string;
+}
+
+export interface SamenwerkingsverbandLidCreate {
+  person_id: string;
+  rol?: string | null;
+  start_datum: string;
+}
+
+export interface SamenwerkingsverbandLidUpdate {
+  rol?: string | null;
+  eind_datum?: string | null;
+}
+
+export interface SamenwerkingsverbandDetail extends Samenwerkingsverband {
+  leden: SamenwerkingsverbandLid[];
+}
+
+export interface PersoonLidmaatschap {
+  id: string;
+  samenwerkingsverband_id: string;
+  samenwerkingsverband_naam: string;
+  samenwerkingsverband_type: string;
+  rol?: string | null;
+  start_datum: string;
+  eind_datum?: string | null;
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -2060,8 +2060,14 @@ export interface LeadParseResult {
 
 // Community Graph types (used by LeadGraphView / CommunityGraph)
 export interface CommunityGraphNode {
-  id: string; // prefixed: "lead-xxx", "person-xxx", "org-xxx", "node-xxx"
-  node_type: 'lead' | 'person' | 'organisation' | 'corpus_node';
+  // prefixed: "lead-xxx", "person-xxx", "oe-xxx", "node-xxx", "swv-xxx"
+  id: string;
+  node_type:
+    | 'lead'
+    | 'person'
+    | 'organisation'
+    | 'corpus_node'
+    | 'samenwerkingsverband';
   label: string;
   stage?: string | null;
   initiatief_id?: string | null;
@@ -2069,6 +2075,7 @@ export interface CommunityGraphNode {
   expertise?: string | null;
   person_role?: 'intern' | 'extern' | null;
   org_type?: string | null;
+  samenwerkingsverband_type?: string | null;
   corpus_node_type?: string | null;
 }
 


### PR DESCRIPTION
## Summary

Sporen 2, 3a en 3b uit het plan voor contactpersoon-typering en samenwerkingsverbanden in het leads-netwerk. Spoor 1 (expertise op Person) is al gemerged via #276.

**Spoor 2 — Samenwerkingsverband-domein**
- Nieuw `Samenwerkingsverband`-model voor ad-hoc samenwerkingsvormen los van de hierarchische OrganisatieEenheid-boom (programma, werkgroep, opschalingsticket, ketenproject), met `PersoonSamenwerkingsverband`-junction voor temporal lidmaatschap (rol, start/eind).
- Vier nieuwe permissies `samenwerkingsverband:{create,read,update,delete}` met dezelfde rolset als `initiatief`. Cross-tenant by design — geen `organisatie_eenheid_id`, zichtbaarheid via permissies.
- Top-level sidebar-item "Samenwerkingsverbanden", lijstpagina met type-filter + zoekveld, detail-pagina met inline edit en ledenbeheer, plus een sectie op `PersonCardExpandable` die toont in welke verbanden iemand actief is.

**Spoor 3a — Rendering in community-graph**
- `Person → Samenwerkingsverband` edges in de community-graph via een extra loop in `repositories/graph.py` (zelfde temporal-filter als organisatie-plaatsingen).
- Nieuw `node_type=samenwerkingsverband` met paarse `Handshake`-icon, `lid_van_swv` edge-styling paars-gestippeld zodat het visueel los staat van organisatie-edges (cyan).
- `CommunityGraphNode.samenwerkingsverband_type` meta-veld zodat de UI het type kan tonen als sublabel.

**Spoor 3b — Uitgebreide inline contact-aanmaak**
- `AddLeadContactModal` is nu een twee-staps modal: bij "Nieuwe persoon aanmaken" krijg je naast naam ook e-mail, functie, expertise (CreatableSelect), organisatie-eenheid (CascadingOrgSelect) en een lijst met selecteerbare samenwerkingsverbanden in één form.
- Backend-calls in volgorde `person → plaatsing → swv-leden → lead-contact`, met fail-safe per follow-up zodat een falende swv-link niet de lead-koppeling blokkeert.

## Test plan

- [ ] `just reset-db && just up`
- [ ] Sidebar toont "Samenwerkingsverbanden"; rol-mapping checken: viewer ziet lijst, editor kan create/update, super_admin kan delete
- [ ] Maak programma "CRI" via UI, voeg twee personen toe (waaronder iemand die ook plaatsing bij een eenheid heeft); verifieer `aantal_leden`-teller
- [ ] Open `PersonCardExpandable` van een lid; sectie "Samenwerkingsverbanden" toont het verband + rol, klik op de naam navigeert naar detail
- [ ] Werkgroep met `eind_datum < today` aanmaken; filter "alleen actieve" verbergt 'm, `actief=false` toont 'm wel
- [ ] Verwijder samenwerkingsverband; lidmaatschap-rij wordt mee opgeruimd via CASCADE
- [ ] Open community-graph van een lead; persoon die in een swv zit krijgt een paarse `Handshake`-node naast eventuele eenheid-node, met `lid_van_swv` edge
- [ ] Open `AddLeadContactModal` op een lead, kies "Nieuwe persoon aanmaken", vul naam + expertise + eenheid + één swv in; controleer dat persoon meteen in de samenwerkingsverband-detail staat én als lead-contact gekoppeld is
- [ ] `uv run --project backend pytest backend/tests/test_samenwerkingsverband.py -v` — 7 tests groen