### PR TITLE
GitHub-werk koppelen aan leads (fase 1)

### DIFF
--- a/backend/bouwmeester/api/routes/leads.py
+++ b/backend/bouwmeester/api/routes/leads.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from bouwmeester.api.deps import require_deleted, require_found, validate_list
 from bouwmeester.core.auth import OptionalUser
 from bouwmeester.core.database import get_db
+from bouwmeester.core.github_url import parse_github_url
 from bouwmeester.core.initiatief_context import (
     InitiatiefContext,
     get_initiatief_context,
@@ -25,12 +26,19 @@ from bouwmeester.core.storage import (
     validate_upload,
     write_upload_to_disk,
 )
+from bouwmeester.models.github_link import SCOPE_LEAD, GitHubLink
 from bouwmeester.models.lead import Lead
 from bouwmeester.models.lead_activity import LeadActivity
 from bouwmeester.models.lead_attachment import LeadAttachment
 from bouwmeester.models.lead_node import LeadNode
+from bouwmeester.repositories.github_link import GitHubLinkRepository
 from bouwmeester.repositories.lead import LeadRepository
 from bouwmeester.repositories.lead_activity import LeadActivityRepository
+from bouwmeester.schema.github_link import (
+    GitHubLinkCreate,
+    GitHubLinkResponse,
+    GitHubLinkUpdate,
+)
 from bouwmeester.schema.lead import (
     LeadActivityCreate,
     LeadActivityResponse,
@@ -39,6 +47,7 @@ from bouwmeester.schema.lead import (
     LeadContactResponse,
     LeadCreate,
     LeadDetailResponse,
+    LeadGitHubLinkSummary,
     LeadMergeRequest,
     LeadMetricsResponse,
     LeadMove,
@@ -354,6 +363,12 @@ async def get_lead(
     response = LeadDetailResponse.model_validate(lead)
     response.contacts = contacts
 
+    gh_repo = GitHubLinkRepository(db)
+    gh_links = await gh_repo.list_for_scope(SCOPE_LEAD, lead_id)
+    response.github_links = [
+        LeadGitHubLinkSummary.model_validate(link) for link in gh_links
+    ]
+
     # Mark file-attachments whose files no longer exist on disk.
     # URL-attachments (soort='link') hebben geen pad — die blijven beschikbaar.
     pad_by_id = {a.id: a.pad for a in lead.attachments}
@@ -452,6 +467,12 @@ async def delete_lead(
         sa_delete(ResourcePermission).where(
             ResourcePermission.resource_type == "lead",
             ResourcePermission.resource_id == lead_id,
+        )
+    )
+    await db.execute(
+        sa_delete(GitHubLink).where(
+            GitHubLink.scope_type == SCOPE_LEAD,
+            GitHubLink.scope_id == lead_id,
         )
     )
 
@@ -1098,6 +1119,162 @@ async def delete_attachment(
 
     if file_path.exists():
         file_path.unlink()
+
+
+# ---------------------------------------------------------------------------
+# GitHub links
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/{lead_id}/github-links",
+    response_model=list[GitHubLinkResponse],
+)
+async def list_github_links(
+    lead_id: UUID,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    init_ctx: InitiatiefContext = Depends(get_initiatief_context),
+) -> list[GitHubLinkResponse]:
+    lead = await db.get(Lead, lead_id)
+    if lead is None:
+        raise HTTPException(status_code=404, detail="Lead niet gevonden")
+    _check_lead_access(lead, init_ctx)
+
+    repo = GitHubLinkRepository(db)
+    links = await repo.list_for_scope(SCOPE_LEAD, lead_id)
+    return [GitHubLinkResponse.model_validate(link) for link in links]
+
+
+@router.post(
+    "/{lead_id}/github-links",
+    response_model=GitHubLinkResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_github_link(
+    lead_id: UUID,
+    payload: GitHubLinkCreate,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    init_ctx: InitiatiefContext = Depends(get_initiatief_context),
+) -> GitHubLinkResponse:
+    lead = await db.get(Lead, lead_id)
+    if lead is None:
+        raise HTTPException(status_code=404, detail="Lead niet gevonden")
+    _check_lead_access(lead, init_ctx)
+
+    parsed = parse_github_url(payload.url)
+    if parsed is None:
+        raise HTTPException(
+            status_code=422,
+            detail="Ongeldige GitHub-URL",
+        )
+
+    normalized_url = payload.url.strip()
+    repo = GitHubLinkRepository(db)
+    existing = await repo.get_by_scope_url(SCOPE_LEAD, lead_id, normalized_url)
+    if existing is not None:
+        raise HTTPException(
+            status_code=409,
+            detail="Deze GitHub-link is al gekoppeld aan deze lead",
+        )
+
+    created_by_id = (
+        UUID(current_user["id"]) if current_user and current_user.get("id") else None
+    )
+
+    link = await repo.create(
+        scope_type=SCOPE_LEAD,
+        scope_id=lead_id,
+        url=normalized_url,
+        link_type=parsed.link_type.value,
+        owner=parsed.owner,
+        repo=parsed.repo,
+        ref=parsed.ref,
+        title=payload.title,
+        created_by_id=created_by_id,
+    )
+
+    await log_activity(
+        db,
+        current_user,
+        None,
+        "lead_github_link.added",
+        details={
+            "lead_id": str(lead_id),
+            "lead_title": lead.title,
+            "url": normalized_url,
+            "link_type": parsed.link_type.value,
+            "owner_repo": f"{parsed.owner}/{parsed.repo}",
+        },
+    )
+
+    return GitHubLinkResponse.model_validate(link)
+
+
+@router.patch(
+    "/{lead_id}/github-links/{link_id}",
+    response_model=GitHubLinkResponse,
+)
+async def update_github_link(
+    lead_id: UUID,
+    link_id: UUID,
+    payload: GitHubLinkUpdate,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    init_ctx: InitiatiefContext = Depends(get_initiatief_context),
+) -> GitHubLinkResponse:
+    lead = await db.get(Lead, lead_id)
+    if lead is None:
+        raise HTTPException(status_code=404, detail="Lead niet gevonden")
+    _check_lead_access(lead, init_ctx)
+
+    repo = GitHubLinkRepository(db)
+    link = await repo.get(link_id)
+    if link is None or link.scope_type != SCOPE_LEAD or link.scope_id != lead_id:
+        raise HTTPException(status_code=404, detail="GitHub-link niet gevonden")
+
+    updated = await repo.update_title(link, payload.title)
+    return GitHubLinkResponse.model_validate(updated)
+
+
+@router.delete(
+    "/{lead_id}/github-links/{link_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_github_link(
+    lead_id: UUID,
+    link_id: UUID,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    init_ctx: InitiatiefContext = Depends(get_initiatief_context),
+) -> None:
+    lead = await db.get(Lead, lead_id)
+    if lead is None:
+        raise HTTPException(status_code=404, detail="Lead niet gevonden")
+    _check_lead_access(lead, init_ctx)
+
+    repo = GitHubLinkRepository(db)
+    link = await repo.get(link_id)
+    if link is None or link.scope_type != SCOPE_LEAD or link.scope_id != lead_id:
+        raise HTTPException(status_code=404, detail="GitHub-link niet gevonden")
+
+    url = link.url
+    owner_repo = f"{link.owner}/{link.repo}"
+    await repo.delete(link)
+
+    await log_activity(
+        db,
+        current_user,
+        None,
+        "lead_github_link.deleted",
+        details={
+            "lead_id": str(lead_id),
+            "lead_title": lead.title,
+            "url": url,
+            "owner_repo": owner_repo,
+        },
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/bouwmeester/api/routes/leads.py
+++ b/backend/bouwmeester/api/routes/leads.py
@@ -1179,9 +1179,7 @@ async def create_github_link(
             detail="Deze GitHub-link is al gekoppeld aan deze lead",
         )
 
-    created_by_id = (
-        UUID(current_user["id"]) if current_user and current_user.get("id") else None
-    )
+    created_by_id = current_user.id if current_user else None
 
     link = await repo.create(
         scope_type=SCOPE_LEAD,

--- a/backend/bouwmeester/api/routes/leads.py
+++ b/backend/bouwmeester/api/routes/leads.py
@@ -47,7 +47,6 @@ from bouwmeester.schema.lead import (
     LeadContactResponse,
     LeadCreate,
     LeadDetailResponse,
-    LeadGitHubLinkSummary,
     LeadMergeRequest,
     LeadMetricsResponse,
     LeadMove,
@@ -366,7 +365,7 @@ async def get_lead(
     gh_repo = GitHubLinkRepository(db)
     gh_links = await gh_repo.list_for_scope(SCOPE_LEAD, lead_id)
     response.github_links = [
-        LeadGitHubLinkSummary.model_validate(link) for link in gh_links
+        GitHubLinkResponse.model_validate(link) for link in gh_links
     ]
 
     # Mark file-attachments whose files no longer exist on disk.

--- a/backend/bouwmeester/core/github_url.py
+++ b/backend/bouwmeester/core/github_url.py
@@ -1,0 +1,123 @@
+"""GitHub URL parsing.
+
+Pikt branch / pull-request / issue / repo / workflow-run URLs op github.com
+en levert (link_type, owner, repo, ref). Bewust strikt: alleen github.com
+en alleen de vormen die hieronder expliciet matchen tellen, de rest valt
+in `other` of is None.
+"""
+
+from __future__ import annotations
+
+import enum
+import re
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+
+class GitHubLinkType(enum.StrEnum):
+    branch = "branch"
+    pull_request = "pull_request"
+    issue = "issue"
+    repo = "repo"
+    workflow_run = "workflow_run"
+    other = "other"
+
+
+@dataclass(frozen=True)
+class ParsedGitHubLink:
+    link_type: GitHubLinkType
+    owner: str
+    repo: str
+    ref: str | None  # branch-naam, PR/issue-nummer (str), run-id (str)
+
+
+_OWNER_RE = r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})"
+_REPO_RE = r"[A-Za-z0-9._-]+"
+
+_PATTERNS: tuple[tuple[GitHubLinkType, re.Pattern[str]], ...] = (
+    (
+        GitHubLinkType.pull_request,
+        re.compile(
+            rf"^/(?P<owner>{_OWNER_RE})/(?P<repo>{_REPO_RE})/pull/(?P<ref>\d+)/?$"
+        ),
+    ),
+    (
+        GitHubLinkType.issue,
+        re.compile(
+            rf"^/(?P<owner>{_OWNER_RE})/(?P<repo>{_REPO_RE})/issues/(?P<ref>\d+)/?$"
+        ),
+    ),
+    (
+        GitHubLinkType.workflow_run,
+        re.compile(
+            rf"^/(?P<owner>{_OWNER_RE})/(?P<repo>{_REPO_RE})/actions/runs/(?P<ref>\d+)/?$"
+        ),
+    ),
+    (
+        GitHubLinkType.branch,
+        re.compile(
+            rf"^/(?P<owner>{_OWNER_RE})/(?P<repo>{_REPO_RE})/tree/(?P<ref>[^?#]+?)/?$"
+        ),
+    ),
+    (
+        GitHubLinkType.repo,
+        re.compile(rf"^/(?P<owner>{_OWNER_RE})/(?P<repo>{_REPO_RE})/?$"),
+    ),
+)
+
+_OTHER_RE = re.compile(rf"^/(?P<owner>{_OWNER_RE})/(?P<repo>{_REPO_RE})(?:/.*)?$")
+
+
+def parse_github_url(url: str) -> ParsedGitHubLink | None:
+    """Parse een GitHub-URL of return None als het er geen is.
+
+    Accepteert https://github.com en https://www.github.com. Strikt voor de
+    bekende vormen; valt anders terug op `other` zolang het pad in elk
+    geval `/owner/repo` is. Trailing slashes worden getolereerd, query- en
+    fragment-suffixen worden genegeerd.
+    """
+    if not url:
+        return None
+
+    try:
+        parsed = urlparse(url.strip())
+    except ValueError:
+        return None
+
+    if parsed.scheme not in ("http", "https"):
+        return None
+
+    host = (parsed.hostname or "").lower()
+    if host not in ("github.com", "www.github.com"):
+        return None
+
+    path = parsed.path or "/"
+
+    for link_type, pattern in _PATTERNS:
+        match = pattern.match(path)
+        if match:
+            owner = match.group("owner")
+            repo = _strip_git_suffix(match.group("repo"))
+            ref = match.groupdict().get("ref")
+            if ref is not None:
+                ref = ref.rstrip("/")
+            return ParsedGitHubLink(
+                link_type=link_type, owner=owner, repo=repo, ref=ref
+            )
+
+    other = _OTHER_RE.match(path)
+    if other:
+        return ParsedGitHubLink(
+            link_type=GitHubLinkType.other,
+            owner=other.group("owner"),
+            repo=_strip_git_suffix(other.group("repo")),
+            ref=None,
+        )
+
+    return None
+
+
+def _strip_git_suffix(repo: str) -> str:
+    if repo.endswith(".git"):
+        return repo[: -len(".git")]
+    return repo

--- a/backend/bouwmeester/core/github_url.py
+++ b/backend/bouwmeester/core/github_url.py
@@ -34,6 +34,36 @@ class ParsedGitHubLink:
 _OWNER_RE = r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})"
 _REPO_RE = r"[A-Za-z0-9._-]+"
 
+# Speciale eerste-segment-paden op github.com die nooit een gebruikersnaam
+# zijn. Een URL als /orgs/foo/projects/1 wijst niet naar een repo en mag
+# niet als ``other`` met owner=orgs gemarkt worden.
+_RESERVED_OWNER_PATHS = frozenset(
+    {
+        "orgs",
+        "settings",
+        "marketplace",
+        "explore",
+        "topics",
+        "trending",
+        "collections",
+        "events",
+        "pulls",
+        "issues",
+        "notifications",
+        "new",
+        "login",
+        "logout",
+        "join",
+        "search",
+        "sponsors",
+        "about",
+        "contact",
+        "site",
+        "security",
+        "enterprise",
+    }
+)
+
 _PATTERNS: tuple[tuple[GitHubLinkType, re.Pattern[str]], ...] = (
     (
         GitHubLinkType.pull_request,
@@ -97,6 +127,8 @@ def parse_github_url(url: str) -> ParsedGitHubLink | None:
         match = pattern.match(path)
         if match:
             owner = match.group("owner")
+            if owner.lower() in _RESERVED_OWNER_PATHS:
+                return None
             repo = _strip_git_suffix(match.group("repo"))
             ref = match.groupdict().get("ref")
             if ref is not None:
@@ -107,9 +139,12 @@ def parse_github_url(url: str) -> ParsedGitHubLink | None:
 
     other = _OTHER_RE.match(path)
     if other:
+        owner = other.group("owner")
+        if owner.lower() in _RESERVED_OWNER_PATHS:
+            return None
         return ParsedGitHubLink(
             link_type=GitHubLinkType.other,
-            owner=other.group("owner"),
+            owner=owner,
             repo=_strip_git_suffix(other.group("repo")),
             ref=None,
         )

--- a/backend/bouwmeester/migrations/versions/f1a2b3c4d5e6_add_github_link.py
+++ b/backend/bouwmeester/migrations/versions/f1a2b3c4d5e6_add_github_link.py
@@ -1,0 +1,81 @@
+"""add github_link
+
+Revision ID: f1a2b3c4d5e6
+Revises: 2c4d6e8f9a01
+Create Date: 2026-05-06 16:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "f1a2b3c4d5e6"
+down_revision: str | None = "2c4d6e8f9a01"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "github_link",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "scope_type",
+            sa.String(length=32),
+            nullable=False,
+            comment="lead|initiatief",
+        ),
+        sa.Column(
+            "scope_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column("url", sa.String(length=1000), nullable=False),
+        sa.Column(
+            "link_type",
+            sa.String(length=32),
+            nullable=False,
+            comment="branch|pull_request|issue|repo|workflow_run|other",
+        ),
+        sa.Column("owner", sa.String(length=100), nullable=False),
+        sa.Column("repo", sa.String(length=200), nullable=False),
+        sa.Column("ref", sa.String(length=500), nullable=True),
+        sa.Column("title", sa.String(length=500), nullable=True),
+        sa.Column(
+            "created_by_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["created_by_id"], ["person.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "scope_type", "scope_id", "url", name="uq_github_link_scope_url"
+        ),
+    )
+    op.create_index(
+        "ix_github_link_scope_id", "github_link", ["scope_id"], unique=False
+    )
+    op.create_index(
+        "ix_github_link_owner_repo", "github_link", ["owner", "repo"], unique=False
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_github_link_owner_repo", table_name="github_link")
+    op.drop_index("ix_github_link_scope_id", table_name="github_link")
+    op.drop_table("github_link")

--- a/backend/bouwmeester/models/__init__.py
+++ b/backend/bouwmeester/models/__init__.py
@@ -21,6 +21,7 @@ from bouwmeester.models.eenheid_module import EenheidModule  # noqa: F401
 from bouwmeester.models.effect import Effect  # noqa: F401
 from bouwmeester.models.externe_organisatie import ExterneOrganisatie  # noqa: F401
 from bouwmeester.models.fcc_sync_log import FccSyncLog  # noqa: F401
+from bouwmeester.models.github_link import GitHubLink  # noqa: F401
 from bouwmeester.models.http_session import HttpSession  # noqa: F401
 from bouwmeester.models.initiatief import Initiatief  # noqa: F401
 from bouwmeester.models.initiatief_update import InitiatiefUpdatePost  # noqa: F401
@@ -102,6 +103,7 @@ __all__ = [
     "Effect",
     "ExterneOrganisatie",
     "FccSyncLog",
+    "GitHubLink",
     "HttpSession",
     "Initiatief",
     "InitiatiefUpdatePost",

--- a/backend/bouwmeester/models/github_link.py
+++ b/backend/bouwmeester/models/github_link.py
@@ -1,0 +1,80 @@
+"""GitHubLink — koppelt een GitHub-resource aan een lead of initiatief.
+
+Polymorf: `scope_type` ∈ {lead, initiatief}, `scope_id` is geen DB-FK omdat
+het naar verschillende tabellen kan wijzen. De route checkt scope vóór gebruik
+(zelfde patroon als `MattermostChannelLink`).
+"""
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional
+
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    Index,
+    String,
+    UniqueConstraint,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from bouwmeester.core.database import Base
+
+if TYPE_CHECKING:
+    from bouwmeester.models.person import Person
+
+
+SCOPE_LEAD = "lead"
+SCOPE_INITIATIEF = "initiatief"
+
+
+class GitHubLink(Base):
+    __tablename__ = "github_link"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    scope_type: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        comment="lead|initiatief",
+    )
+    scope_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        nullable=False,
+        index=True,
+    )
+    url: Mapped[str] = mapped_column(String(1000), nullable=False)
+    link_type: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        comment="branch|pull_request|issue|repo|workflow_run|other",
+    )
+    owner: Mapped[str] = mapped_column(String(100), nullable=False)
+    repo: Mapped[str] = mapped_column(String(200), nullable=False)
+    ref: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    title: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    created_by_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("person.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+    created_by: Mapped[Optional["Person"]] = relationship(
+        "Person", foreign_keys=[created_by_id]
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "scope_type", "scope_id", "url", name="uq_github_link_scope_url"
+        ),
+        Index("ix_github_link_owner_repo", "owner", "repo"),
+    )

--- a/backend/bouwmeester/repositories/github_link.py
+++ b/backend/bouwmeester/repositories/github_link.py
@@ -1,0 +1,80 @@
+"""Repository voor GitHubLink."""
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bouwmeester.models.github_link import GitHubLink
+
+
+class GitHubLinkRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def get(self, link_id: UUID) -> GitHubLink | None:
+        stmt = select(GitHubLink).where(GitHubLink.id == link_id)
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def get_by_scope_url(
+        self, scope_type: str, scope_id: UUID, url: str
+    ) -> GitHubLink | None:
+        stmt = select(GitHubLink).where(
+            GitHubLink.scope_type == scope_type,
+            GitHubLink.scope_id == scope_id,
+            GitHubLink.url == url,
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def list_for_scope(self, scope_type: str, scope_id: UUID) -> list[GitHubLink]:
+        stmt = (
+            select(GitHubLink)
+            .where(
+                GitHubLink.scope_type == scope_type,
+                GitHubLink.scope_id == scope_id,
+            )
+            .order_by(GitHubLink.created_at.desc())
+        )
+        result = await self.session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def create(
+        self,
+        *,
+        scope_type: str,
+        scope_id: UUID,
+        url: str,
+        link_type: str,
+        owner: str,
+        repo: str,
+        ref: str | None,
+        title: str | None,
+        created_by_id: UUID | None,
+    ) -> GitHubLink:
+        link = GitHubLink(
+            scope_type=scope_type,
+            scope_id=scope_id,
+            url=url,
+            link_type=link_type,
+            owner=owner,
+            repo=repo,
+            ref=ref,
+            title=title,
+            created_by_id=created_by_id,
+        )
+        self.session.add(link)
+        await self.session.flush()
+        await self.session.refresh(link)
+        return link
+
+    async def update_title(self, link: GitHubLink, title: str | None) -> GitHubLink:
+        link.title = title
+        await self.session.flush()
+        await self.session.refresh(link)
+        return link
+
+    async def delete(self, link: GitHubLink) -> None:
+        await self.session.delete(link)
+        await self.session.flush()

--- a/backend/bouwmeester/schema/__init__.py
+++ b/backend/bouwmeester/schema/__init__.py
@@ -81,6 +81,12 @@ from bouwmeester.schema.fcc import (
     SyncDirection,
     SyncStatus,
 )
+from bouwmeester.schema.github_link import (
+    GitHubLinkCreate,
+    GitHubLinkResponse,
+    GitHubLinkType,
+    GitHubLinkUpdate,
+)
 from bouwmeester.schema.graph import (
     GraphNeighborsResponse,
     GraphSearchParams,
@@ -378,6 +384,11 @@ __all__ = [
     "FccSyncTriggerResponse",
     "SyncDirection",
     "SyncStatus",
+    # github_link
+    "GitHubLinkCreate",
+    "GitHubLinkResponse",
+    "GitHubLinkType",
+    "GitHubLinkUpdate",
     # opdracht
     "FinancieelJaar",
     "FinancieelOverzicht",

--- a/backend/bouwmeester/schema/github_link.py
+++ b/backend/bouwmeester/schema/github_link.py
@@ -1,0 +1,41 @@
+"""Pydantic-schema's voor GitHubLink."""
+
+import enum
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class GitHubLinkType(enum.StrEnum):
+    branch = "branch"
+    pull_request = "pull_request"
+    issue = "issue"
+    repo = "repo"
+    workflow_run = "workflow_run"
+    other = "other"
+
+
+class GitHubLinkCreate(BaseModel):
+    url: str = Field(..., min_length=1, max_length=1000)
+    title: str | None = Field(None, max_length=500)
+
+
+class GitHubLinkUpdate(BaseModel):
+    title: str | None = Field(None, max_length=500)
+
+
+class GitHubLinkResponse(BaseModel):
+    id: UUID
+    scope_type: str
+    scope_id: UUID
+    url: str
+    link_type: GitHubLinkType
+    owner: str
+    repo: str
+    ref: str | None = None
+    title: str | None = None
+    created_by_id: UUID | None = None
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/bouwmeester/schema/github_link.py
+++ b/backend/bouwmeester/schema/github_link.py
@@ -1,19 +1,18 @@
 """Pydantic-schema's voor GitHubLink."""
 
-import enum
 from datetime import datetime
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from bouwmeester.core.github_url import GitHubLinkType
 
-class GitHubLinkType(enum.StrEnum):
-    branch = "branch"
-    pull_request = "pull_request"
-    issue = "issue"
-    repo = "repo"
-    workflow_run = "workflow_run"
-    other = "other"
+__all__ = [
+    "GitHubLinkType",
+    "GitHubLinkCreate",
+    "GitHubLinkUpdate",
+    "GitHubLinkResponse",
+]
 
 
 class GitHubLinkCreate(BaseModel):

--- a/backend/bouwmeester/schema/lead.py
+++ b/backend/bouwmeester/schema/lead.py
@@ -7,6 +7,8 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from bouwmeester.schema.github_link import GitHubLinkResponse
+
 
 class LeadStage(enum.StrEnum):
     inbox = "inbox"
@@ -260,25 +262,12 @@ class LeadResponse(BaseModel):
         return data
 
 
-class LeadGitHubLinkSummary(BaseModel):
-    id: UUID
-    url: str
-    link_type: str
-    owner: str
-    repo: str
-    ref: str | None = None
-    title: str | None = None
-    created_at: datetime
-
-    model_config = ConfigDict(from_attributes=True)
-
-
 class LeadDetailResponse(LeadResponse):
     activities: list[LeadActivityResponse] = Field(default_factory=list)
     attachments: list[LeadAttachmentResponse] = Field(default_factory=list)
     contacts: list[LeadContactResponse] = Field(default_factory=list)
     linked_nodes: list[LeadNodeResponse] = Field(default_factory=list)
-    github_links: list[LeadGitHubLinkSummary] = Field(default_factory=list)
+    github_links: list[GitHubLinkResponse] = Field(default_factory=list)
 
 
 class LeadMetricsResponse(BaseModel):

--- a/backend/bouwmeester/schema/lead.py
+++ b/backend/bouwmeester/schema/lead.py
@@ -260,11 +260,25 @@ class LeadResponse(BaseModel):
         return data
 
 
+class LeadGitHubLinkSummary(BaseModel):
+    id: UUID
+    url: str
+    link_type: str
+    owner: str
+    repo: str
+    ref: str | None = None
+    title: str | None = None
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 class LeadDetailResponse(LeadResponse):
     activities: list[LeadActivityResponse] = Field(default_factory=list)
     attachments: list[LeadAttachmentResponse] = Field(default_factory=list)
     contacts: list[LeadContactResponse] = Field(default_factory=list)
     linked_nodes: list[LeadNodeResponse] = Field(default_factory=list)
+    github_links: list[LeadGitHubLinkSummary] = Field(default_factory=list)
 
 
 class LeadMetricsResponse(BaseModel):

--- a/backend/tests/test_github_url.py
+++ b/backend/tests/test_github_url.py
@@ -120,6 +120,12 @@ def test_parse_github_url_happy_path(url, expected_type, owner, repo, ref):
         "https://example.com/foo/bar",
         "https://github.com/",
         "https://github.com/onlyowner",
+        # Reserved first-path-segments are never an owner.
+        "https://github.com/orgs/foo/projects/1",
+        "https://github.com/settings/profile",
+        "https://github.com/marketplace/actions/checkout",
+        "https://github.com/notifications",
+        "https://github.com/search?q=foo",
     ],
 )
 def test_parse_github_url_invalid(url):

--- a/backend/tests/test_github_url.py
+++ b/backend/tests/test_github_url.py
@@ -1,0 +1,133 @@
+"""Tests voor de GitHub URL-parser."""
+
+import pytest
+
+from bouwmeester.core.github_url import GitHubLinkType, parse_github_url
+
+
+@pytest.mark.parametrize(
+    "url,expected_type,owner,repo,ref",
+    [
+        (
+            "https://github.com/anneschuth/regelrecht-upload",
+            GitHubLinkType.repo,
+            "anneschuth",
+            "regelrecht-upload",
+            None,
+        ),
+        (
+            "https://github.com/anneschuth/regelrecht-upload/",
+            GitHubLinkType.repo,
+            "anneschuth",
+            "regelrecht-upload",
+            None,
+        ),
+        (
+            "https://www.github.com/anneschuth/regelrecht-upload",
+            GitHubLinkType.repo,
+            "anneschuth",
+            "regelrecht-upload",
+            None,
+        ),
+        (
+            "https://github.com/anneschuth/regelrecht-upload.git",
+            GitHubLinkType.repo,
+            "anneschuth",
+            "regelrecht-upload",
+            None,
+        ),
+        (
+            "https://github.com/foo/bar/tree/main",
+            GitHubLinkType.branch,
+            "foo",
+            "bar",
+            "main",
+        ),
+        (
+            "https://github.com/foo/bar/tree/feat/nested/branch",
+            GitHubLinkType.branch,
+            "foo",
+            "bar",
+            "feat/nested/branch",
+        ),
+        (
+            "https://github.com/foo/bar/tree/main/",
+            GitHubLinkType.branch,
+            "foo",
+            "bar",
+            "main",
+        ),
+        (
+            "https://github.com/foo/bar/pull/42",
+            GitHubLinkType.pull_request,
+            "foo",
+            "bar",
+            "42",
+        ),
+        (
+            "https://github.com/foo/bar/pull/42/files",
+            GitHubLinkType.other,
+            "foo",
+            "bar",
+            None,
+        ),
+        (
+            "https://github.com/foo/bar/issues/7",
+            GitHubLinkType.issue,
+            "foo",
+            "bar",
+            "7",
+        ),
+        (
+            "https://github.com/foo/bar/actions/runs/12345",
+            GitHubLinkType.workflow_run,
+            "foo",
+            "bar",
+            "12345",
+        ),
+        (
+            "https://github.com/foo/bar/wiki",
+            GitHubLinkType.other,
+            "foo",
+            "bar",
+            None,
+        ),
+        (
+            "https://github.com/foo/bar/pull/42?diff=split#L10",
+            GitHubLinkType.pull_request,
+            "foo",
+            "bar",
+            "42",
+        ),
+    ],
+)
+def test_parse_github_url_happy_path(url, expected_type, owner, repo, ref):
+    parsed = parse_github_url(url)
+    assert parsed is not None
+    assert parsed.link_type is expected_type
+    assert parsed.owner == owner
+    assert parsed.repo == repo
+    assert parsed.ref == ref
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "",
+        "not-a-url",
+        "ftp://github.com/foo/bar",
+        "https://gitlab.com/foo/bar",
+        "https://example.com/foo/bar",
+        "https://github.com/",
+        "https://github.com/onlyowner",
+    ],
+)
+def test_parse_github_url_invalid(url):
+    assert parse_github_url(url) is None
+
+
+def test_parse_github_url_strips_whitespace():
+    parsed = parse_github_url("  https://github.com/foo/bar/pull/1  ")
+    assert parsed is not None
+    assert parsed.link_type is GitHubLinkType.pull_request
+    assert parsed.ref == "1"

--- a/backend/tests/test_lead_github_links.py
+++ b/backend/tests/test_lead_github_links.py
@@ -5,6 +5,7 @@ import uuid
 import pytest
 from sqlalchemy import select
 
+from bouwmeester.core.auth import get_optional_user
 from bouwmeester.models.github_link import SCOPE_LEAD, GitHubLink
 from bouwmeester.models.lead import Lead
 
@@ -160,6 +161,74 @@ async def test_delete_lead_cascades_github_links(client, db_session, sample_lead
         .all()
     )
     assert remaining == []
+
+
+async def test_create_on_unknown_lead_returns_404(client):
+    fake_id = uuid.uuid4()
+    resp = await client.post(
+        f"/api/leads/{fake_id}/github-links",
+        json={"url": "https://github.com/foo/bar"},
+    )
+    assert resp.status_code == 404
+
+
+async def test_list_on_unknown_lead_returns_404(client):
+    fake_id = uuid.uuid4()
+    resp = await client.get(f"/api/leads/{fake_id}/github-links")
+    assert resp.status_code == 404
+
+
+async def test_same_url_can_be_linked_to_two_leads(client, db_session, sample_lead):
+    # Eerste lead krijgt de URL.
+    first = await client.post(
+        f"/api/leads/{sample_lead.id}/github-links",
+        json={"url": "https://github.com/foo/bar/pull/100"},
+    )
+    assert first.status_code == 201
+
+    # Tweede lead krijgt dezelfde URL — dat moet ook gewoon kunnen,
+    # de unique constraint is (scope_type, scope_id, url) en niet alleen url.
+    other = Lead(id=uuid.uuid4(), title="Tweede lead", stage="inbox")
+    db_session.add(other)
+    await db_session.flush()
+
+    second = await client.post(
+        f"/api/leads/{other.id}/github-links",
+        json={"url": "https://github.com/foo/bar/pull/100"},
+    )
+    assert second.status_code == 201
+
+
+async def test_created_by_id_is_set_when_authenticated(
+    client, _test_app, db_session, sample_lead, sample_person
+):
+    """Regressie: current_user is een Person-model, geen dict.
+
+    De code moet ``current_user.id`` gebruiken, niet ``current_user["id"]``,
+    anders throwt de POST-route op een echte authenticated user.
+    """
+    _test_app.dependency_overrides[get_optional_user] = lambda: sample_person
+    try:
+        resp = await client.post(
+            f"/api/leads/{sample_lead.id}/github-links",
+            json={"url": "https://github.com/foo/bar/pull/200"},
+        )
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["created_by_id"] == str(sample_person.id)
+
+        # En in de DB zit dezelfde waarde.
+        link = (
+            (
+                await db_session.execute(
+                    select(GitHubLink).where(GitHubLink.url.endswith("/200"))
+                )
+            )
+            .scalars()
+            .one()
+        )
+        assert link.created_by_id == sample_person.id
+    finally:
+        _test_app.dependency_overrides.pop(get_optional_user, None)
 
 
 async def test_link_for_other_lead_returns_404(client, db_session, sample_lead):

--- a/backend/tests/test_lead_github_links.py
+++ b/backend/tests/test_lead_github_links.py
@@ -1,0 +1,185 @@
+"""Tests voor de lead-GitHub-links endpoints."""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from bouwmeester.models.github_link import SCOPE_LEAD, GitHubLink
+from bouwmeester.models.lead import Lead
+
+
+@pytest.fixture
+async def sample_lead(db_session):
+    lead = Lead(
+        id=uuid.uuid4(),
+        title="GitHub-link lead",
+        stage="interne_check",
+    )
+    db_session.add(lead)
+    await db_session.flush()
+    return lead
+
+
+async def test_create_branch_link_201(client, sample_lead):
+    resp = await client.post(
+        f"/api/leads/{sample_lead.id}/github-links",
+        json={
+            "url": "https://github.com/foo/bar/tree/feat/x",
+            "title": "Werk-branch",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["link_type"] == "branch"
+    assert body["owner"] == "foo"
+    assert body["repo"] == "bar"
+    assert body["ref"] == "feat/x"
+    assert body["title"] == "Werk-branch"
+
+
+async def test_create_pull_request_link_201(client, sample_lead):
+    resp = await client.post(
+        f"/api/leads/{sample_lead.id}/github-links",
+        json={"url": "https://github.com/foo/bar/pull/12"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["link_type"] == "pull_request"
+    assert body["ref"] == "12"
+
+
+async def test_create_invalid_url_422(client, sample_lead):
+    resp = await client.post(
+        f"/api/leads/{sample_lead.id}/github-links",
+        json={"url": "https://gitlab.com/foo/bar"},
+    )
+    assert resp.status_code == 422
+
+
+async def test_create_duplicate_url_409(client, sample_lead):
+    url = "https://github.com/foo/bar/pull/1"
+    first = await client.post(
+        f"/api/leads/{sample_lead.id}/github-links",
+        json={"url": url},
+    )
+    assert first.status_code == 201
+    second = await client.post(
+        f"/api/leads/{sample_lead.id}/github-links",
+        json={"url": url},
+    )
+    assert second.status_code == 409
+
+
+async def test_list_returns_all_created_links(client, sample_lead):
+    urls = {
+        "https://github.com/foo/bar/issues/1",
+        "https://github.com/foo/bar/pull/2",
+    }
+    for url in urls:
+        resp = await client.post(
+            f"/api/leads/{sample_lead.id}/github-links",
+            json={"url": url},
+        )
+        assert resp.status_code == 201
+
+    list_resp = await client.get(f"/api/leads/{sample_lead.id}/github-links")
+    assert list_resp.status_code == 200
+    body = list_resp.json()
+    assert {item["url"] for item in body} == urls
+
+
+async def test_lead_detail_includes_github_links(client, sample_lead):
+    await client.post(
+        f"/api/leads/{sample_lead.id}/github-links",
+        json={"url": "https://github.com/foo/bar"},
+    )
+    detail = await client.get(f"/api/leads/{sample_lead.id}")
+    assert detail.status_code == 200
+    body = detail.json()
+    assert len(body["github_links"]) == 1
+    assert body["github_links"][0]["link_type"] == "repo"
+
+
+async def test_patch_updates_only_title(client, sample_lead):
+    create = await client.post(
+        f"/api/leads/{sample_lead.id}/github-links",
+        json={"url": "https://github.com/foo/bar/pull/9", "title": "Oud"},
+    )
+    link_id = create.json()["id"]
+
+    resp = await client.patch(
+        f"/api/leads/{sample_lead.id}/github-links/{link_id}",
+        json={"title": "Nieuw"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["title"] == "Nieuw"
+
+
+async def test_delete_returns_204_and_removes(client, db_session, sample_lead):
+    create = await client.post(
+        f"/api/leads/{sample_lead.id}/github-links",
+        json={"url": "https://github.com/foo/bar/pull/3"},
+    )
+    link_id = create.json()["id"]
+
+    resp = await client.delete(f"/api/leads/{sample_lead.id}/github-links/{link_id}")
+    assert resp.status_code == 204
+
+    remaining = (
+        (
+            await db_session.execute(
+                select(GitHubLink).where(GitHubLink.id == uuid.UUID(link_id))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert remaining == []
+
+
+async def test_delete_lead_cascades_github_links(client, db_session, sample_lead):
+    await client.post(
+        f"/api/leads/{sample_lead.id}/github-links",
+        json={"url": "https://github.com/foo/bar/pull/4"},
+    )
+
+    resp = await client.delete(f"/api/leads/{sample_lead.id}")
+    assert resp.status_code == 204
+
+    remaining = (
+        (
+            await db_session.execute(
+                select(GitHubLink).where(
+                    GitHubLink.scope_type == SCOPE_LEAD,
+                    GitHubLink.scope_id == sample_lead.id,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert remaining == []
+
+
+async def test_link_for_other_lead_returns_404(client, db_session, sample_lead):
+    # Maak een link op sample_lead
+    create = await client.post(
+        f"/api/leads/{sample_lead.id}/github-links",
+        json={"url": "https://github.com/foo/bar/pull/7"},
+    )
+    link_id = create.json()["id"]
+
+    # Maak een tweede lead, probeer de link via die lead te benaderen
+    other = Lead(id=uuid.uuid4(), title="Andere lead", stage="inbox")
+    db_session.add(other)
+    await db_session.flush()
+
+    resp = await client.delete(f"/api/leads/{other.id}/github-links/{link_id}")
+    assert resp.status_code == 404
+
+    patch = await client.patch(
+        f"/api/leads/{other.id}/github-links/{link_id}",
+        json={"title": "x"},
+    )
+    assert patch.status_code == 404

--- a/frontend/src/api/leads.ts
+++ b/frontend/src/api/leads.ts
@@ -1,4 +1,4 @@
-import { apiGet, apiPost, apiPut, apiDelete, getCsrfToken, BASE_URL } from './client';
+import { apiGet, apiPost, apiPut, apiPatch, apiDelete, getCsrfToken, BASE_URL } from './client';
 import type {
   Lead,
   LeadDetail,
@@ -9,6 +9,7 @@ import type {
   LeadMetrics,
   LeadFilters,
   LeadAttachment,
+  LeadGitHubLink,
   LeadParseResult,
   CommunityGraphResponse,
   LeadTimelineResponse,
@@ -194,4 +195,31 @@ export async function parseLeadIntake(rawText?: string, files?: File[]): Promise
     throw new Error(`Parse failed: ${response.status} ${text}`);
   }
   return response.json();
+}
+
+export async function listLeadGitHubLinks(leadId: string): Promise<LeadGitHubLink[]> {
+  return apiGet<LeadGitHubLink[]>(`/api/leads/${leadId}/github-links`);
+}
+
+export async function addLeadGitHubLink(
+  leadId: string,
+  url: string,
+  title?: string | null,
+): Promise<LeadGitHubLink> {
+  return apiPost<LeadGitHubLink>(`/api/leads/${leadId}/github-links`, { url, title });
+}
+
+export async function updateLeadGitHubLink(
+  leadId: string,
+  linkId: string,
+  title: string | null,
+): Promise<LeadGitHubLink> {
+  return apiPatch<LeadGitHubLink>(
+    `/api/leads/${leadId}/github-links/${linkId}`,
+    { title },
+  );
+}
+
+export async function deleteLeadGitHubLink(leadId: string, linkId: string): Promise<void> {
+  return apiDelete(`/api/leads/${leadId}/github-links/${linkId}`);
 }

--- a/frontend/src/components/leads/LeadDetailPanel.tsx
+++ b/frontend/src/components/leads/LeadDetailPanel.tsx
@@ -26,6 +26,7 @@ import { RichTextEditor } from '@/components/common/RichTextEditor';
 import { RichTextDisplay } from '@/components/common/RichTextDisplay';
 import { LinkLeadNodeModal } from './LinkLeadNodeModal';
 import { AddLeadContactModal } from './AddLeadContactModal';
+import { LeadGitHubLinks } from './LeadGitHubLinks';
 import { MattermostChannelsSection } from '@/components/mattermost/MattermostChannelsSection';
 import { Badge } from '@/components/common/Badge';
 import { DetailSection } from '@/components/common/DetailSection';
@@ -905,6 +906,8 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
               <p className="text-sm text-text-secondary">Geen bijlagen</p>
             )}
           </DetailSection>
+
+          <LeadGitHubLinks leadId={lead.id} links={lead.github_links ?? []} />
 
           {/* Externe contactpersonen */}
           <DetailSection

--- a/frontend/src/components/leads/LeadGitHubLinks.tsx
+++ b/frontend/src/components/leads/LeadGitHubLinks.tsx
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react';
 import { Button } from '@/components/common/Button';
 import { DetailSection } from '@/components/common/DetailSection';
+import { ApiError } from '@/api/client';
 import {
   useAddLeadGitHubLink,
   useUpdateLeadGitHubLink,
@@ -86,10 +87,15 @@ export function LeadGitHubLinks({ leadId, links }: Props) {
       setTitle('');
       setShowForm(false);
     } catch (e) {
-      const msg = e instanceof Error ? e.message : 'Kon link niet toevoegen.';
-      if (msg.includes('422')) setError('Geen geldige GitHub-URL.');
-      else if (msg.includes('409')) setError('Deze link is al gekoppeld.');
-      else setError(msg);
+      if (e instanceof ApiError && e.status === 422) {
+        setError('Geen geldige GitHub-URL.');
+      } else if (e instanceof ApiError && e.status === 409) {
+        setError('Deze link is al gekoppeld.');
+      } else if (e instanceof Error) {
+        setError(e.message);
+      } else {
+        setError('Kon link niet toevoegen.');
+      }
     }
   };
 

--- a/frontend/src/components/leads/LeadGitHubLinks.tsx
+++ b/frontend/src/components/leads/LeadGitHubLinks.tsx
@@ -1,0 +1,253 @@
+import { useState } from 'react';
+import {
+  GitBranch,
+  GitPullRequest,
+  CircleDot,
+  Github,
+  Play,
+  ExternalLink,
+  Pencil,
+  Trash2,
+  Check,
+  X,
+  Plus,
+} from 'lucide-react';
+import { Button } from '@/components/common/Button';
+import { DetailSection } from '@/components/common/DetailSection';
+import {
+  useAddLeadGitHubLink,
+  useUpdateLeadGitHubLink,
+  useDeleteLeadGitHubLink,
+} from '@/hooks/useLeads';
+import type { LeadGitHubLink, GitHubLinkType } from '@/types';
+
+interface Props {
+  leadId: string;
+  links: LeadGitHubLink[];
+}
+
+const TYPE_ICONS: Record<GitHubLinkType, React.ReactNode> = {
+  branch: <GitBranch className="h-3.5 w-3.5 text-text-secondary shrink-0" />,
+  pull_request: <GitPullRequest className="h-3.5 w-3.5 text-text-secondary shrink-0" />,
+  issue: <CircleDot className="h-3.5 w-3.5 text-text-secondary shrink-0" />,
+  repo: <Github className="h-3.5 w-3.5 text-text-secondary shrink-0" />,
+  workflow_run: <Play className="h-3.5 w-3.5 text-text-secondary shrink-0" />,
+  other: <ExternalLink className="h-3.5 w-3.5 text-text-secondary shrink-0" />,
+};
+
+const TYPE_LABELS: Record<GitHubLinkType, string> = {
+  branch: 'branch',
+  pull_request: 'PR',
+  issue: 'issue',
+  repo: 'repo',
+  workflow_run: 'run',
+  other: 'link',
+};
+
+function shortRef(link: LeadGitHubLink): string {
+  if (link.link_type === 'pull_request' || link.link_type === 'issue') {
+    return `#${link.ref ?? '?'}`;
+  }
+  if (link.link_type === 'workflow_run') {
+    return `run ${link.ref ?? '?'}`;
+  }
+  if (link.link_type === 'branch') {
+    return link.ref ?? '?';
+  }
+  return '';
+}
+
+export function LeadGitHubLinks({ leadId, links }: Props) {
+  const [showForm, setShowForm] = useState(false);
+  const [url, setUrl] = useState('');
+  const [title, setTitle] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingTitle, setEditingTitle] = useState('');
+
+  const addLink = useAddLeadGitHubLink();
+  const updateLink = useUpdateLeadGitHubLink();
+  const deleteLink = useDeleteLeadGitHubLink();
+
+  const submit = async () => {
+    setError(null);
+    const trimmed = url.trim();
+    if (!trimmed) {
+      setError('Plak een GitHub-URL.');
+      return;
+    }
+    try {
+      await addLink.mutateAsync({
+        leadId,
+        url: trimmed,
+        title: title.trim() || null,
+      });
+      setUrl('');
+      setTitle('');
+      setShowForm(false);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Kon link niet toevoegen.';
+      if (msg.includes('422')) setError('Geen geldige GitHub-URL.');
+      else if (msg.includes('409')) setError('Deze link is al gekoppeld.');
+      else setError(msg);
+    }
+  };
+
+  const startEdit = (link: LeadGitHubLink) => {
+    setEditingId(link.id);
+    setEditingTitle(link.title ?? '');
+  };
+
+  const saveEdit = async (link: LeadGitHubLink) => {
+    await updateLink.mutateAsync({
+      leadId,
+      linkId: link.id,
+      title: editingTitle.trim() || null,
+    });
+    setEditingId(null);
+  };
+
+  return (
+    <DetailSection
+      title="GitHub-werk"
+      icon={<Github className="h-3.5 w-3.5" />}
+      count={links.length}
+      separated
+      action={
+        <Button
+          variant="ghost"
+          size="sm"
+          icon={<Plus className="h-3.5 w-3.5" />}
+          onClick={() => setShowForm((v) => !v)}
+        >
+          Link toevoegen
+        </Button>
+      }
+    >
+      {showForm && (
+        <div className="mb-3 space-y-2 rounded-lg border border-border bg-gray-50 p-3">
+          <input
+            type="url"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="https://github.com/owner/repo/pull/123"
+            className="w-full rounded-md border border-border px-2 py-1.5 text-sm focus:border-primary-500 focus:outline-none"
+            autoFocus
+          />
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Titel (optioneel)"
+            className="w-full rounded-md border border-border px-2 py-1.5 text-sm focus:border-primary-500 focus:outline-none"
+          />
+          {error && <p className="text-xs text-red-500">{error}</p>}
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                setShowForm(false);
+                setUrl('');
+                setTitle('');
+                setError(null);
+              }}
+            >
+              Annuleren
+            </Button>
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={submit}
+              disabled={addLink.isPending}
+            >
+              Toevoegen
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {links.length > 0 ? (
+        <div className="space-y-1">
+          {links.map((link) => {
+            const ref = shortRef(link);
+            const display =
+              link.title ??
+              (ref ? `${link.owner}/${link.repo} ${ref}` : `${link.owner}/${link.repo}`);
+            return (
+              <div
+                key={link.id}
+                className="flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm hover:bg-gray-50"
+              >
+                {TYPE_ICONS[link.link_type]}
+                {editingId === link.id ? (
+                  <>
+                    <input
+                      type="text"
+                      value={editingTitle}
+                      onChange={(e) => setEditingTitle(e.target.value)}
+                      className="flex-1 rounded-md border border-border px-1.5 py-0.5 text-sm"
+                      autoFocus
+                    />
+                    <button
+                      onClick={() => saveEdit(link)}
+                      className="p-1 text-text-secondary hover:text-green-600"
+                      title="Opslaan"
+                    >
+                      <Check className="h-3.5 w-3.5" />
+                    </button>
+                    <button
+                      onClick={() => setEditingId(null)}
+                      className="p-1 text-text-secondary hover:text-red-500"
+                      title="Annuleren"
+                    >
+                      <X className="h-3.5 w-3.5" />
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    <a
+                      href={link.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="flex-1 truncate text-primary-700 hover:underline"
+                      title={link.url}
+                    >
+                      {display}
+                    </a>
+                    <span className="text-[10px] uppercase tracking-wider text-text-secondary px-1.5 py-0.5 rounded bg-gray-100">
+                      {TYPE_LABELS[link.link_type]}
+                    </span>
+                    <button
+                      onClick={() => startEdit(link)}
+                      className="p-1 text-text-secondary hover:text-primary-600"
+                      title="Titel bewerken"
+                    >
+                      <Pencil className="h-3.5 w-3.5" />
+                    </button>
+                    <button
+                      onClick={() =>
+                        deleteLink.mutate({ leadId, linkId: link.id })
+                      }
+                      className="p-1 text-text-secondary hover:text-red-500"
+                      title="Verwijderen"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        !showForm && (
+          <p className="text-sm text-text-secondary">
+            Nog geen GitHub-werk gekoppeld. Plak een URL van een branch, PR of
+            issue.
+          </p>
+        )
+      )}
+    </DetailSection>
+  );
+}

--- a/frontend/src/hooks/queryKeys.ts
+++ b/frontend/src/hooks/queryKeys.ts
@@ -204,6 +204,7 @@ export const queryKeys = {
     list: (filters?: LeadFilters) => ['leads', 'list', filters] as const,
     detail: (id: string | null) => ['leads', 'detail', id] as const,
     activities: (leadId: string | null) => ['leads', 'detail', leadId, 'activities'] as const,
+    githubLinks: (leadId: string | null) => ['leads', 'detail', leadId, 'github-links'] as const,
     metrics: () => ['leads', 'metrics'] as const,
   },
 

--- a/frontend/src/hooks/useLeads.ts
+++ b/frontend/src/hooks/useLeads.ts
@@ -18,6 +18,9 @@ import {
   getLeadMetrics,
   uploadLeadAttachment,
   deleteLeadAttachment,
+  addLeadGitHubLink,
+  updateLeadGitHubLink,
+  deleteLeadGitHubLink,
   parseLeadIntake,
   getCommunityGraph,
   getLeadTimeline,
@@ -263,6 +266,52 @@ export function useDeleteLeadAttachment() {
       attachmentId: string;
     }) => deleteLeadAttachment(leadId, attachmentId),
     errorMessage: 'Fout bij verwijderen bijlage',
+    invalidateKeys: [queryKeys.leads.all],
+  });
+}
+
+export function useAddLeadGitHubLink() {
+  return useMutationWithError({
+    mutationFn: ({
+      leadId,
+      url,
+      title,
+    }: {
+      leadId: string;
+      url: string;
+      title?: string | null;
+    }) => addLeadGitHubLink(leadId, url, title),
+    errorMessage: 'Fout bij toevoegen GitHub-link',
+    invalidateKeys: [queryKeys.leads.all],
+  });
+}
+
+export function useUpdateLeadGitHubLink() {
+  return useMutationWithError({
+    mutationFn: ({
+      leadId,
+      linkId,
+      title,
+    }: {
+      leadId: string;
+      linkId: string;
+      title: string | null;
+    }) => updateLeadGitHubLink(leadId, linkId, title),
+    errorMessage: 'Fout bij bewerken GitHub-link',
+    invalidateKeys: [queryKeys.leads.all],
+  });
+}
+
+export function useDeleteLeadGitHubLink() {
+  return useMutationWithError({
+    mutationFn: ({
+      leadId,
+      linkId,
+    }: {
+      leadId: string;
+      linkId: string;
+    }) => deleteLeadGitHubLink(leadId, linkId),
+    errorMessage: 'Fout bij verwijderen GitHub-link',
     invalidateKeys: [queryKeys.leads.all],
   });
 }

--- a/frontend/src/hooks/useLeads.ts
+++ b/frontend/src/hooks/useLeads.ts
@@ -271,7 +271,10 @@ export function useDeleteLeadAttachment() {
 }
 
 export function useAddLeadGitHubLink() {
-  return useMutationWithError({
+  // Geen useMutationWithError: de form toont een inline error voor 422/409
+  // bij ongeldige of dubbele URL. Een toast er bovenop zou dubbel zijn.
+  const queryClient = useQueryClient();
+  return useMutation({
     mutationFn: ({
       leadId,
       url,
@@ -281,8 +284,9 @@ export function useAddLeadGitHubLink() {
       url: string;
       title?: string | null;
     }) => addLeadGitHubLink(leadId, url, title),
-    errorMessage: 'Fout bij toevoegen GitHub-link',
-    invalidateKeys: [queryKeys.leads.all],
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.leads.all });
+    },
   });
 }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1754,11 +1754,31 @@ export interface Lead {
   updated_at: string | null;
 }
 
+export type GitHubLinkType =
+  | "branch"
+  | "pull_request"
+  | "issue"
+  | "repo"
+  | "workflow_run"
+  | "other";
+
+export interface LeadGitHubLink {
+  id: string;
+  url: string;
+  link_type: GitHubLinkType;
+  owner: string;
+  repo: string;
+  ref: string | null;
+  title: string | null;
+  created_at: string;
+}
+
 export interface LeadDetail extends Lead {
   activities: LeadActivity[];
   attachments: LeadAttachment[];
   contacts: LeadContact[];
   linked_nodes: LeadNode[];
+  github_links: LeadGitHubLink[];
 }
 
 export interface LeadCreate {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1764,12 +1764,15 @@ export type GitHubLinkType =
 
 export interface LeadGitHubLink {
   id: string;
+  scope_type: string;
+  scope_id: string;
   url: string;
   link_type: GitHubLinkType;
   owner: string;
   repo: string;
   ref: string | null;
   title: string | null;
+  created_by_id: string | null;
   created_at: string;
 }
 


### PR DESCRIPTION
## Wat

Op een lead kun je nu GitHub-URLs plakken (branch, PR, issue, repo, workflow-run). Ze verschijnen als gestructureerde, klikbare links met een type-icoon en optionele eigen titel.

Eerste stap richting "werk aan een lead tracken in GitHub" — fundering voor latere fasen (live status, triggers, webhooks).

## Architectuurkeuzes

- **Polymorf model `github_link`** (`scope_type` ∈ `lead|initiatief`, `scope_id` zonder DB-FK). Volgt `MattermostChannelLink`-patroon. Maakt het in fase 2 een one-liner om links ook op initiatief-niveau te tonen.
- **Niet hergebruik van `LeadAttachment`** ondanks dat die nu `soort='link'` ondersteunt: GitHub-resources hebben een eigen lifecycle (status-fetch, triggers, webhooks komen later) en eigen indexen (`owner`, `repo`) die je in fase 4 nodig hebt.
- **Strikte URL-parser** in `core/github_url.py`: alleen `github.com`-host, expliciete vormen voor de vijf bekende types, andere paden worden `other`. Gevolgd door 422 op niet-GitHub-URLs.

## Backend

- `github_link` tabel + Alembic-migratie (`f1a2b3c4d5e6`)
- Polymorfe scope, unique `(scope_type, scope_id, url)`, index `(owner, repo)` voor latere reverse-lookup
- 4 routes onder `/api/leads/{id}/github-links` (GET/POST/PATCH/DELETE)
- `delete_lead` ruimt github-links op (geen FK-cascade door polymorfie, zelfde aanpak als bestaande `resource_permission` cleanup)
- `LeadDetailResponse.github_links` voor de detail-handler

## Frontend

- `LeadGitHubLinks` component in `LeadDetailPanel`, vlak onder Bijlagen
- Form: URL + optionele titel; 422/409 vertaald naar nette meldingen
- Lijst met type-icoon (`GitBranch`, `GitPullRequest`, `CircleDot`, `Github`, `Play`), inline titel-edit, delete-knop
- React Query mutations met invalidate op `queryKeys.leads.all`

## Tests

- 21 parser-tests (alle linktypes, branches met slashes, query/anchor, niet-GitHub-host, malformed)
- 10 endpoint-tests (happy paths, 422 invalid, 409 duplicate, detail-include, patch-title, delete + cascade-bij-lead-delete, cross-lead 404)
- Inventory-test (route-authz) groen
- `npx tsc --noEmit` en `eslint` schoon
- Frontend build groen

## Out of scope (volgende fasen)

- Live status-fetch via GitHub API (groene/rode iconen op merged PRs)
- Workflow-triggers vanuit Bouwmeester (knop "harvester aftrappen")
- Webhook-handler voor auto-koppeling via branchnaam-conventie of stage-overgang
- Initiatief-scope (model is polymorf, route is een one-liner extra)

## Test plan

- [ ] `just reset-db && just up`
- [ ] Open een lead in stage `interne_check` of verder
- [ ] Sectie "GitHub-werk" zichtbaar onder Bijlagen
- [ ] Plak `https://github.com/foo/bar/pull/1` — verschijnt met PR-icoon, badge "PR"
- [ ] Plak `https://github.com/foo/bar/tree/main` — branch-icoon, badge "branch"
- [ ] Plak `https://gitlab.com/foo/bar` — foutmelding "Geen geldige GitHub-URL"
- [ ] Plak dezelfde URL twee keer — foutmelding "Deze link is al gekoppeld"
- [ ] Edit titel inline, opslaan
- [ ] Verwijder een link
- [ ] Verwijder de hele lead — links zijn weg