### PR TITLE
Leads-netwerk: filter graaf op geselecteerd initiatief + swv-toggle aan

### DIFF
--- a/backend/bouwmeester/api/routes/graph.py
+++ b/backend/bouwmeester/api/routes/graph.py
@@ -77,13 +77,19 @@ async def get_community_graph(
     current_user: OptionalUser,
     org_ctx: OrgContext = Depends(get_org_context),
     init_ctx: InitiatiefContext = Depends(get_initiatief_context),
+    initiatief_id: UUID | None = Query(None),
     db: AsyncSession = Depends(get_db),
 ) -> CommunityGraphResponse:
     """Return a community graph of leads, people, organisations and corpus nodes.
 
-    Builds a unified graph starting from all visible leads (filtered by
-    the caller's initiatief context) and transitively includes all related
-    persons, external organisations, and linked corpus nodes.
+    Builds a unified graph starting from leads (filtered by the caller's
+    initiatief context for visibility, and optionally narrowed to a single
+    ``initiatief_id``) and transitively includes all related persons,
+    external organisations, samenwerkingsverbanden and corpus nodes.
     """
     repo = GraphRepository(db)
-    return await repo.get_community_graph(org_ctx=org_ctx, init_ctx=init_ctx)
+    return await repo.get_community_graph(
+        org_ctx=org_ctx,
+        init_ctx=init_ctx,
+        initiatief_id=initiatief_id,
+    )

--- a/backend/bouwmeester/repositories/graph.py
+++ b/backend/bouwmeester/repositories/graph.py
@@ -219,12 +219,14 @@ class GraphRepository:
         self,
         org_ctx: OrgContext | None = None,
         init_ctx: InitiatiefContext | None = None,
+        initiatief_id: UUID | None = None,
     ) -> CommunityGraphResponse:
         """Build a unified graph of leads, persons, organisations and corpus nodes.
 
-        The graph includes all visible leads (filtered by InitiatiefContext)
-        and transitively collects every person, external organisation, and
-        corpus node connected to those leads.
+        The graph starts from leads filtered by ``init_ctx`` (visibility) and,
+        when ``initiatief_id`` is given, narrowed to that single initiatief.
+        It then transitively collects every person, external organisation,
+        samenwerkingsverband and corpus node connected to those leads.
 
         Returns a ``CommunityGraphResponse`` with deduplicated nodes and edges.
         """
@@ -240,6 +242,8 @@ class GraphRepository:
         # -- 1. Visible leads --
         leads_stmt = select(Lead)
         leads_stmt = apply_initiatief_filter(leads_stmt, Lead.initiatief_id, init_ctx)
+        if initiatief_id is not None:
+            leads_stmt = leads_stmt.where(Lead.initiatief_id == initiatief_id)
         leads_result = await self.session.execute(leads_stmt)
         leads = list(leads_result.scalars().all())
 

--- a/backend/tests/test_graph.py
+++ b/backend/tests/test_graph.py
@@ -402,3 +402,91 @@ async def test_community_graph_renders_samenwerkingsverband(
     )
     assert swv_edge is not None
     assert swv_edge["label"] == "trekker"
