### PR TITLE
Ontbrekende DB-indices op recente tabellen en kolommen

### DIFF
--- a/backend/bouwmeester/migrations/versions/1fe90cecedd9_add_missing_indexes_recent_tables.py
+++ b/backend/bouwmeester/migrations/versions/1fe90cecedd9_add_missing_indexes_recent_tables.py
@@ -54,8 +54,21 @@ _INDEXES: list[tuple[str, str, list[str]]] = [
 def upgrade() -> None:
     for name, table, columns in _INDEXES:
         op.create_index(name, table, columns, if_not_exists=True)
+    # Drop redundant single-column index now that the composite
+    # (scope_type, scope_id) handles every scope_id lookup we make.
+    op.drop_index(
+        "ix_stakeholder_assessment_scope_id",
+        table_name="stakeholder_assessment",
+        if_exists=True,
+    )
 
 
 def downgrade() -> None:
+    op.create_index(
+        "ix_stakeholder_assessment_scope_id",
+        "stakeholder_assessment",
+        ["scope_id"],
+        if_not_exists=True,
+    )
     for name, table, _columns in reversed(_INDEXES):
         op.drop_index(name, table_name=table, if_exists=True)

--- a/backend/bouwmeester/migrations/versions/1fe90cecedd9_add_missing_indexes_recent_tables.py
+++ b/backend/bouwmeester/migrations/versions/1fe90cecedd9_add_missing_indexes_recent_tables.py
@@ -1,0 +1,61 @@
+"""add missing indexes recent tables
+
+Revision ID: 1fe90cecedd9
+Revises: 2c4d6e8f9a01
+Create Date: 2026-05-06 12:00:00.000000
+
+Sluit de FK- en hot-filter-index gaten die door recente migraties zijn
+ontstaan (stakeholder_assessment, initiatief_update, samenwerkingsverband,
+notification.related_lead_id, lead.engagement_type). Idempotent via
+``if_not_exists=True`` in dezelfde stijl als 025becdecf77.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "1fe90cecedd9"
+down_revision: str | None = "2c4d6e8f9a01"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_INDEXES: list[tuple[str, str, list[str]]] = [
+    # FK columns added in recent migrations that skipped the FK index.
+    ("ix_notification_related_lead_id", "notification", ["related_lead_id"]),
+    (
+        "ix_stakeholder_assessment_assessed_by_id",
+        "stakeholder_assessment",
+        ["assessed_by_id"],
+    ),
+    (
+        "ix_initiatief_update_published_by_id",
+        "initiatief_update",
+        ["published_by_id"],
+    ),
+    ("ix_initiatief_created_by_id", "initiatief", ["created_by_id"]),
+    (
+        "ix_samenwerkingsverband_created_by_id",
+        "samenwerkingsverband",
+        ["created_by_id"],
+    ),
+    # Hot filter columns.
+    ("ix_samenwerkingsverband_type", "samenwerkingsverband", ["type"]),
+    ("ix_lead_engagement_type", "lead", ["engagement_type"]),
+    # Composite for stakeholder_assessment.list_for_scope (scope_type+scope_id).
+    (
+        "ix_stakeholder_assessment_scope",
+        "stakeholder_assessment",
+        ["scope_type", "scope_id"],
+    ),
+]
+
+
+def upgrade() -> None:
+    for name, table, columns in _INDEXES:
+        op.create_index(name, table, columns, if_not_exists=True)
+
+
+def downgrade() -> None:
+    for name, table, _columns in reversed(_INDEXES):
+        op.drop_index(name, table_name=table, if_exists=True)

--- a/backend/bouwmeester/migrations/versions/1fe90cecedd9_add_missing_indexes_recent_tables.py
+++ b/backend/bouwmeester/migrations/versions/1fe90cecedd9_add_missing_indexes_recent_tables.py
@@ -1,7 +1,7 @@
 """add missing indexes recent tables
 
 Revision ID: 1fe90cecedd9
-Revises: 2c4d6e8f9a01
+Revises: f1a2b3c4d5e6
 Create Date: 2026-05-06 12:00:00.000000
 
 Sluit de FK- en hot-filter-index gaten die door recente migraties zijn
@@ -16,7 +16,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "1fe90cecedd9"
-down_revision: str | None = "2c4d6e8f9a01"
+down_revision: str | None = "f1a2b3c4d5e6"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
@@ -39,6 +39,7 @@ _INDEXES: list[tuple[str, str, list[str]]] = [
         "samenwerkingsverband",
         ["created_by_id"],
     ),
+    ("ix_github_link_created_by_id", "github_link", ["created_by_id"]),
     # Hot filter columns.
     ("ix_samenwerkingsverband_type", "samenwerkingsverband", ["type"]),
     ("ix_lead_engagement_type", "lead", ["engagement_type"]),

--- a/backend/bouwmeester/models/github_link.py
+++ b/backend/bouwmeester/models/github_link.py
@@ -63,6 +63,7 @@ class GitHubLink(Base):
         UUID(as_uuid=True),
         ForeignKey("person.id", ondelete="SET NULL"),
         nullable=True,
+        index=True,
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()

--- a/backend/bouwmeester/models/initiatief.py
+++ b/backend/bouwmeester/models/initiatief.py
@@ -39,6 +39,7 @@ class Initiatief(Base):
         UUID(as_uuid=True),
         ForeignKey("person.id", ondelete="SET NULL"),
         nullable=True,
+        index=True,
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()

--- a/backend/bouwmeester/models/initiatief_update.py
+++ b/backend/bouwmeester/models/initiatief_update.py
@@ -44,6 +44,7 @@ class InitiatiefUpdatePost(Base):
         UUID(as_uuid=True),
         ForeignKey("person.id", ondelete="SET NULL"),
         nullable=True,
+        index=True,
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()

--- a/backend/bouwmeester/models/lead.py
+++ b/backend/bouwmeester/models/lead.py
@@ -59,6 +59,7 @@ class Lead(Base):
     raw_intake_text: Mapped[str | None] = mapped_column(Text, nullable=True)
     engagement_type: Mapped[str | None] = mapped_column(
         nullable=True,
+        index=True,
         comment=(
             "intern_oppakken|voorbereiden_eigen_team|betrokken_houden|"
             "verkenning|nog_te_bepalen"

--- a/backend/bouwmeester/models/notification.py
+++ b/backend/bouwmeester/models/notification.py
@@ -51,6 +51,7 @@ class Notification(Base):
         UUID(as_uuid=True),
         ForeignKey("lead.id", ondelete="SET NULL"),
         nullable=True,
+        index=True,
     )
     sender_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),

--- a/backend/bouwmeester/models/samenwerkingsverband.py
+++ b/backend/bouwmeester/models/samenwerkingsverband.py
@@ -30,6 +30,7 @@ class Samenwerkingsverband(Base):
     naam: Mapped[str] = mapped_column(nullable=False)
     type: Mapped[str] = mapped_column(
         nullable=False,
+        index=True,
         comment=(
             "programma|werkgroep|opschalingsticket|ketenproject|stuurgroep|"
             "taskforce|innovatiebudget|community_of_practice|pilot|convenant"
@@ -42,6 +43,7 @@ class Samenwerkingsverband(Base):
         UUID(as_uuid=True),
         ForeignKey("person.id", ondelete="SET NULL"),
         nullable=True,
+        index=True,
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()

--- a/backend/bouwmeester/models/stakeholder_assessment.py
+++ b/backend/bouwmeester/models/stakeholder_assessment.py
@@ -55,7 +55,6 @@ class StakeholderAssessment(Base):
     scope_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         nullable=False,
-        index=True,
     )
     belang: Mapped[int | None] = mapped_column(nullable=True)
     houding: Mapped[str | None] = mapped_column(

--- a/backend/bouwmeester/models/stakeholder_assessment.py
+++ b/backend/bouwmeester/models/stakeholder_assessment.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING, Optional
 
-from sqlalchemy import DateTime, ForeignKey, Text, UniqueConstraint, func, text
+from sqlalchemy import DateTime, ForeignKey, Index, Text, UniqueConstraint, func, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -29,6 +29,11 @@ class StakeholderAssessment(Base):
             "scope_type",
             "scope_id",
             name="uq_stakeholder_assessment_person_scope",
+        ),
+        Index(
+            "ix_stakeholder_assessment_scope",
+            "scope_type",
+            "scope_id",
         ),
     )
 
@@ -63,6 +68,7 @@ class StakeholderAssessment(Base):
         UUID(as_uuid=True),
         ForeignKey("person.id", ondelete="SET NULL"),
         nullable=True,
+        index=True,
     )
     assessed_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True

