### PR TITLE
Leads-netwerk: betere verticale hierarchie via swim-lanes

### DIFF
--- a/frontend/src/components/leads/LeadGraphView.tsx
+++ b/frontend/src/components/leads/LeadGraphView.tsx
@@ -74,7 +74,14 @@ const RANK_PERSON_INTERN = 4;
 const RANK_PERSON_EXTERN = 5;
 const RANK_DEFAULT = RANK_LEAD;
 
-const LANE_Y = [40, 240, 440, 640, 840, 1040];
+const LANE_Y: Record<number, number> = {
+  [RANK_ORGANISATION]: 40,
+  [RANK_CORPUS_NODE]: 240,
+  [RANK_LEAD]: 440,
+  [RANK_SAMENWERKINGSVERBAND]: 640,
+  [RANK_PERSON_INTERN]: 840,
+  [RANK_PERSON_EXTERN]: 1040,
+};
 
 function getNodeRank(node: CommunityGraphNode): number {
   if (node.node_type === 'person') {
@@ -323,23 +330,29 @@ const CommunityGraphNodeMemo = memo(CommunityGraphNodeComponent);
 const nodeTypes = { communityNode: CommunityGraphNodeMemo };
 
 // ---- Dagre layout ----
+interface LayoutResult {
+  positions: Map<string, { x: number; y: number }>;
+  ranks: Map<string, number>;
+}
+
 function computeLayout(
   nodes: CommunityGraphNode[],
   edges: CommunityGraphEdge[],
-): Map<string, { x: number; y: number }> {
+): LayoutResult {
   const positions = new Map<string, { x: number; y: number }>();
-  if (nodes.length === 0) return positions;
+  const nodeRankMap = new Map(nodes.map((n) => [n.id, getNodeRank(n)]));
+  if (nodes.length === 0) return { positions, ranks: nodeRankMap };
 
   const nodeIds = new Set(nodes.map((n) => n.id));
-  const nodeRankMap = new Map(nodes.map((n) => [n.id, getNodeRank(n)]));
 
   const g = new dagre.graphlib.Graph();
   g.setDefaultEdgeLabel(() => ({}));
+  // We overschrijven dagre's y-output met LANE_Y, dus ranksep en edgesep
+  // hebben geen visuele werking meer. nodesep en align bepalen nog wel
+  // x-positie binnen een lane.
   g.setGraph({
     rankdir: 'TB',
     nodesep: 70,
-    ranksep: 120,
-    edgesep: 20,
     marginx: 40,
     marginy: 40,
     align: 'UL',
@@ -365,7 +378,7 @@ function computeLayout(
     }
   }
 
-  return positions;
+  return { positions, ranks: nodeRankMap };
 }
 
 // ---- Filter bar types ----
@@ -446,8 +459,7 @@ function CommunityGraphInner({
   const { allRfNodes, allRfEdges } = useMemo(() => {
     if (!data?.nodes?.length) return { allRfNodes: [], allRfEdges: [] };
 
-    const positions = computeLayout(data.nodes, data.edges);
-    const nodeRankLookup = new Map(data.nodes.map((n) => [n.id, getNodeRank(n)]));
+    const { positions, ranks: nodeRankLookup } = computeLayout(data.nodes, data.edges);
 
     const allRfNodes: RFNode<CommunityGraphNodeData>[] = data.nodes.map((node) => {
       const pos = positions.get(node.id) ?? { x: 0, y: 0 };

--- a/frontend/src/components/leads/LeadGraphView.tsx
+++ b/frontend/src/components/leads/LeadGraphView.tsx
@@ -63,18 +63,18 @@ const ORG_COLOR = '#14B8A6';
 const SWV_COLOR = '#8B5CF6';
 const CORPUS_NODE_FALLBACK = '#6B7280';
 
-// ---- Community node type to rank (dagre) ----
-// Externe personen krijgen een eigen onderste laag, los van de interne (assignee/stakeholder)
-// personen, zodat externen en hun verbindingen visueel gescheiden zijn.
-// Samenwerkingsverbanden bovenaan, naast organisaties — beide zijn "context"
-// rond personen.
+// ---- Community node type to rank (swim-lane y) ----
+// Strikte horizontale swim-lanes per node-type, top-down. Y wordt opgelegd
+// via LANE_Y; dagre regelt alleen nog x-positie en cross-minimization.
 const RANK_ORGANISATION = 0;
-const RANK_SAMENWERKINGSVERBAND = 0;
 const RANK_CORPUS_NODE = 1;
 const RANK_LEAD = 2;
-const RANK_PERSON_INTERN = 3;
-const RANK_PERSON_EXTERN = 4;
+const RANK_SAMENWERKINGSVERBAND = 3;
+const RANK_PERSON_INTERN = 4;
+const RANK_PERSON_EXTERN = 5;
 const RANK_DEFAULT = RANK_LEAD;
+
+const LANE_Y = [40, 240, 440, 640, 840, 1040];
 
 function getNodeRank(node: CommunityGraphNode): number {
   if (node.node_type === 'person') {
@@ -337,11 +337,12 @@ function computeLayout(
   g.setDefaultEdgeLabel(() => ({}));
   g.setGraph({
     rankdir: 'TB',
-    nodesep: 50,
+    nodesep: 70,
     ranksep: 120,
     edgesep: 20,
     marginx: 40,
     marginy: 40,
+    align: 'UL',
   });
 
   for (const node of nodes) {
@@ -350,13 +351,7 @@ function computeLayout(
 
   for (const edge of edges) {
     if (nodeIds.has(edge.source) && nodeIds.has(edge.target)) {
-      const fromRank = nodeRankMap.get(edge.source) ?? RANK_DEFAULT;
-      const toRank = nodeRankMap.get(edge.target) ?? RANK_DEFAULT;
-      if (fromRank <= toRank) {
-        g.setEdge(edge.source, edge.target);
-      } else {
-        g.setEdge(edge.target, edge.source);
-      }
+      g.setEdge(edge.source, edge.target);
     }
   }
 
@@ -365,7 +360,8 @@ function computeLayout(
   for (const node of nodes) {
     const n = g.node(node.id);
     if (n) {
-      positions.set(node.id, { x: n.x - 100, y: n.y - 40 });
+      const rank = nodeRankMap.get(node.id) ?? RANK_DEFAULT;
+      positions.set(node.id, { x: n.x - 100, y: LANE_Y[rank] ?? LANE_Y[RANK_DEFAULT] });
     }
   }
 
@@ -451,6 +447,7 @@ function CommunityGraphInner({
     if (!data?.nodes?.length) return { allRfNodes: [], allRfEdges: [] };
 
     const positions = computeLayout(data.nodes, data.edges);
+    const nodeRankLookup = new Map(data.nodes.map((n) => [n.id, getNodeRank(n)]));
 
     const allRfNodes: RFNode<CommunityGraphNodeData>[] = data.nodes.map((node) => {
       const pos = positions.get(node.id) ?? { x: 0, y: 0 };
@@ -495,13 +492,17 @@ function CommunityGraphInner({
       const toPos = positions.get(edge.target);
       const goesUpward = fromPos && toPos && fromPos.y > toPos.y;
       const marker = { type: MarkerType.ArrowClosed, width: 14, height: 14, color: style.color };
+      const fromRank = nodeRankLookup.get(edge.source) ?? RANK_DEFAULT;
+      const toRank = nodeRankLookup.get(edge.target) ?? RANK_DEFAULT;
+      const isSameLane = fromRank === toRank;
 
       return {
         id: edge.id,
         source: goesUpward ? edge.target : edge.source,
         target: goesUpward ? edge.source : edge.target,
         label: edge.label ?? style.label,
-        type: 'bezier',
+        type: isSameLane ? 'bezier' : 'smoothstep',
+        ...(isSameLane ? {} : { pathOptions: { offset: 20, borderRadius: 10 } }),
         animated: style.animated ?? false,
         ...(goesUpward ? { markerStart: marker } : { markerEnd: marker }),
         style: {
@@ -696,7 +697,7 @@ function CommunityGraphInner({
           fitViewOptions={{ padding: 0.2, maxZoom: 1.5 }}
           minZoom={0.1}
           maxZoom={3}
-          defaultEdgeOptions={{ type: 'bezier' }}
+          defaultEdgeOptions={{ type: 'smoothstep' }}
           proOptions={{ hideAttribution: true }}
         >
           <Background color="#e2e8f0" gap={20} size={1} />


### PR DESCRIPTION
## Summary

- Strikte horizontale swim-lanes per node-type met 200px gap: organisaties → corpus_nodes → leads → samenwerkingsverbanden → interne personen → externe personen.
- Y wordt opgelegd via `LANE_Y`; dagre regelt nog x-positie en cross-minimization. Edge-flip-logica is weg, want die verzwakte juist de rank-dwang.
- Cross-lane edges gebruiken `smoothstep` voor orthogonale routing langs lanes (lijnen lopen niet meer dwars door cards heen); same-lane edges (lead↔lead, corpus↔corpus) blijven `bezier` voor korte verbindingen.
- Samenwerkingsverbanden (Team RegelRecht) zitten nu in een eigen rij **onder** de leads, dicht bij de personen waar SWV-edges naar wijzen.

## Test plan

- [ ] `just up`, navigeer naar `/leads`, switch naar de "graph" view
- [ ] Selecteer een initiatief met leads, organisaties, een SWV en externe contactpersonen
- [ ] Verifieer per lane:
  - [ ] Lane 0 — alle organisaties op één horizontale lijn
  - [ ] Lane 1 — corpus_nodes (incl. opschalingstickets) duidelijk boven de leads
  - [ ] Lane 2 — alle lead-cards op één rij, geen corpus_node ertussen
  - [ ] Lane 3 — samenwerkingsverbanden op een eigen rij onder de leads
  - [ ] Lane 4 / 5 — interne en externe personen op eigen rijen
- [ ] Cross-lane edges lopen orthogonaal langs lanes, niet door cards
- [ ] Same-lane edges blijven korte bezier-curves
- [ ] Klik op een persoon — focus dimt buurt; layout verandert niet
- [ ] Type-toggle "Verbanden" uit/aan — lane 3 leegt en vult zich weer