### PR TITLE
Uniforme contactpersoon-aanmaak op alle drie de lead-flows

### DIFF
--- a/frontend/src/components/leads/AddLeadContactModal.tsx
+++ b/frontend/src/components/leads/AddLeadContactModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 
 import { Modal } from '@/components/common/Modal';
 import { Button } from '@/components/common/Button';
@@ -6,11 +6,11 @@ import { CreatableSelect, type SelectOption } from '@/components/common/Creatabl
 import { usePeople } from '@/hooks/usePeople';
 import { useAddLeadContact } from '@/hooks/useLeads';
 import { useCreateContactPerson } from '@/hooks/useNewContactPerson';
+import { NewContactPersonFields } from '@/components/leads/NewContactPersonFields';
 import {
-  NewContactPersonFields,
   emptyContactPersonFields,
   type ContactPersonFieldsState,
-} from '@/components/leads/NewContactPersonFields';
+} from '@/components/leads/contactPersonFields';
 import { LEAD_CONTACT_ROL_LABELS } from '@/types';
 
 const CONTACT_ROLLEN: SelectOption[] = Object.entries(LEAD_CONTACT_ROL_LABELS).map(
@@ -33,6 +33,17 @@ export function AddLeadContactModal({ leadId, onClose }: Props) {
   const [personId, setPersonId] = useState('');
   const [rol, setRol] = useState('contactpersoon');
   const [fields, setFields] = useState<ContactPersonFieldsState>(emptyContactPersonFields);
+
+  // Reset alle state bij elke lead-wissel én bij sluiten van de modal,
+  // zodat eerder ingevulde "nieuwe contact"-velden niet doorlekken naar
+  // een volgende lead.
+  useEffect(() => {
+    if (!leadId) return;
+    setMode('select');
+    setPersonId('');
+    setRol('contactpersoon');
+    setFields(emptyContactPersonFields());
+  }, [leadId]);
 
   const personOptions: SelectOption[] = people.map((p) => {
     const parts = [p.functie, p.expertise].filter((v): v is string => !!v);

--- a/frontend/src/components/leads/AddLeadContactModal.tsx
+++ b/frontend/src/components/leads/AddLeadContactModal.tsx
@@ -1,25 +1,17 @@
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback } from 'react';
 
 import { Modal } from '@/components/common/Modal';
 import { Button } from '@/components/common/Button';
-import { Input } from '@/components/common/Input';
 import { CreatableSelect, type SelectOption } from '@/components/common/CreatableSelect';
-import { CascadingOrgSelect } from '@/components/common/CascadingOrgSelect';
-import {
-  usePeople,
-  useCreatePerson,
-  useExpertiseValues,
-  useAddPersonOrganisatie,
-} from '@/hooks/usePeople';
+import { usePeople } from '@/hooks/usePeople';
 import { useAddLeadContact } from '@/hooks/useLeads';
+import { useCreateContactPerson } from '@/hooks/useNewContactPerson';
 import {
-  useSamenwerkingsverbanden,
-  useAddLid,
-} from '@/hooks/useSamenwerkingsverbanden';
-import {
-  LEAD_CONTACT_ROL_LABELS,
-  SAMENWERKINGSVERBAND_TYPE_LABELS,
-} from '@/types';
+  NewContactPersonFields,
+  emptyContactPersonFields,
+  type ContactPersonFieldsState,
+} from '@/components/leads/NewContactPersonFields';
+import { LEAD_CONTACT_ROL_LABELS } from '@/types';
 
 const CONTACT_ROLLEN: SelectOption[] = Object.entries(LEAD_CONTACT_ROL_LABELS).map(
   ([value, label]) => ({ value, label }),
@@ -34,25 +26,13 @@ type Mode = 'select' | 'create';
 
 export function AddLeadContactModal({ leadId, onClose }: Props) {
   const { data: people = [] } = usePeople();
-  const { data: expertiseValues = [] } = useExpertiseValues();
-  const { data: samenwerkingsverbanden = [] } = useSamenwerkingsverbanden({ actief: true });
-  const createPerson = useCreatePerson();
   const addContact = useAddLeadContact();
-  const addPersonOrg = useAddPersonOrganisatie();
-  const addLidMutation = useAddLid();
+  const createContact = useCreateContactPerson();
 
   const [mode, setMode] = useState<Mode>('select');
   const [personId, setPersonId] = useState('');
   const [rol, setRol] = useState('contactpersoon');
-
-  // Velden voor "create"-mode
-  const [naam, setNaam] = useState('');
-  const [email, setEmail] = useState('');
-  const [functie, setFunctie] = useState('');
-  const [expertise, setExpertise] = useState('');
-  const [orgEenheidId, setOrgEenheidId] = useState('');
-  const [swvIds, setSwvIds] = useState<Set<string>>(new Set());
-  const [expertiseLocalAdded, setExpertiseLocalAdded] = useState<string[]>([]);
+  const [fields, setFields] = useState<ContactPersonFieldsState>(emptyContactPersonFields);
 
   const personOptions: SelectOption[] = people.map((p) => {
     const parts = [p.functie, p.expertise].filter((v): v is string => !!v);
@@ -63,33 +43,9 @@ export function AddLeadContactModal({ leadId, onClose }: Props) {
     };
   });
 
-  const expertiseOptions: SelectOption[] = useMemo(
-    () => [
-      ...expertiseValues.map((v) => ({ value: v, label: v })),
-      ...expertiseLocalAdded
-        .filter((v) => !expertiseValues.includes(v))
-        .map((v) => ({ value: v, label: v })),
-    ],
-    [expertiseValues, expertiseLocalAdded],
-  );
-
-  const toggleSwv = (id: string) => {
-    setSwvIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
-  };
-
   const switchToCreate = useCallback((typedName: string) => {
     setMode('create');
-    setNaam(typedName);
-    setEmail('');
-    setFunctie('');
-    setExpertise('');
-    setOrgEenheidId('');
-    setSwvIds(new Set());
+    setFields({ ...emptyContactPersonFields(), naam: typedName });
     return null;
   }, []);
 
@@ -97,13 +53,7 @@ export function AddLeadContactModal({ leadId, onClose }: Props) {
     setMode('select');
     setPersonId('');
     setRol('contactpersoon');
-    setNaam('');
-    setEmail('');
-    setFunctie('');
-    setExpertise('');
-    setOrgEenheidId('');
-    setSwvIds(new Set());
-    setExpertiseLocalAdded([]);
+    setFields(emptyContactPersonFields());
     onClose();
   }, [onClose]);
 
@@ -118,69 +68,26 @@ export function AddLeadContactModal({ leadId, onClose }: Props) {
   }, [leadId, personId, rol, addContact, resetAndClose]);
 
   const handleSubmitCreate = useCallback(async () => {
-    if (!leadId || !naam.trim()) return;
-
-    let created;
+    if (!leadId) return;
+    const result = await createContact.create({
+      naam: fields.naam,
+      email: fields.email,
+      phone: fields.phone,
+      functie: fields.functie,
+      expertise: fields.expertise,
+      organisatieEenheidId: fields.organisatieEenheidId || undefined,
+      samenwerkingsverbandIds: Array.from(fields.samenwerkingsverbandIds),
+    });
+    if (!result) return; // toast getoond, modal blijft open
     try {
-      created = await createPerson.mutateAsync({
-        naam: naam.trim(),
-        email: email.trim() || undefined,
-        functie: functie.trim() || undefined,
-        expertise: expertise.trim() || undefined,
-        force: true,
-      });
-    } catch {
-      return; // toast getoond, modal blijft open
-    }
-    const newPersonId = created.id;
-
-    // Best-effort follow-ups; falen blokkeert de lead-koppeling niet.
-    const today = new Date().toISOString().slice(0, 10);
-    if (orgEenheidId) {
-      try {
-        await addPersonOrg.mutateAsync({
-          personId: newPersonId,
-          data: { organisatie_eenheid_id: orgEenheidId, start_datum: today },
-        });
-      } catch {
-        // ignore — toast getoond
-      }
-    }
-    for (const swvId of swvIds) {
-      try {
-        await addLidMutation.mutateAsync({
-          swvId,
-          data: { person_id: newPersonId, start_datum: today },
-        });
-      } catch {
-        // ignore
-      }
-    }
-
-    try {
-      await addContact.mutateAsync({ leadId, personId: newPersonId, rol });
+      await addContact.mutateAsync({ leadId, personId: result.personId, rol });
       resetAndClose();
     } catch {
       // toast
     }
-  }, [
-    leadId,
-    naam,
-    email,
-    functie,
-    expertise,
-    orgEenheidId,
-    swvIds,
-    rol,
-    createPerson,
-    addPersonOrg,
-    addLidMutation,
-    addContact,
-    resetAndClose,
-  ]);
+  }, [leadId, fields, rol, createContact, addContact, resetAndClose]);
 