--- a/backend/tests/test_fk_index_inventory.py
+++ b/backend/tests/test_fk_index_inventory.py
@@ -1,0 +1,134 @@
+"""Regression guard: every foreign-key column should have an index.
+
+PostgreSQL does not auto-index FKs.  Without an index, any DELETE on the
+referenced table forces a sequential scan of the referring table to
+honour the ON DELETE rule, and any join that filters on the FK column is
+similarly slow.  The fix is cheap (one B-tree per FK) but easy to
+forget on new migrations — this test fails the build when an FK column
+slips through without a matching index.
+
+The check runs against the live database (so raw-SQL ``op.execute`` index
+migrations are captured) and asks: for every FK column, is there an
+index whose first column is that FK column?  PK columns and unique
+constraints satisfy the requirement implicitly because Postgres backs
+both with a B-tree.
+
+If a FK genuinely doesn't need an index, add it to ``_FK_WHITELIST``
+with a justification.
+"""
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# (table, column) pairs where skipping the FK index is intentional.
+# Each entry must include a comment with the reason.
+#
+# Most entries below are "known debt" rather than principled exclusions:
+# they're FKs that aren't on a hot query path today (write-only audit
+# trails, manager/decider attribution columns, etc.) but should still
+# get an index before the referencing tables grow.  Address in a
+# follow-up housekeeping PR — empty this list when done.
+_FK_WHITELIST: dict[tuple[str, str], str] = {
+    # Audit / attribution columns — only read for display, not for filtering.
+    ("org_placement_request", "decided_by"): "audit-only column",
+    ("person_role", "granted_by_id"): "audit-only column",
+    ("shared_access", "shared_by_id"): "audit-only column",
+    ("suggested_lead", "reviewed_by_id"): "audit-only column",
+    ("mattermost_channel_link", "created_by_id"): "audit-only column",
+    # Outcome / link-back columns from suggested_lead — only read after a
+    # lead has been approved/matched, never as a filter predicate.
+    ("suggested_lead", "approved_lead_id"): "outcome link, read by id only",
+    ("suggested_lead", "match_existing_lead_id"): "outcome link, read by id only",
+    # Mattermost-post-link columns — small table, joined by post_id (PK)
+    # rather than by these FKs.
+    ("mattermost_post_link", "lead_activity_id"): "joined via post_id (PK)",
+    ("mattermost_post_link", "person_id"): "joined via post_id (PK)",
+    ("mattermost_post_link", "suggested_lead_id"): "joined via post_id (PK)",
+    # Static reference data, ~30 rows — seq-scan is faster than index.
+    ("role_permission", "permission_id"): "small static reference table",
+}
+
+
+_FK_INVENTORY_QUERY = text("""
+    SELECT
+        c.conrelid::regclass::text AS table_name,
+        a.attname AS column_name,
+        EXISTS (
+            SELECT 1
+            FROM pg_index i
+            JOIN pg_attribute ia
+              ON ia.attrelid = i.indrelid
+             AND ia.attnum = i.indkey[0]
+            WHERE i.indrelid = c.conrelid
+              AND ia.attname = a.attname
+        ) AS has_leading_index
+    FROM pg_constraint c
+    JOIN pg_attribute a
+      ON a.attrelid = c.conrelid
+     AND a.attnum = ANY(c.conkey)
+    WHERE c.contype = 'f'
+      AND array_length(c.conkey, 1) = 1
+      AND c.connamespace = 'public'::regnamespace
+    ORDER BY table_name, column_name
+""")
+
+
+@pytest.mark.asyncio
+async def test_every_fk_has_an_index(db_session: AsyncSession):
+    """Fail if any FK column lacks a leading-column index.
+
+    Indexes whose leading column matches the FK satisfy the requirement.
+    PK columns and unique constraints implicitly count because Postgres
+    backs both with a B-tree.
+    """
+    result = await db_session.execute(_FK_INVENTORY_QUERY)
+    offenders: list[str] = []
+
+    for table_name, column_name, has_leading_index in result.all():
+        if (table_name, column_name) in _FK_WHITELIST:
+            continue
+        if not has_leading_index:
+            offenders.append(f"{table_name}.{column_name}")
+
+    assert not offenders, (
+        "These foreign-key columns are not indexed.  Add ``index=True`` "
+        "on the column (or an explicit ``Index(...)`` in ``__table_args__``) "
+        "and create a migration with ``op.create_index(..., if_not_exists=True)``.\n"
+        "If the index is genuinely unnecessary, whitelist in _FK_WHITELIST with "
+        "a justification.\n\n"
+        "Missing FK indexes:\n" + "\n".join(f"  - {col}" for col in offenders)
+    )
+
+
+@pytest.mark.asyncio
+async def test_whitelist_entries_still_apply(db_session: AsyncSession):
+    """Fail if a whitelist entry has been fixed or no longer exists.
+
+    Forces cleanup when the underlying schema changes, so the whitelist
+    can't accumulate stale exemptions.
+    """
+    if not _FK_WHITELIST:
+        return
+
+    result = await db_session.execute(_FK_INVENTORY_QUERY)
+    rows = {(t, c): has_idx for t, c, has_idx in result.all()}
+
+    obsolete: list[str] = []
+    fixed: list[str] = []
+
+    for key in _FK_WHITELIST:
+        if key not in rows:
+            obsolete.append(f"{key[0]}.{key[1]} — FK no longer exists")
+            continue
+        if rows[key]:
+            fixed.append(f"{key[0]}.{key[1]}")
+
+    assert not obsolete, (
+        "Whitelist entries reference removed FKs. Clean up _FK_WHITELIST:\n"
+        + "\n".join(f"  - {e}" for e in obsolete)
+    )
+    assert not fixed, (
+        "These whitelist entries are now indexed — remove them from "
+        "_FK_WHITELIST:\n" + "\n".join(f"  - {e}" for e in fixed)
+    )


