### PR TITLE
AddLeadContactModal: groter + rol als CreatableSelect

### DIFF
--- a/frontend/src/components/leads/AddLeadContactModal.tsx
+++ b/frontend/src/components/leads/AddLeadContactModal.tsx
@@ -37,21 +37,25 @@ export function AddLeadContactModal({ leadId, onClose }: Props) {
 
   const rolOptions: SelectOption[] = [...DEFAULT_CONTACT_ROLLEN, ...extraRollen];
 
-  const handleCreateRol = async (text: string): Promise<string | null> => {
-    const value = text.trim();
-    if (!value) return null;
-    // Sla de getypte tekst zelf op als rol-waarde. Geen slug-conversie:
-    // ResourcePermission.rol is een vrij stringveld en LeadDetailPanel
-    // toont de raw waarde als fallback. Een slug zou diakriet/haakjes
-    // verminken zonder voordeel.
-    if (rolOptions.some((o) => o.value === value)) {
+  const handleCreateRol = useCallback(
+    async (text: string): Promise<string | null> => {
+      const value = text.trim();
+      if (!value) return null;
+      // Sla de getypte tekst zelf op als rol-waarde. Geen slug-conversie:
+      // ResourcePermission.rol is een vrij stringveld en LeadDetailPanel
+      // toont de raw waarde als fallback. Een slug zou diakriet/haakjes
+      // verminken zonder voordeel.
+      setExtraRollen((prev) =>
+        prev.some((o) => o.value === value) ||
+        DEFAULT_CONTACT_ROLLEN.some((o) => o.value === value)
+          ? prev
+          : [...prev, { value, label: value }],
+      );
       setRol(value);
       return value;
-    }
-    setExtraRollen((prev) => [...prev, { value, label: value }]);
-    setRol(value);
-    return value;
-  };
+    },
+    [],
+  );
 
   // Reset alle state bij elke lead-wissel én bij sluiten van de modal,
   // zodat eerder ingevulde "nieuwe contact"-velden niet doorlekken naar
@@ -62,6 +66,7 @@ export function AddLeadContactModal({ leadId, onClose }: Props) {
     setPersonId('');
     setRol('contactpersoon');
     setFields(emptyContactPersonFields());
+    setExtraRollen([]);
   }, [leadId]);
 
   const personOptions: SelectOption[] = people.map((p) => {
@@ -84,6 +89,7 @@ export function AddLeadContactModal({ leadId, onClose }: Props) {
     setPersonId('');
     setRol('contactpersoon');
     setFields(emptyContactPersonFields());
+    setExtraRollen([]);
     onClose();
   }, [onClose]);
 

--- a/frontend/src/components/leads/AddLeadContactModal.tsx
+++ b/frontend/src/components/leads/AddLeadContactModal.tsx
@@ -40,14 +40,17 @@ export function AddLeadContactModal({ leadId, onClose }: Props) {
   const handleCreateRol = async (text: string): Promise<string | null> => {
     const value = text.trim();
     if (!value) return null;
-    const slug = value.toLowerCase().replace(/\s+/g, '_');
-    if (rolOptions.some((o) => o.value === slug)) {
-      setRol(slug);
-      return slug;
+    // Sla de getypte tekst zelf op als rol-waarde. Geen slug-conversie:
+    // ResourcePermission.rol is een vrij stringveld en LeadDetailPanel
+    // toont de raw waarde als fallback. Een slug zou diakriet/haakjes
+    // verminken zonder voordeel.
+    if (rolOptions.some((o) => o.value === value)) {
+      setRol(value);
+      return value;
     }
-    setExtraRollen((prev) => [...prev, { value: slug, label: value }]);
-    setRol(slug);
-    return slug;
+    setExtraRollen((prev) => [...prev, { value, label: value }]);
+    setRol(value);
+    return value;
   };
 
   // Reset alle state bij elke lead-wissel én bij sluiten van de modal,

--- a/frontend/src/components/leads/AddLeadContactModal.tsx
+++ b/frontend/src/components/leads/AddLeadContactModal.tsx
@@ -13,9 +13,9 @@ import {
 } from '@/components/leads/contactPersonFields';
 import { LEAD_CONTACT_ROL_LABELS } from '@/types';
 
-const CONTACT_ROLLEN: SelectOption[] = Object.entries(LEAD_CONTACT_ROL_LABELS).map(
-  ([value, label]) => ({ value, label }),
-);
+const DEFAULT_CONTACT_ROLLEN: SelectOption[] = Object.entries(
+  LEAD_CONTACT_ROL_LABELS,
+).map(([value, label]) => ({ value, label }));
 
 interface Props {
   leadId: string | null;
@@ -33,6 +33,22 @@ export function AddLeadContactModal({ leadId, onClose }: Props) {
   const [personId, setPersonId] = useState('');
   const [rol, setRol] = useState('contactpersoon');
   const [fields, setFields] = useState<ContactPersonFieldsState>(emptyContactPersonFields);
+  const [extraRollen, setExtraRollen] = useState<SelectOption[]>([]);
+
+  const rolOptions: SelectOption[] = [...DEFAULT_CONTACT_ROLLEN, ...extraRollen];
+
+  const handleCreateRol = async (text: string): Promise<string | null> => {
+    const value = text.trim();
+    if (!value) return null;
+    const slug = value.toLowerCase().replace(/\s+/g, '_');
+    if (rolOptions.some((o) => o.value === slug)) {
+      setRol(slug);
+      return slug;
+    }
+    setExtraRollen((prev) => [...prev, { value: slug, label: value }]);
+    setRol(slug);
+    return slug;
+  };
 
   // Reset alle state bij elke lead-wissel én bij sluiten van de modal,
   // zodat eerder ingevulde "nieuwe contact"-velden niet doorlekken naar
@@ -107,7 +123,7 @@ export function AddLeadContactModal({ leadId, onClose }: Props) {
       title={
         mode === 'create' ? 'Nieuwe contactpersoon' : 'Externe contactpersoon toevoegen'
       }
-      size={mode === 'create' ? 'md' : 'sm'}
+      size="md"
       zIndex={60}
       closeable={!isPending}
       footer={
@@ -156,9 +172,10 @@ export function AddLeadContactModal({ leadId, onClose }: Props) {
             label="Rol"
             value={rol}
             onChange={setRol}
-            options={CONTACT_ROLLEN}
-            placeholder="Selecteer een rol..."
-            searchable={false}
+            options={rolOptions}
+            placeholder="Selecteer of typ een rol..."
+            onCreate={handleCreateRol}
+            createLabel="Nieuwe rol toevoegen"
           />
         </div>
       ) : (
@@ -172,9 +189,10 @@ export function AddLeadContactModal({ leadId, onClose }: Props) {
             label="Rol op deze lead"
             value={rol}
             onChange={setRol}
-            options={CONTACT_ROLLEN}
-            placeholder="Selecteer een rol..."
-            searchable={false}
+            options={rolOptions}
+            placeholder="Selecteer of typ een rol..."
+            onCreate={handleCreateRol}
+            createLabel="Nieuwe rol toevoegen"
           />
         </div>
       )}


### PR DESCRIPTION
## Summary

- `AddLeadContactModal` was `size="sm"` in select-mode, waardoor de zoekbalk en de rol-dropdown in de knel kwamen. Naar `size="md"` in beide modes.
- De Rol-select had geen `onCreate` waardoor je beperkt was tot de drie defaults uit `LEAD_CONTACT_ROL_LABELS`. Nu is het een volle CreatableSelect: typ een nieuwe waarde, klik "Nieuwe rol toevoegen", staat als optie in de dropdown en wordt geselecteerd.

## Test plan

- [ ] Open een lead → Contactpersonen → Toevoegen, modal is breder
- [ ] In de Rol-select: typ "Adviseur juridisch" → klik "Nieuwe rol toevoegen" → verschijnt en is geselecteerd
- [ ] Submit met de eigen rol → controleer in lead-detail dat de badge "Adviseur juridisch" toont (raw value)