+
+
+async def test_community_graph_filters_by_initiatief_id_query_param(
+    client, db_session, sample_person
+):
+    """initiatief_id query-param beperkt de graaf tot die ene initiatief.
+
+    Voorheen filterde alleen de frontend op `lead.initiatiefId`, waardoor
+    persons en organisations die aan leads van een ander initiatief
+    hingen wel in de respons stonden en in de UI 'rondzwommen'.
+    """
+    from bouwmeester.models.initiatief import Initiatief
+
+    init_a = Initiatief(id=uuid.uuid4(), naam="Init A")
+    init_b = Initiatief(id=uuid.uuid4(), naam="Init B")
+    db_session.add_all([init_a, init_b])
+    await db_session.flush()
+
+    lead_a = Lead(
+        id=uuid.uuid4(),
+        title="Lead in A",
+        stage="verkennen",
+        initiatief_id=init_a.id,
+        assignee_id=sample_person.id,
+    )
+    lead_b = Lead(
+        id=uuid.uuid4(),
+        title="Lead in B",
+        stage="verkennen",
+        initiatief_id=init_b.id,
+    )
+    db_session.add_all([lead_a, lead_b])
+    await db_session.flush()
+
+    resp = await client.get(f"/api/graph/community?initiatief_id={init_a.id}")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    lead_ids = {n["id"] for n in data["nodes"] if n["node_type"] == "lead"}
+    assert f"lead-{lead_a.id}" in lead_ids
+    assert f"lead-{lead_b.id}" not in lead_ids
+
+    person_ids = {n["id"] for n in data["nodes"] if n["node_type"] == "person"}
+    assert f"person-{sample_person.id}" in person_ids
+
+
+async def test_community_graph_excludes_persons_from_other_initiatief(
+    client, db_session, create_person
+):
+    """Een persoon die alleen via een lead van een ander initiatief in de
+    graaf zou komen, mag bij filtering op initiatief_id niet meer verschijnen.
+    """
+    from bouwmeester.models.initiatief import Initiatief
+
+    init_a = Initiatief(id=uuid.uuid4(), naam="Init A")
+    init_b = Initiatief(id=uuid.uuid4(), naam="Init B")
+    db_session.add_all([init_a, init_b])
+
+    person_a = await create_person(naam="Alice")
+    person_b = await create_person(naam="Bob")
+
+    db_session.add_all(
+        [
+            Lead(
+                id=uuid.uuid4(),
+                title="Lead in A",
+                stage="verkennen",
+                initiatief_id=init_a.id,
+                assignee_id=person_a.id,
+            ),
+            Lead(
+                id=uuid.uuid4(),
+                title="Lead in B",
+                stage="verkennen",
+                initiatief_id=init_b.id,
+                assignee_id=person_b.id,
+            ),
+        ]
+    )
+    await db_session.flush()
+
+    resp = await client.get(f"/api/graph/community?initiatief_id={init_a.id}")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    person_ids = {n["id"] for n in data["nodes"] if n["node_type"] == "person"}
+    assert f"person-{person_a.id}" in person_ids
+    assert f"person-{person_b.id}" not in person_ids

--- a/frontend/src/api/leads.ts
+++ b/frontend/src/api/leads.ts
@@ -140,8 +140,11 @@ export function getLeadAttachmentDownloadUrl(leadId: string, attachmentId: strin
   return `${BASE_URL}/api/leads/${leadId}/attachments/${attachmentId}/download`;
 }
 
