### PR TITLE
Extra samenwerkingsverband-types

### DIFF
--- a/backend/bouwmeester/api/routes/samenwerkingsverband.py
+++ b/backend/bouwmeester/api/routes/samenwerkingsverband.py
@@ -1,4 +1,4 @@
-"""API routes for Samenwerkingsverband (programma/werkgroep/...)."""
+"""API routes for Samenwerkingsverband (programma/werkgroep/stuurgroep/...)."""
 
 from uuid import UUID
 

--- a/backend/bouwmeester/models/samenwerkingsverband.py
+++ b/backend/bouwmeester/models/samenwerkingsverband.py
@@ -1,6 +1,7 @@
-"""Samenwerkingsverband model — ad-hoc samenwerkingsvormen los van de
+"""Samenwerkingsverband model: ad-hoc samenwerkingsvormen los van de
 hierarchische OrganisatieEenheid-boom (programma, werkgroep,
-opschalingsticket, ketenproject)."""
+opschalingsticket, ketenproject, stuurgroep, taskforce, innovatiebudget,
+community_of_practice, pilot, convenant)."""
 
 import uuid
 from datetime import date, datetime
@@ -29,7 +30,10 @@ class Samenwerkingsverband(Base):
     naam: Mapped[str] = mapped_column(nullable=False)
     type: Mapped[str] = mapped_column(
         nullable=False,
-        comment="programma|werkgroep|opschalingsticket|ketenproject",
+        comment=(
+            "programma|werkgroep|opschalingsticket|ketenproject|stuurgroep|"
+            "taskforce|innovatiebudget|community_of_practice|pilot|convenant"
+        ),
     )
     beschrijving: Mapped[str | None] = mapped_column(Text, nullable=True)
     start_datum: Mapped[date | None] = mapped_column(Date, nullable=True)

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -2097,20 +2097,32 @@ export interface CommunityGraphResponse {
 }
 
 // ---------------------------------------------------------------------------
-// Samenwerkingsverband (programma | werkgroep | opschalingsticket | ...)
+// Samenwerkingsverband (programma | werkgroep | stuurgroep | taskforce | ...)
 // ---------------------------------------------------------------------------
 
 export type SamenwerkingsverbandType =
   | 'programma'
   | 'werkgroep'
   | 'opschalingsticket'
-  | 'ketenproject';
+  | 'ketenproject'
+  | 'stuurgroep'
+  | 'taskforce'
+  | 'innovatiebudget'
+  | 'community_of_practice'
+  | 'pilot'
+  | 'convenant';
 
 export const SAMENWERKINGSVERBAND_TYPE_LABELS: Record<string, string> = {
   programma: 'Programma',
   werkgroep: 'Werkgroep',
   opschalingsticket: 'Opschalingsticket',
   ketenproject: 'Ketenproject',
+  stuurgroep: 'Stuurgroep',
+  taskforce: 'Taskforce',
+  innovatiebudget: 'Innovatiebudget',
+  community_of_practice: 'Community of Practice',
+  pilot: 'Pilot',
+  convenant: 'Convenant',
 };
 
 export const SAMENWERKINGSVERBAND_TYPE_BADGE_COLORS: Record<string, BadgeVariant> = {
@@ -2118,6 +2130,12 @@ export const SAMENWERKINGSVERBAND_TYPE_BADGE_COLORS: Record<string, BadgeVariant
   werkgroep: 'cyan',
   opschalingsticket: 'amber',
   ketenproject: 'emerald',
+  stuurgroep: 'indigo',
+  taskforce: 'red',
+  innovatiebudget: 'green',
+  community_of_practice: 'blue',
+  pilot: 'orange',
+  convenant: 'slate',
 };
 
 export const SAMENWERKINGSVERBAND_TYPE_OPTIONS: { value: string; label: string }[] =


### PR DESCRIPTION
## Summary
- Voegt zes types toe aan `Samenwerkingsverband`: `stuurgroep`, `taskforce`, `innovatiebudget`, `community_of_practice`, `pilot`, `convenant`.
- Geen migration: `type` is een vrije string in DB. Alleen labels, badge-kleuren en de TS-union breiden mee.
- Frontend (filter-dropdown, detail/lijst-pagina, lead-graph, persoonkaart) consumeert overal de records, dus pikt de nieuwe waarden automatisch op.

## Achtergrond
De bestaande set (`programma | werkgroep | opschalingsticket | ketenproject`) miste een paar samenwerkingsvormen die in BZK-/Logius-context vaak voorkomen:

- **stuurgroep** — formele besluitvorming bovenop een programma of ketenproject
- **taskforce** — tijdelijk, bredere scope dan een opschalingsticket
- **innovatiebudget** — budgetlijn met eigen governance, eigenaar en looptijd, los van het organogram
- **community of practice** — kennisnetwerk zonder deliverable
- **pilot** — experiment met evaluatiemoment
- **convenant** — afspraak tussen partijen, vaak extern

## Test plan
- [ ] `just up` en navigeer naar Samenwerkingsverbanden
- [ ] Open de Type-filter: alle tien waarden staan erin
- [ ] Maak een nieuwe SWV aan met type `stuurgroep` of `innovatiebudget` en controleer dat de juiste badge-kleur verschijnt
- [ ] Filter op `taskforce` en bevestig dat de query correct doorgegeven wordt