### PR TITLE
Fix: rich text werd rauw gerendered op leads-tijdlijn

### DIFF
--- a/frontend/src/components/leads/LeadTimelineView.tsx
+++ b/frontend/src/components/leads/LeadTimelineView.tsx
@@ -12,6 +12,7 @@ import {
 import { format, isToday, isYesterday, subDays, subMonths } from 'date-fns';
 import { nl } from 'date-fns/locale';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
+import { RichTextDisplay } from '@/components/common/RichTextDisplay';
 import { LeadMetricsBar } from './LeadMetricsBar';
 import { useLeadTimeline } from '@/hooks/useLeads';
 import { useLeadDetail } from '@/contexts/LeadDetailContext';
@@ -146,9 +147,9 @@ function EventDescription({ event }: { event: LeadTimelineEvent }) {
 
     case 'note':
       return event.content ? (
-        <p className="mt-2 text-sm text-text-secondary line-clamp-2">
-          {event.content}
-        </p>
+        <div className="mt-2 line-clamp-2 [&_p]:m-0 [&_p]:leading-snug">
+          <RichTextDisplay content={event.content} fallback="" />
+        </div>
       ) : null;
 
     case 'meeting':
@@ -157,15 +158,21 @@ function EventDescription({ event }: { event: LeadTimelineEvent }) {
       return (
         <div className="mt-2 flex items-start gap-2 text-sm text-text-secondary">
           <EventIcon type={event.event_type} />
-          <span className="line-clamp-2">{event.content ?? getActivityLabel(event.event_type)}</span>
+          {event.content ? (
+            <div className="line-clamp-2 flex-1 [&_p]:m-0 [&_p]:leading-snug">
+              <RichTextDisplay content={event.content} fallback="" />
+            </div>
+          ) : (
+            <span className="line-clamp-2">{getActivityLabel(event.event_type)}</span>
+          )}
         </div>
       );
 
     default:
       return event.content ? (
-        <p className="mt-2 text-sm text-text-secondary line-clamp-2">
-          {event.content}
-        </p>
+        <div className="mt-2 line-clamp-2 [&_p]:m-0 [&_p]:leading-snug">
+          <RichTextDisplay content={event.content} fallback="" />
+        </div>
       ) : null;
   }
 }

--- a/frontend/src/components/organisatie/OrganisatieDetail.tsx
+++ b/frontend/src/components/organisatie/OrganisatieDetail.tsx
@@ -4,6 +4,7 @@ import { clsx } from 'clsx';
 import { Button } from '@/components/common/Button';
 import { Badge } from '@/components/common/Badge';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
+import { RichTextDisplay } from '@/components/common/RichTextDisplay';
 import { PersonCardExpandable } from '@/components/people/PersonCardExpandable';
 import { useOrganisatieEenheid, useOrganisatiePersonenRecursive } from '@/hooks/useOrganisatie';
 import { formatOrganisatieType, ORGANISATIE_TYPE_BADGE_COLORS, formatFunctie } from '@/types';
@@ -273,26 +274,11 @@ export function OrganisatieDetail({
               {eenheid.manager.naam}{eenheid.manager.functie ? ` — ${formatFunctie(eenheid.manager.functie)}` : ''}
             </p>
           )}
-          {eenheid.beschrijving && (() => {
-            // Extract plain text from TipTap JSON, or show as-is for plain text
-            let displayText = eenheid.beschrijving;
-            try {
-              const parsed = JSON.parse(eenheid.beschrijving);
-              if (parsed?.type === 'doc' && Array.isArray(parsed.content)) {
-                displayText = parsed.content
-                  .map((block: { content?: { text?: string }[] }) =>
-                    block.content?.map((c) => c.text ?? '').join('') ?? ''
-                  )
-                  .filter(Boolean)
-                  .join('\n');
-              }
-            } catch {
-              // plain text — use as-is
-            }
-            return displayText ? (
-              <p className="text-sm text-text-secondary mt-1">{displayText}</p>
-            ) : null;
-          })()}
+          {eenheid.beschrijving && (
+            <div className="mt-1">
+              <RichTextDisplay content={eenheid.beschrijving} fallback="" />
+            </div>
+          )}
         </div>
         <div className="flex items-center gap-2 shrink-0">
           <Button

--- a/frontend/src/components/stakeholders/StakeholderTab.tsx
+++ b/frontend/src/components/stakeholders/StakeholderTab.tsx
@@ -3,6 +3,7 @@ import { Trash2 } from 'lucide-react';
 import { Badge } from '@/components/common/Badge';
 import { CreatableSelect } from '@/components/common/CreatableSelect';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
+import { RichTextDisplay } from '@/components/common/RichTextDisplay';
 import {
   useStakeholderAssessments,
   useCreateStakeholderAssessment,
@@ -136,9 +137,7 @@ export function StakeholderTab({
                 />
               )}
               {readOnly && a.notitie && (
-                <p className="text-sm text-text-secondary whitespace-pre-wrap">
-                  {a.notitie}
-                </p>
+                <RichTextDisplay content={a.notitie} fallback="" />
               )}
             </li>
           ))}


### PR DESCRIPTION
## Summary

- `LeadTimelineView.EventDescription` printte `event.content` letterlijk, waardoor notes/meetings/calls/emails als ruwe TipTap-JSON op de tijdlijn verschenen zodra de auteur een mention of opmaak gebruikte. Nu via `RichTextDisplay`.
- Bij dezelfde sweep twee andere plekken met hetzelfde patroon meegenomen: `OrganisatieDetail` (eigen mini-parser die mentions/links sloopte) en `StakeholderTab` (read-only `a.notitie` als rauwe `<p>`).

## Test plan

- [ ] Lead met note die een persoon-mention bevat verschijnt op de tijdlijn als leesbare zin met `@Naam`-pill, niet als JSON-string
- [ ] Note/meeting/call/email-events op de tijdlijn renderen mentions, links, **vet**, *cursief* en lijsten correct
- [ ] Beschrijving op organisatie-eenheid met mentions/links toont nu pills en klikbare links (was: ruwe JSON of plain text zonder mentions)
- [ ] Stakeholder-notitie in read-only modus toont rich text correct