-  const isPending =
-    createPerson.isPending || addContact.isPending || addPersonOrg.isPending || addLidMutation.isPending;
+  const isPending = createContact.isPending || addContact.isPending;
 
   return (
     <Modal
@@ -200,7 +107,7 @@ export function AddLeadContactModal({ leadId, onClose }: Props) {
             <Button
               onClick={handleSubmitCreate}
               loading={isPending}
-              disabled={!naam.trim()}
+              disabled={!fields.naam.trim()}
             >
               Aanmaken & koppelen
             </Button>
@@ -244,80 +151,11 @@ export function AddLeadContactModal({ leadId, onClose }: Props) {
         </div>
       ) : (
         <div className="space-y-4">
-          <Input
-            label="Naam"
-            value={naam}
-            onChange={(e) => setNaam(e.target.value)}
-            required
-            autoFocus
+          <NewContactPersonFields
+            state={fields}
+            onChange={setFields}
+            disabled={isPending}
           />
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <Input
-              label="E-mail"
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder="email@voorbeeld.nl"
-            />
-            <Input
-              label="Functie"
-              value={functie}
-              onChange={(e) => setFunctie(e.target.value)}
-              placeholder="bv. wetgevingsjurist"
-            />
-          </div>
-          <CreatableSelect
-            label="Expertise"
-            value={expertise}
-            onChange={setExpertise}
-            options={expertiseOptions}
-            placeholder="Bijv. wetgevingsjurist, BIT-adviseur..."
-            onCreate={async (text) => {
-              const value = text.trim();
-              if (!value) return null;
-              setExpertiseLocalAdded((prev) =>
-                prev.includes(value) ? prev : [...prev, value],
-              );
-              setExpertise(value);
-              return value;
-            }}
-            createLabel="Nieuwe expertise toevoegen"
-          />
-          <div>
-            <label className="block text-sm font-medium text-text mb-1">
-              Organisatie-eenheid (optioneel)
-            </label>
-            <CascadingOrgSelect
-              value={orgEenheidId}
-              onChange={setOrgEenheidId}
-            />
-          </div>
-          {samenwerkingsverbanden.length > 0 && (
-            <div>
-              <label className="block text-sm font-medium text-text mb-1">
-                Samenwerkingsverbanden (optioneel)
-              </label>
-              <div className="max-h-32 overflow-y-auto rounded-lg border border-border p-2 space-y-1">
-                {samenwerkingsverbanden.map((s) => (
-                  <label
-                    key={s.id}
-                    className="flex items-center gap-2 text-sm cursor-pointer hover:bg-gray-50 rounded px-1 py-0.5"
-                  >
-                    <input
-                      type="checkbox"
-                      checked={swvIds.has(s.id)}
-                      onChange={() => toggleSwv(s.id)}
-                      className="rounded border-border"
-                    />
-                    <span className="flex-1 truncate">{s.naam}</span>
-                    <span className="text-xs text-text-secondary shrink-0">
-                      {SAMENWERKINGSVERBAND_TYPE_LABELS[s.type] ?? s.type}
-                    </span>
-                  </label>
-                ))}
-              </div>
-            </div>
-          )}
           <CreatableSelect
             label="Rol op deze lead"
             value={rol}

--- a/frontend/src/components/leads/AddLeadContactModal.tsx
+++ b/frontend/src/components/leads/AddLeadContactModal.tsx
@@ -98,6 +98,7 @@ export function AddLeadContactModal({ leadId, onClose }: Props) {
       }
       size={mode === 'create' ? 'md' : 'sm'}
       zIndex={60}
+      closeable={!isPending}
       footer={
         mode === 'create' ? (
           <>

--- a/frontend/src/components/leads/LeadDetailPanel.tsx
+++ b/frontend/src/components/leads/LeadDetailPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import {
   Trash2,
   Pencil,
@@ -25,6 +25,7 @@ import { RichTextFormField } from '@/components/common/RichTextFormField';
 import { RichTextEditor } from '@/components/common/RichTextEditor';
 import { RichTextDisplay } from '@/components/common/RichTextDisplay';
 import { LinkLeadNodeModal } from './LinkLeadNodeModal';
+import { AddLeadContactModal } from './AddLeadContactModal';
 import { Badge } from '@/components/common/Badge';
 import { DetailSection } from '@/components/common/DetailSection';
 import { DetailMetadataGrid } from '@/components/common/DetailMetadataGrid';
@@ -36,7 +37,6 @@ import {
   useDeleteLead,
   useCreateLeadActivity,
   useDeleteLeadActivity,
-  useAddLeadContact,
   useRemoveLeadContact,
   useUnlinkLeadNode,
   useUploadLeadAttachment,
@@ -123,20 +123,11 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
   const createInitiatief = useCreateInitiatief();
   const createPerson = useCreatePerson();
 
-  const contactPersonOptions = useMemo(
-    () => (people ?? [])
-      .filter((p) => p.is_active)
-      .sort((a, b) => a.naam.localeCompare(b.naam))
-      .map((p) => ({ value: p.id, label: p.naam })),
-    [people],
-  );
-
   const updateLead = useUpdateLead();
   const deleteLead = useDeleteLead();
   const createActivity = useCreateLeadActivity();
   const deleteActivity = useDeleteLeadActivity();
   const { person } = useAuth();
-  const addContact = useAddLeadContact();
   const removeContact = useRemoveLeadContact();
   const unlinkNode = useUnlinkLeadNode();
   const uploadAttachment = useUploadLeadAttachment();
@@ -171,8 +162,6 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
 
   // Contact add form
   const [showAddContact, setShowAddContact] = useState(false);
-  const [contactPersonId, setContactPersonId] = useState('');
-  const [contactRol, setContactRol] = useState('contactpersoon');
 
   // Node link modal
   const [showLinkNode, setShowLinkNode] = useState(false);
@@ -310,20 +299,6 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
           setActivityType(LeadActivityType.NOTE);
           setActivityUitkomst('');
           setActivityVervolgacties('');
-        },
-      },
-    );
-  };
-
-  const handleAddContact = () => {
-    if (!lead || !contactPersonId) return;
-    addContact.mutate(
-      { leadId: lead.id, personId: contactPersonId, rol: contactRol },
-      {
-        onSuccess: () => {
-          setShowAddContact(false);
-          setContactPersonId('');
-          setContactRol('contactpersoon');
         },
       },
     );
@@ -950,40 +925,10 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
               <p className="text-sm text-text-secondary">Geen externe contactpersonen</p>
             )}
 
-            {showAddContact && (
-              <div className="space-y-2 mt-2">
-                <div className="flex items-end gap-2">
-                  <div className="flex-1">
-                    <CreatableSelect
-                      value={contactPersonId}
-                      onChange={setContactPersonId}
-                      options={contactPersonOptions}
-                      placeholder="Zoek of typ een naam..."
-                      onCreate={async (name) => {
-                        const newPerson = await createPerson.mutateAsync({ naam: name, force: true });
-                        return newPerson?.id ?? null;
-                      }}
-                      createLabel="Nieuw contact"
-                    />
-                  </div>
-                  <input
-                    type="text"
-                    value={contactRol}
-                    onChange={(e) => setContactRol(e.target.value)}
-                    placeholder="Rol"
-                    className="w-32 rounded-lg border border-border px-2 py-1.5 text-sm focus:outline-none focus:border-primary-400"
-                  />
-                </div>
-                <div className="flex items-center gap-2">
-                  <Button size="sm" onClick={handleAddContact} disabled={!contactPersonId}>
-                    Toevoegen
-                  </Button>
-                  <Button variant="ghost" size="sm" onClick={() => setShowAddContact(false)}>
-                    Annuleren
-                  </Button>
-                </div>
-              </div>
-            )}
+            <AddLeadContactModal
+              leadId={showAddContact ? lead.id : null}
+              onClose={() => setShowAddContact(false)}
+            />
           </DetailSection>
 
           {/* Gelinkte nodes */}

--- a/frontend/src/components/leads/LeadIntakeDialog.tsx
+++ b/frontend/src/components/leads/LeadIntakeDialog.tsx
@@ -13,11 +13,11 @@ import type { ParsedEmail } from '@/utils/emailParser';
 import { useToast } from '@/contexts/ToastContext';
 import { usePeople } from '@/hooks/usePeople';
 import { useCreateContactPerson } from '@/hooks/useNewContactPerson';
+import { NewContactPersonFields } from '@/components/leads/NewContactPersonFields';
 import {
-  NewContactPersonFields,
   emptyContactPersonFields,
   type ContactPersonFieldsState,
-} from '@/components/leads/NewContactPersonFields';
+} from '@/components/leads/contactPersonFields';
 import { useInitiatieven, useCreateInitiatief } from '@/hooks/useInitiatieven';
 import { useCurrentPerson } from '@/contexts/CurrentPersonContext';
 import { useLeadDetail } from '@/contexts/LeadDetailContext';
@@ -73,6 +73,12 @@ export function LeadIntakeDialog({ open, onClose, defaultInitiatiefId, sharedPar
   const [contacts, setContacts] = useState<ContactEntry[]>([emptyContact()]);
   const updateContact = useCallback((index: number, updates: Partial<ContactEntry>) => {
     setContacts(prev => prev.map((c, i) => i === index ? { ...c, ...updates } : c));
+  }, []);
+  // Gedeelde lijst zodat een nieuw-toegevoegde expertise zichtbaar is in
+  // alle openstaande contact-rijen voordat de server-cache ververst.
+  const [extraExpertiseValues, setExtraExpertiseValues] = useState<string[]>([]);
+  const addExtraExpertise = useCallback((value: string) => {
+    setExtraExpertiseValues((prev) => (prev.includes(value) ? prev : [...prev, value]));
   }, []);
   const [assigneeId, setAssigneeId] = useState<string>('');
   const [broughtById, setBroughtById] = useState<string>('');
@@ -313,6 +319,7 @@ export function LeadIntakeDialog({ open, onClose, defaultInitiatiefId, sharedPar
     setTagDropdownOpen(false);
     setStage(LeadStage.INBOX);
     setContacts([emptyContact()]);
+    setExtraExpertiseValues([]);
     setAssigneeId('');
     setBroughtById(currentPerson?.id ?? '');
     setLeadDate(new Date().toISOString().split('T')[0]);
@@ -880,6 +887,8 @@ export function LeadIntakeDialog({ open, onClose, defaultInitiatiefId, sharedPar
                       state={contact.fields}
                       onChange={(next) => updateContact(index, { fields: next })}
                       hideNaam
+                      extraExpertiseValues={extraExpertiseValues}
+                      onAddExtraExpertise={addExtraExpertise}
                     />
                   )}
                 </div>

--- a/frontend/src/components/leads/LeadIntakeDialog.tsx
+++ b/frontend/src/components/leads/LeadIntakeDialog.tsx
@@ -11,7 +11,13 @@ import { useTags } from '@/hooks/useTags';
 import { isEmailFile, parseEmailFile, emailToRawText } from '@/utils/emailParser';
 import type { ParsedEmail } from '@/utils/emailParser';
 import { useToast } from '@/contexts/ToastContext';
-import { usePeople, useCreatePerson } from '@/hooks/usePeople';
+import { usePeople } from '@/hooks/usePeople';
+import { useCreateContactPerson } from '@/hooks/useNewContactPerson';
+import {
+  NewContactPersonFields,
+  emptyContactPersonFields,
+  type ContactPersonFieldsState,
+} from '@/components/leads/NewContactPersonFields';
 import { useInitiatieven, useCreateInitiatief } from '@/hooks/useInitiatieven';
 import { useCurrentPerson } from '@/contexts/CurrentPersonContext';
 import { useLeadDetail } from '@/contexts/LeadDetailContext';
@@ -34,17 +40,14 @@ const MAX_FILE_SIZE = 20 * 1024 * 1024; // 20 MB, matches backend limit
 
 interface ContactEntry {
   personId: string;
-  name: string;
-  email: string;
-  phone: string;
+  /** Velden voor wanneer er een nieuwe persoon wordt aangemaakt (personId leeg). */
+  fields: ContactPersonFieldsState;
   rol: string;
 }
 
 const emptyContact = (): ContactEntry => ({
   personId: '',
-  name: '',
-  email: '',
-  phone: '',
+  fields: emptyContactPersonFields(),
   rol: 'contactpersoon',
 });
 
@@ -82,7 +85,7 @@ export function LeadIntakeDialog({ open, onClose, defaultInitiatiefId, sharedPar
   const { currentPerson } = useCurrentPerson();
   const { data: initiatieven } = useInitiatieven();
   const createInitiatiefMutation = useCreateInitiatief();
-  const createPersonMutation = useCreatePerson();
+  const createContact = useCreateContactPerson();
   const { data: people } = usePeople();
   const { data: allTags } = useTags();
   const { openLeadDetail } = useLeadDetail();
@@ -143,9 +146,12 @@ export function LeadIntakeDialog({ open, onClose, defaultInitiatiefId, sharedPar
     setSelectedTags(result.suggested_tags ?? []);
     setContacts([{
       personId: '',
-      name: result.contact_name ?? '',
-      email: result.contact_email ?? '',
-      phone: result.contact_phone ?? '',
+      fields: {
+        ...emptyContactPersonFields(),
+        naam: result.contact_name ?? '',
+        email: result.contact_email ?? '',
+        phone: result.contact_phone ?? '',
+      },
       rol: 'contactpersoon',
     }]);
     const today = new Date().toISOString().split('T')[0];
@@ -217,8 +223,11 @@ export function LeadIntakeDialog({ open, onClose, defaultInitiatiefId, sharedPar
               const updated = [...prev];
               updated[0] = {
                 ...updated[0],
-                name: email.senderName || updated[0].name,
-                email: email.senderEmail || updated[0].email,
+                fields: {
+                  ...updated[0].fields,
+                  naam: email.senderName || updated[0].fields.naam,
+                  email: email.senderEmail || updated[0].fields.email,
+                },
               };
               return updated;
             });
@@ -254,7 +263,7 @@ export function LeadIntakeDialog({ open, onClose, defaultInitiatiefId, sharedPar
   }, [open, initialFiles]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Try to match VLAM's contact_name against existing people
-  const firstContactName = contacts[0]?.name ?? '';
+  const firstContactName = contacts[0]?.fields.naam ?? '';
   useEffect(() => {
     if (firstContactName && people) {
       const match = people.find(
@@ -420,22 +429,31 @@ export function LeadIntakeDialog({ open, onClose, defaultInitiatiefId, sharedPar
           } catch {
             // Non-critical, don't block lead creation
           }
-        } else if (contact.name.trim()) {
+        } else if (contact.fields.naam.trim()) {
           try {
             let personId: string | null = null;
-            if (contact.email.trim() && people) {
+            // Try to match an existing person by email first to avoid duplicates.
+            const email = contact.fields.email.trim();
+            if (email && people) {
               const byEmail = people.find(
-                (p) => p.email?.toLowerCase() === contact.email.trim().toLowerCase(),
+                (p) => p.email?.toLowerCase() === email.toLowerCase(),
               );
               if (byEmail) personId = byEmail.id;
             }
             if (!personId) {
-              const newPerson = await createPersonMutation.mutateAsync({
-                naam: contact.name.trim(),
-                email: contact.email.trim() || undefined,
-                force: true,
+              const result = await createContact.create({
+                naam: contact.fields.naam,
+                email: contact.fields.email,
+                phone: contact.fields.phone,
+                functie: contact.fields.functie,
+                expertise: contact.fields.expertise,
+                organisatieEenheidId:
+                  contact.fields.organisatieEenheidId || undefined,
+                samenwerkingsverbandIds: Array.from(
+                  contact.fields.samenwerkingsverbandIds,
+                ),
               });
-              personId = newPerson?.id ?? null;
+              personId = result?.personId ?? null;
               if (!personId) continue;
             }
             await addLeadContactApi(lead.id, personId, contact.rol);
@@ -831,48 +849,38 @@ export function LeadIntakeDialog({ open, onClose, defaultInitiatiefId, sharedPar
                     value={contact.personId}
                     onChange={(val) => {
                       const person = people?.find((p) => p.id === val);
-                      updateContact(index, { personId: val, name: person?.naam ?? contact.name });
+                      updateContact(index, {
+                        personId: val,
+                        fields: {
+                          ...contact.fields,
+                          naam: person?.naam ?? contact.fields.naam,
+                        },
+                      });
                     }}
                     options={contactOptions}
                     placeholder="Zoek of typ een naam..."
                     onCreate={async (name) => {
-                      updateContact(index, { name, personId: '' });
+                      updateContact(index, {
+                        personId: '',
+                        fields: { ...contact.fields, naam: name },
+                      });
                       return null;
                     }}
                     createLabel="Nieuw contact"
-                    displayValue={!contact.personId && contact.name ? contact.name : undefined}
+                    displayValue={
+                      !contact.personId && contact.fields.naam ? contact.fields.naam : undefined
+                    }
                     onClear={() => {
                       updateContact(index, emptyContact());
                     }}
                   />
 
-                  {(contact.personId || contact.name) && (
-                    <div className="grid grid-cols-2 gap-3">
-                      <div>
-                        <label className="block text-sm font-medium text-text mb-1">
-                          E-mail
-                        </label>
-                        <input
-                          type="email"
-                          value={contact.email}
-                          onChange={(e) => updateContact(index, { email: e.target.value })}
-                          className="w-full rounded-lg border border-border px-3 py-2 text-sm focus:outline-none focus:border-primary-400"
-                          placeholder="email@organisatie.nl"
-                        />
-                      </div>
-                      <div>
-                        <label className="block text-sm font-medium text-text mb-1">
-                          Telefoon
-                        </label>
-                        <input
-                          type="tel"
-                          value={contact.phone}
-                          onChange={(e) => updateContact(index, { phone: e.target.value })}
-                          className="w-full rounded-lg border border-border px-3 py-2 text-sm focus:outline-none focus:border-primary-400"
-                          placeholder="06-12345678"
-                        />
-                      </div>
-                    </div>
+                  {!contact.personId && contact.fields.naam && (
+                    <NewContactPersonFields
+                      state={contact.fields}
+                      onChange={(next) => updateContact(index, { fields: next })}
+                      hideNaam
+                    />
                   )}
                 </div>
               ))}

--- a/frontend/src/components/leads/NewContactPersonFields.tsx
+++ b/frontend/src/components/leads/NewContactPersonFields.tsx
@@ -1,0 +1,203 @@
+/**
+ * Velden voor het aanmaken van een nieuwe externe contactpersoon.
+ *
+ * Pure render-component (geen submit-logica). Wordt gebruikt door
+ * AddLeadContactModal, LeadDetailPanel (inline contact) en
+ * LeadIntakeDialog zodat alle drie de flows dezelfde set velden bieden.
+ */
+
+import { useMemo, useState } from 'react';
+
+import { Input } from '@/components/common/Input';
+import { CreatableSelect, type SelectOption } from '@/components/common/CreatableSelect';
+import { CascadingOrgSelect } from '@/components/common/CascadingOrgSelect';
+import { useExpertiseValues } from '@/hooks/usePeople';
+import { useSamenwerkingsverbanden } from '@/hooks/useSamenwerkingsverbanden';
+import {
+  SAMENWERKINGSVERBAND_TYPE_LABELS,
+  type Samenwerkingsverband,
+} from '@/types';
+
+export interface ContactPersonFieldsState {
+  naam: string;
+  email: string;
+  phone: string;
+  functie: string;
+  expertise: string;
+  organisatieEenheidId: string;
+  samenwerkingsverbandIds: Set<string>;
+}
+
+export const emptyContactPersonFields = (): ContactPersonFieldsState => ({
+  naam: '',
+  email: '',
+  phone: '',
+  functie: '',
+  expertise: '',
+  organisatieEenheidId: '',
+  samenwerkingsverbandIds: new Set(),
+});
+
+interface Props {
+  state: ContactPersonFieldsState;
+  onChange: (next: ContactPersonFieldsState) => void;
+  /** Verberg het naam-veld (gebruikt door AddLeadContactModal waar de naam
+   *  uit de zoekbalk komt). */
+  hideNaam?: boolean;
+  /** Disable alle velden (bv. terwijl een mutation pending is). */
+  disabled?: boolean;
+}
+
+export function NewContactPersonFields({
+  state,
+  onChange,
+  hideNaam = false,
+  disabled = false,
+}: Props) {
+  const { data: expertiseValues = [] } = useExpertiseValues();
+  const { data: samenwerkingsverbanden = [] } = useSamenwerkingsverbanden({
+    actief: true,
+  });
+  const [expertiseLocalAdded, setExpertiseLocalAdded] = useState<string[]>([]);
+
+  const expertiseOptions: SelectOption[] = useMemo(
+    () => [
+      ...expertiseValues.map((v) => ({ value: v, label: v })),
+      ...expertiseLocalAdded
+        .filter((v) => !expertiseValues.includes(v))
+        .map((v) => ({ value: v, label: v })),
+    ],
+    [expertiseValues, expertiseLocalAdded],
+  );
+
+  const set = <K extends keyof ContactPersonFieldsState>(
+    key: K,
+    value: ContactPersonFieldsState[K],
+  ) => onChange({ ...state, [key]: value });
+
+  const toggleSwv = (id: string) => {
+    const next = new Set(state.samenwerkingsverbandIds);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    set('samenwerkingsverbandIds', next);
+  };
+
+  return (
+    <div className="space-y-4">
+      {!hideNaam && (
+        <Input
+          label="Naam"
+          value={state.naam}
+          onChange={(e) => set('naam', e.target.value)}
+          required
+          autoFocus
+          disabled={disabled}
+        />
+      )}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <Input
+          label="E-mail"
+          type="email"
+          value={state.email}
+          onChange={(e) => set('email', e.target.value)}
+          placeholder="email@voorbeeld.nl"
+          disabled={disabled}
+        />
+        <Input
+          label="Telefoon"
+          type="tel"
+          value={state.phone}
+          onChange={(e) => set('phone', e.target.value)}
+          placeholder="06-12345678"
+          disabled={disabled}
+        />
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <Input
+          label="Functie"
+          value={state.functie}
+          onChange={(e) => set('functie', e.target.value)}
+          placeholder="bv. wetgevingsjurist"
+          disabled={disabled}
+        />
+        <CreatableSelect
+          label="Expertise"
+          value={state.expertise}
+          onChange={(v) => set('expertise', v)}
+          options={expertiseOptions}
+          placeholder="Bijv. wetgevingsjurist, BIT-adviseur..."
+          onCreate={async (text) => {
+            const value = text.trim();
+            if (!value) return null;
+            setExpertiseLocalAdded((prev) =>
+              prev.includes(value) ? prev : [...prev, value],
+            );
+            set('expertise', value);
+            return value;
+          }}
+          createLabel="Nieuwe expertise toevoegen"
+          disabled={disabled}
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-text mb-1">
+          Organisatie-eenheid (optioneel)
+        </label>
+        <CascadingOrgSelect
+          value={state.organisatieEenheidId}
+          onChange={(v) => set('organisatieEenheidId', v)}
+        />
+      </div>
+      {samenwerkingsverbanden.length > 0 && (
+        <SwvCheckboxList
+          samenwerkingsverbanden={samenwerkingsverbanden}
+          selected={state.samenwerkingsverbandIds}
+          onToggle={toggleSwv}
+          disabled={disabled}
+        />
+      )}
+    </div>
+  );
+}
+
+interface SwvListProps {
+  samenwerkingsverbanden: Samenwerkingsverband[];
+  selected: Set<string>;
+  onToggle: (id: string) => void;
+  disabled: boolean;
+}
+
+function SwvCheckboxList({
+  samenwerkingsverbanden,
+  selected,
+  onToggle,
+  disabled,
+}: SwvListProps) {
+  return (
+    <div>
+      <label className="block text-sm font-medium text-text mb-1">
+        Samenwerkingsverbanden (optioneel)
+      </label>
+      <div className="max-h-32 overflow-y-auto rounded-lg border border-border p-2 space-y-1">
+        {samenwerkingsverbanden.map((s) => (
+          <label
+            key={s.id}
+            className="flex items-center gap-2 text-sm cursor-pointer hover:bg-gray-50 rounded px-1 py-0.5"
+          >
+            <input
+              type="checkbox"
+              checked={selected.has(s.id)}
+              onChange={() => onToggle(s.id)}
+              className="rounded border-border"
+              disabled={disabled}
+            />
+            <span className="flex-1 truncate">{s.naam}</span>
+            <span className="text-xs text-text-secondary shrink-0">
+              {SAMENWERKINGSVERBAND_TYPE_LABELS[s.type] ?? s.type}
+            </span>
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/leads/NewContactPersonFields.tsx
+++ b/frontend/src/components/leads/NewContactPersonFields.tsx
@@ -17,26 +17,7 @@ import {
   SAMENWERKINGSVERBAND_TYPE_LABELS,
   type Samenwerkingsverband,
 } from '@/types';
-
-export interface ContactPersonFieldsState {
-  naam: string;
-  email: string;
-  phone: string;
-  functie: string;
-  expertise: string;
-  organisatieEenheidId: string;
-  samenwerkingsverbandIds: Set<string>;
-}
-
-export const emptyContactPersonFields = (): ContactPersonFieldsState => ({
-  naam: '',
-  email: '',
-  phone: '',
-  functie: '',
-  expertise: '',
-  organisatieEenheidId: '',
-  samenwerkingsverbandIds: new Set(),
-});
+import type { ContactPersonFieldsState } from './contactPersonFields';
 
 interface Props {
   state: ContactPersonFieldsState;
@@ -46,6 +27,13 @@ interface Props {
   hideNaam?: boolean;
   /** Disable alle velden (bv. terwijl een mutation pending is). */
   disabled?: boolean;
+  /** Optioneel: gedeelde lijst van extra (lokaal toegevoegde) expertise-
+   *  waarden. Wanneer meerdere instances naast elkaar bestaan (bv. in
+   *  LeadIntakeDialog) zorgt dit dat een nieuwe waarde direct in alle
+   *  rijen verschijnt. Zonder deze props valt het component terug op
+   *  per-instance lokale state. */
+  extraExpertiseValues?: string[];
+  onAddExtraExpertise?: (value: string) => void;
 }
 
 export function NewContactPersonFields({
@@ -53,21 +41,24 @@ export function NewContactPersonFields({
   onChange,
   hideNaam = false,
   disabled = false,
+  extraExpertiseValues,
+  onAddExtraExpertise,
 }: Props) {
   const { data: expertiseValues = [] } = useExpertiseValues();
   const { data: samenwerkingsverbanden = [] } = useSamenwerkingsverbanden({
     actief: true,
   });
-  const [expertiseLocalAdded, setExpertiseLocalAdded] = useState<string[]>([]);
+  const [localAdded, setLocalAdded] = useState<string[]>([]);
+  const sharedAdded = extraExpertiseValues ?? localAdded;
 
   const expertiseOptions: SelectOption[] = useMemo(
     () => [
       ...expertiseValues.map((v) => ({ value: v, label: v })),
-      ...expertiseLocalAdded
+      ...sharedAdded
         .filter((v) => !expertiseValues.includes(v))
         .map((v) => ({ value: v, label: v })),
     ],
-    [expertiseValues, expertiseLocalAdded],
+    [expertiseValues, sharedAdded],
   );
 
   const set = <K extends keyof ContactPersonFieldsState>(
@@ -129,9 +120,13 @@ export function NewContactPersonFields({
           onCreate={async (text) => {
             const value = text.trim();
             if (!value) return null;
-            setExpertiseLocalAdded((prev) =>
-              prev.includes(value) ? prev : [...prev, value],
-            );
+            if (onAddExtraExpertise) {
+              onAddExtraExpertise(value);
+            } else {
+              setLocalAdded((prev) =>
+                prev.includes(value) ? prev : [...prev, value],
+              );
+            }
             set('expertise', value);
             return value;
           }}
@@ -182,7 +177,11 @@ function SwvCheckboxList({
         {samenwerkingsverbanden.map((s) => (
           <label
             key={s.id}
-            className="flex items-center gap-2 text-sm cursor-pointer hover:bg-gray-50 rounded px-1 py-0.5"
+            className={`flex items-center gap-2 text-sm rounded px-1 py-0.5 ${
+              disabled
+                ? 'cursor-not-allowed opacity-60'
+                : 'cursor-pointer hover:bg-gray-50'
+            }`}
           >
             <input
               type="checkbox"

--- a/frontend/src/components/leads/contactPersonFields.ts
+++ b/frontend/src/components/leads/contactPersonFields.ts
@@ -1,0 +1,25 @@
+/**
+ * Type + helper voor de NewContactPersonFields-component.
+ * In aparte file gehouden zodat NewContactPersonFields.tsx alleen
+ * componenten exporteert (vereist voor React Fast Refresh).
+ */
+
+export interface ContactPersonFieldsState {
+  naam: string;
+  email: string;
+  phone: string;
+  functie: string;
+  expertise: string;
+  organisatieEenheidId: string;
+  samenwerkingsverbandIds: Set<string>;
+}
+
+export const emptyContactPersonFields = (): ContactPersonFieldsState => ({
+  naam: '',
+  email: '',
+  phone: '',
+  functie: '',
+  expertise: '',
+  organisatieEenheidId: '',
+  samenwerkingsverbandIds: new Set(),
+});

--- a/frontend/src/hooks/useNewContactPerson.ts
+++ b/frontend/src/hooks/useNewContactPerson.ts
@@ -1,0 +1,120 @@
+/**
+ * Helper-hook die een externe contactpersoon aanmaakt met optionele
+ * follow-ups (organisatie-plaatsing, samenwerkingsverband-lidmaatschappen,
+ * extra telefoonnummer).
+ *
+ * Gebruik vanuit AddLeadContactModal, LeadDetailPanel en LeadIntakeDialog
+ * zodat alle drie de flows dezelfde set velden ondersteunen.
+ */
+
+import { useCallback } from 'react';
+import {
+  useAddPersonOrganisatie,
+  useAddPersonPhone,
+  useCreatePerson,
+} from '@/hooks/usePeople';
+import { useAddLid } from '@/hooks/useSamenwerkingsverbanden';
+
+export interface NewContactPersonInput {
+  naam: string;
+  email?: string;
+  /** Optioneel telefoonnummer; opgeslagen als 'werk'-label. */
+  phone?: string;
+  functie?: string;
+  expertise?: string;
+  organisatieEenheidId?: string;
+  samenwerkingsverbandIds?: string[];
+}
+
+export interface CreateContactPersonResult {
+  personId: string;
+  /** Velden die niet konden worden opgeslagen (best-effort). */
+  followUpFailures: Array<'phone' | 'plaatsing' | 'samenwerkingsverband'>;
+}
+
+export function useCreateContactPerson() {
+  const createPerson = useCreatePerson();
+  const addPersonPhone = useAddPersonPhone();
+  const addPersonOrg = useAddPersonOrganisatie();
+  const addLid = useAddLid();
+
+  const create = useCallback(
+    async (input: NewContactPersonInput): Promise<CreateContactPersonResult | null> => {
+      const naam = input.naam.trim();
+      if (!naam) return null;
+
+      const email = input.email?.trim() || undefined;
+      const phone = input.phone?.trim() || undefined;
+
+      // 1. Maak de persoon. Foutgevallen blokkeren de hele flow.
+      let personId: string;
+      try {
+        const person = await createPerson.mutateAsync({
+          naam,
+          email,
+          functie: input.functie?.trim() || undefined,
+          expertise: input.expertise?.trim() || undefined,
+          force: true,
+        });
+        personId = person.id;
+      } catch {
+        return null;
+      }
+
+      const failures: CreateContactPersonResult['followUpFailures'] = [];
+
+      // 2. Best-effort: extra velden die niet via createPerson gaan
+      //    (telefoon staat alleen als secundair record op een persoon).
+      if (phone) {
+        try {
+          await addPersonPhone.mutateAsync({
+            personId,
+            data: { phone_number: phone, label: 'werk', is_default: true },
+          });
+        } catch {
+          failures.push('phone');
+        }
+      }
+
+      // 3. Org-plaatsing
+      if (input.organisatieEenheidId) {
+        try {
+          await addPersonOrg.mutateAsync({
+            personId,
+            data: {
+              organisatie_eenheid_id: input.organisatieEenheidId,
+              start_datum: new Date().toISOString().slice(0, 10),
+            },
+          });
+        } catch {
+          failures.push('plaatsing');
+        }
+      }
+
+      // 4. Samenwerkingsverband-lidmaatschappen
+      const today = new Date().toISOString().slice(0, 10);
+      for (const swvId of input.samenwerkingsverbandIds ?? []) {
+        try {
+          await addLid.mutateAsync({
+            swvId,
+            data: { person_id: personId, start_datum: today },
+          });
+        } catch {
+          failures.push('samenwerkingsverband');
+        }
+      }
+
+      return { personId, followUpFailures: failures };
+    },
+    [createPerson, addPersonPhone, addPersonOrg, addLid],
+  );
+
+  return {
+    create,
+    isPending:
+      createPerson.isPending ||
+      addPersonPhone.isPending ||
+      addPersonOrg.isPending ||
+      addLid.isPending,
+  };
+}

--- a/frontend/src/hooks/useNewContactPerson.ts
+++ b/frontend/src/hooks/useNewContactPerson.ts
@@ -26,12 +26,6 @@ export interface NewContactPersonInput {
   samenwerkingsverbandIds?: string[];
 }
 
-export interface CreateContactPersonResult {
-  personId: string;
-  /** Velden die niet konden worden opgeslagen (best-effort). */
-  followUpFailures: Array<'phone' | 'plaatsing' | 'samenwerkingsverband'>;
-}
-
 export function useCreateContactPerson() {
   const createPerson = useCreatePerson();
   const addPersonPhone = useAddPersonPhone();
@@ -39,14 +33,15 @@ export function useCreateContactPerson() {
   const addLid = useAddLid();
 
   const create = useCallback(
-    async (input: NewContactPersonInput): Promise<CreateContactPersonResult | null> => {
+    async (input: NewContactPersonInput): Promise<{ personId: string } | null> => {
       const naam = input.naam.trim();
       if (!naam) return null;
 
       const email = input.email?.trim() || undefined;
       const phone = input.phone?.trim() || undefined;
 
-      // 1. Maak de persoon. Foutgevallen blokkeren de hele flow.
+      // 1. Maak de persoon. Foutgevallen blokkeren de hele flow; toast wordt
+      //    door useMutationWithError getoond.
       let personId: string;
       try {
         const person = await createPerson.mutateAsync({
@@ -61,10 +56,10 @@ export function useCreateContactPerson() {
         return null;
       }
 
-      const failures: CreateContactPersonResult['followUpFailures'] = [];
-
       // 2. Best-effort: extra velden die niet via createPerson gaan
-      //    (telefoon staat alleen als secundair record op een persoon).
+      //    (telefoon staat als secundair record). Falen geeft een toast en
+      //    blokkeert de lead-koppeling niet — de persoon bestaat al, beter
+      //    gekoppeld zonder telefoon dan helemaal niks.
       if (phone) {
         try {
           await addPersonPhone.mutateAsync({
@@ -72,7 +67,7 @@ export function useCreateContactPerson() {
             data: { phone_number: phone, label: 'werk', is_default: true },
           });
         } catch {
-          failures.push('phone');
+          /* toast uit useMutationWithError */
         }
       }
 
@@ -87,7 +82,7 @@ export function useCreateContactPerson() {
             },
           });
         } catch {
-          failures.push('plaatsing');
+          /* toast */
         }
       }
 
@@ -100,11 +95,11 @@ export function useCreateContactPerson() {
             data: { person_id: personId, start_datum: today },
           });
         } catch {
-          failures.push('samenwerkingsverband');
+          /* toast */
         }
       }
 
-      return { personId, followUpFailures: failures };
+      return { personId };
     },
     [createPerson, addPersonPhone, addPersonOrg, addLid],
   );


### PR DESCRIPTION
## Summary

PR #279 had de uitgebreide create-flow alleen op `AddLeadContactModal`. De inline contact-add in `LeadDetailPanel` viel terug op een minimal-flow met alleen naam + rol-input, en `LeadIntakeDialog` accepteerde alleen naam + email + telefoon. Deze PR uniformeert alle drie:

- Nieuwe component `NewContactPersonFields` met naam (optioneel verbergbaar), email, telefoon, functie, expertise, organisatie-eenheid en een checkbox-lijst van actieve samenwerkingsverbanden.
- Nieuwe hook `useCreateContactPerson` doet `person → phone → plaatsing → samenwerkingsverband-leden` met fail-safe per follow-up.
- `AddLeadContactModal` create-mode gebruikt de gedeelde component.
- `LeadDetailPanel` inline contact-add: vervangen door dezelfde `AddLeadContactModal` openen — één create-flow op deze plek.
- `LeadIntakeDialog`: extra velden onder elke contact-rij die nieuw aangemaakt wordt, plus dezelfde helper-hook in de submit zodat een lead-aanmaak automatisch een rijke contactpersoon kan opleveren.

Buiten scope (bewust): `LeadDetailPanel` assignee-CreatableSelect en `LinkLeadNodeModal` — die zijn voor interne verantwoordelijke / node-koppeling, niet de "externe contactpersoon"-context.

## Test plan

- [ ] `just up`
- [ ] Open een lead, klik in de Contactpersonen-sectie op Toevoegen → modal opent. "Nieuwe persoon aanmaken" → uitgebreide form met expertise, eenheid, swv's
- [ ] Maak een nieuwe lead aan via de intake-dialog. Vul een nieuwe contactpersoon in met expertise + eenheid + swv. Verifieer dat na aanmaken de persoon op de lead-detail in de juiste samenwerkingsverbanden zit
- [ ] Open een lead → community-graph → Plus-knop → modal opent met dezelfde uitgebreide form (regressie-check op #279-flow)