### PR DESCRIPTION
## Summary
- Voegt 8 ontbrekende indices toe op recent toegevoegde FKs en hot filter-kolommen (stakeholder_assessment, initiatief_update, samenwerkingsverband, notification.related_lead_id, lead.engagement_type, initiatief.created_by_id).
- Eén nieuwe Alembic-migratie `1fe90cecedd9`, idempotent via `if_not_exists=True`, zelfde stijl als `025becdecf77`.
- Modellen krijgen `index=True` zodat `alembic revision --autogenerate` geen drift meer detecteert op deze kolommen.
- **Follow-up commit** dropt redundante single-column index `ix_stakeholder_assessment_scope_id` (overschaduwd door de nieuwe composite) en voegt regressietest `test_fk_index_inventory.py` toe die elke FK-kolom controleert op een leading-column index.

## Achtergrond
PostgreSQL indexeert FKs niet automatisch. Recente migraties (zoals `a5c6d7e8f024`, `b6d7e8f90135`, `e4f5a6b7c8d9`, `c1d4e7a3b9f2`, `e3a4b5c6d802`) lieten optionele FKs en filter-kolommen zonder index achter. Zonder deze indices krijg je seq-scans op queries als `StakeholderAssessmentRepository.list_for_scope` en op person-delete CASCADE-checks (`SET NULL` op assessed_by_id, published_by_id, created_by_id).