-export async function getCommunityGraph(): Promise<CommunityGraphResponse> {
-  return apiGet<CommunityGraphResponse>('/api/graph/community');
+export async function getCommunityGraph(
+  initiatiefId?: string,
+): Promise<CommunityGraphResponse> {
+  const qs = initiatiefId ? `?initiatief_id=${encodeURIComponent(initiatiefId)}` : '';
+  return apiGet<CommunityGraphResponse>(`/api/graph/community${qs}`);
 }
 
 // --- Lead tags ---

--- a/frontend/src/components/leads/LeadGraphView.tsx
+++ b/frontend/src/components/leads/LeadGraphView.tsx
@@ -137,7 +137,6 @@ interface CommunityGraphNodeData {
   label: string;
   nodeType: CommunityNodeType;
   stage?: string | null;
-  initiatiefId?: string | null;
   functie?: string | null;
   expertise?: string | null;
   personRole?: 'intern' | 'extern' | null;
@@ -478,7 +477,6 @@ function CommunityGraphInner({
           label: node.label,
           nodeType: node.node_type,
           stage: node.stage,
-          initiatiefId: node.initiatief_id,
           functie: node.functie,
           expertise: node.expertise,
           personRole: node.person_role ?? null,

--- a/frontend/src/components/leads/LeadGraphView.tsx
+++ b/frontend/src/components/leads/LeadGraphView.tsx
@@ -1,5 +1,14 @@
 import { useState, useMemo, useCallback, useEffect, useRef, memo } from 'react';
-import { Building2, User, UserCircle2, FileText, Lightbulb, Plus, X, Handshake } from 'lucide-react';
+import {
+  Building2,
+  User,
+  UserCircle2,
+  FileText,
+  Lightbulb,
+  Plus,
+  X,
+  Handshake,
+} from 'lucide-react';
 import { useIsMobile } from '@/hooks/useMediaQuery';
 import ReactFlow, {
   Background,
@@ -376,6 +385,7 @@ const NODE_TYPE_TOGGLES: NodeTypeToggle[] = [
   { key: 'lead', label: 'Leads', icon: <Lightbulb className="h-3.5 w-3.5" />, activeColor: 'bg-blue-100 text-blue-800' },
   { key: 'person', label: 'Personen', icon: <User className="h-3.5 w-3.5" />, activeColor: 'bg-pink-100 text-pink-800' },
   { key: 'organisation', label: 'Organisaties', icon: <Building2 className="h-3.5 w-3.5" />, activeColor: 'bg-teal-100 text-teal-800' },
+  { key: 'samenwerkingsverband', label: 'Verbanden', icon: <Handshake className="h-3.5 w-3.5" />, activeColor: 'bg-purple-100 text-purple-800' },
   { key: 'corpus_node', label: 'Beleidsnodes', icon: <FileText className="h-3.5 w-3.5" />, activeColor: 'bg-gray-100 text-gray-700' },
 ];
 
@@ -392,7 +402,7 @@ function CommunityGraphInner({
   stageFilter: stageFilterProp = '',
 }: CommunityGraphInnerProps) {
   const isMobile = useIsMobile();
-  const { data, isLoading, error } = useCommunityGraph();
+  const { data, isLoading, error } = useCommunityGraph(initiatiefId || undefined);
   const { openLeadDetail } = useLeadDetail();
   const { openNodeDetail } = useNodeDetail();
 
@@ -422,7 +432,7 @@ function CommunityGraphInner({
 
   // View-specific filter: node type toggles
   const [enabledTypes, setEnabledTypes] = useState<Set<CommunityNodeType>>(
-    new Set(['lead', 'person', 'organisation', 'corpus_node']),
+    new Set(['lead', 'person', 'organisation', 'samenwerkingsverband', 'corpus_node']),
   );
 
   const toggleType = useCallback((type: CommunityNodeType) => {
@@ -566,9 +576,8 @@ function CommunityGraphInner({
       const d = node.data as CommunityGraphNodeData;
       const matchesType = enabledTypes.has(d.nodeType);
       const matchesStage = !stageFilterProp || d.nodeType !== 'lead' || d.stage === stageFilterProp;
-      const matchesInitiatief = !initiatiefId || d.nodeType !== 'lead' || d.initiatiefId === initiatiefId;
       const matchesSearch = !q || searchActsAsFocus || d.label.toLowerCase().includes(q);
-      const isVisible = matchesType && matchesStage && matchesInitiatief && matchesSearch;
+      const isVisible = matchesType && matchesStage && matchesSearch;
       if (isVisible) visibleIds.add(node.id);
       const dimmed = isVisible && focusedSet !== null && !focusedSet.has(node.id);
       return { ...node, hidden: !isVisible, data: { ...d, dimmed } };
@@ -597,7 +606,6 @@ function CommunityGraphInner({
     allRfEdges,
     enabledTypes,
     stageFilterProp,
-    initiatiefId,
     searchQueryProp,
     searchFocusId,
     focusedSet,

--- a/frontend/src/hooks/useLeads.ts
+++ b/frontend/src/hooks/useLeads.ts
@@ -267,10 +267,10 @@ export function useDeleteLeadAttachment() {
   });
 }
 
-export function useCommunityGraph() {
+export function useCommunityGraph(initiatiefId?: string) {
   return useQuery({
-    queryKey: [...queryKeys.leads.all, 'community-graph'],
-    queryFn: getCommunityGraph,
+    queryKey: [...queryKeys.leads.all, 'community-graph', initiatiefId ?? null],
+    queryFn: () => getCommunityGraph(initiatiefId),
   });
 }
 


### PR DESCRIPTION
## Summary
- Backend `/api/graph/community` accepteert een optionele `initiatief_id`-query-param. Voorheen filterde alleen `InitiatiefContext` (zichtbaarheid), waardoor personen/organisaties/samenwerkingsverbanden die via leads van een ander initiatief bereikbaar waren door de graaf zwommen.
- De samenwerkingsverband-toggle uit #279 was nooit aangezet: swv stond niet in de default `enabledTypes` en niet in `NODE_TYPE_TOGGLES`. Nieuwe paarse "Verbanden"-toggle met Handshake-icoon, default aan.
- Frontend gebruikt nu de query-param via `useCommunityGraph(initiatiefId)`; de inadequate frontend-only `matchesInitiatief`-check op lead-nodes is uit de filter gehaald.
- Twee nieuwe tests in `test_graph.py` (positief pad + regressiepad voor de cross-initiatief-personen).

## Test plan
- [ ] `just reset-db && just up`, leads-pagina openen
- [ ] Initiatief A selecteren: alleen leads van A + hun directe netwerk (personen, orgs, swv'n) zichtbaar
- [ ] Wisselen naar initiatief B: graaf vernieuwt en toont alleen B's netwerk; personen die alleen aan A hingen zijn weg
- [ ] "Verbanden"-toggle staat default aan, swv-nodes en `lid_van_swv`-edges zichtbaar
- [ ] Toggle uitzetten verbergt swv-nodes en hun edges, weer aanzetten brengt ze terug
- [ ] `uv run --project backend pytest backend/tests/test_graph.py -v -k community_graph`