## Indices in deze migratie

| Index | Tabel | Reden |
|---|---|---|
| `ix_notification_related_lead_id` | notification | FK naar lead, geen index |
| `ix_stakeholder_assessment_assessed_by_id` | stakeholder_assessment | FK naar person (SET NULL) |
| `ix_stakeholder_assessment_scope` | stakeholder_assessment | composite (scope_type, scope_id) — `list_for_scope` filtert altijd op beide |
| `ix_initiatief_update_published_by_id` | initiatief_update | FK naar person (SET NULL) |
| `ix_initiatief_created_by_id` | initiatief | FK naar person (SET NULL) |
| `ix_samenwerkingsverband_created_by_id` | samenwerkingsverband | FK naar person (SET NULL) |
| `ix_samenwerkingsverband_type` | samenwerkingsverband | hot filter in `get_all` |
| `ix_lead_engagement_type` | lead | nieuw funnel-veld, gefilterd in funnel-views |

Plus drop van `ix_stakeholder_assessment_scope_id` (single column) — vervangen door de composite hierboven.

## Regressietest
`backend/tests/test_fk_index_inventory.py` queryt `pg_indexes` en faalt als een FK-kolom in `public.*` geen leading-column index heeft. PK's en unique constraints tellen impliciet (Postgres backt beide met een B-tree). Whitelist `_FK_WHITELIST` bevat 11 bestaande FKs die niet op een hot query path zitten (audit/attribution columns, kleine reference-tabellen) — bewust niet in scope van deze PR; aparte housekeeping PR ruimt die op.

## Test plan
- [x] `alembic upgrade head` voegt alle 8 indices toe in `pg_indexes` en dropt de redundante single
- [x] `alembic downgrade -1 && upgrade head` round-trip schoon
- [x] `alembic revision --autogenerate` detecteert geen drift op deze kolommen
- [x] `pytest backend/tests/` — 922 passed (3 pre-existing LLM-config failures buiten scope)
- [x] CI groen op de eerste commit
- [ ] CI groen op de follow-up commit