### PR TITLE
GitHub-PR-status op leads (fase 2, PR-only)

### DIFF
--- a/backend/bouwmeester/api/routes/leads.py
+++ b/backend/bouwmeester/api/routes/leads.py
@@ -149,8 +149,13 @@ def _check_initiatief_access(
 async def _refresh_stale_github_links(links: list[GitHubLink]) -> None:
     """Lazy-on-view refresh: links waarvan de status ouder dan TTL is (of
     nog nooit opgehaald) krijgen een verse fetch binnen één gedeelde
-    httpx-client. Faalt stil als auth ontbreekt of timeouts optreden —
-    de lead-detail-render moet hier nooit op blokkeren.
+    httpx-client. Faalt stil als auth ontbreekt.
+
+    Let op: deze call blokkeert de lead-detail-response tot alle stale
+    fetches klaar zijn, met als bovengrens de per-call timeout uit
+    ``GITHUB_FETCH_TIMEOUT_SECONDS``. Een trage GitHub of veel stale
+    links is dus voelbaar in de detail-render. Voor v1 acceptabel; bij
+    voldoende drukte verschuiven we de fetches naar de worker.
     """
     settings = get_settings()
     ttl = settings.GITHUB_STATUS_TTL_SECONDS

--- a/backend/bouwmeester/api/routes/leads.py
+++ b/backend/bouwmeester/api/routes/leads.py
@@ -1,7 +1,7 @@
 """API routes for leads (sales/intake funnel)."""
 
 import logging
-from datetime import date
+from datetime import UTC, date, datetime
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, UploadFile, status
@@ -11,7 +11,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from bouwmeester.api.deps import require_deleted, require_found, validate_list
 from bouwmeester.core.auth import OptionalUser
+from bouwmeester.core.config import get_settings
 from bouwmeester.core.database import get_db
+from bouwmeester.core.github_client import GitHubAuthNotConfiguredError, GitHubClient
 from bouwmeester.core.github_url import parse_github_url
 from bouwmeester.core.initiatief_context import (
     InitiatiefContext,
@@ -63,6 +65,7 @@ from bouwmeester.schema.lead import (
 from bouwmeester.schema.notification import NotificationCreate
 from bouwmeester.schema.tag import LeadTagCreate, LeadTagResponse, TagCreate
 from bouwmeester.services.activity_service import log_activity
+from bouwmeester.services.github_fetch import refresh_link_status
 from bouwmeester.services.mention_helper import sync_and_notify_mentions
 from bouwmeester.services.notification_service import NotificationService
 
@@ -141,6 +144,38 @@ def _check_initiatief_access(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Geen toegang tot dit initiatief",
         )
+
+
+async def _refresh_stale_github_links(links: list[GitHubLink]) -> None:
+    """Lazy-on-view refresh: links waarvan de status ouder dan TTL is (of
+    nog nooit opgehaald) krijgen een verse fetch binnen één gedeelde
+    httpx-client. Faalt stil als auth ontbreekt of timeouts optreden —
+    de lead-detail-render moet hier nooit op blokkeren.
+    """
+    settings = get_settings()
+    ttl = settings.GITHUB_STATUS_TTL_SECONDS
+    now = datetime.now(UTC)
+
+    stale: list[GitHubLink] = []
+    for link in links:
+        if link.link_type != "pull_request":
+            continue  # v1: alleen PR's
+        if link.last_checked_at is None:
+            stale.append(link)
+            continue
+        age = (now - link.last_checked_at).total_seconds()
+        if age >= ttl:
+            stale.append(link)
+
+    if not stale:
+        return
+
+    try:
+        async with GitHubClient() as client:
+            for link in stale:
+                await refresh_link_status(link, client=client)
+    except GitHubAuthNotConfiguredError:
+        return  # geen token → niets om te doen
 
 
 # ---------------------------------------------------------------------------
@@ -364,6 +399,7 @@ async def get_lead(
 
     gh_repo = GitHubLinkRepository(db)
     gh_links = await gh_repo.list_for_scope(SCOPE_LEAD, lead_id)
+    await _refresh_stale_github_links(gh_links)
     response.github_links = [
         GitHubLinkResponse.model_validate(link) for link in gh_links
     ]
@@ -1272,6 +1308,47 @@ async def delete_github_link(
             "owner_repo": owner_repo,
         },
     )
+
+
+@router.post(
+    "/{lead_id}/github-links/{link_id}/refresh",
+    response_model=GitHubLinkResponse,
+)
+async def refresh_github_link(
+    lead_id: UUID,
+    link_id: UUID,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    init_ctx: InitiatiefContext = Depends(get_initiatief_context),
+) -> GitHubLinkResponse:
+    """Forceer een verse status-fetch voor één link. Negeert TTL.
+
+    Bij ontbrekende GITHUB_TOKEN return we 503 zodat de UI weet dat
+    statusfetch hier niet beschikbaar is — anders zou de knop stilletjes
+    niets lijken te doen.
+    """
+    lead = await db.get(Lead, lead_id)
+    if lead is None:
+        raise HTTPException(status_code=404, detail="Lead niet gevonden")
+    _check_lead_access(lead, init_ctx)
+
+    repo = GitHubLinkRepository(db)
+    link = await repo.get(link_id)
+    if link is None or link.scope_type != SCOPE_LEAD or link.scope_id != lead_id:
+        raise HTTPException(status_code=404, detail="GitHub-link niet gevonden")
+
+    try:
+        async with GitHubClient() as client:
+            await refresh_link_status(link, client=client)
+    except GitHubAuthNotConfiguredError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail="GitHub-status-fetch is niet geconfigureerd op de server.",
+        ) from exc
+
+    await db.flush()
+    await db.refresh(link)
+    return GitHubLinkResponse.model_validate(link)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/bouwmeester/core/config.py
+++ b/backend/bouwmeester/core/config.py
@@ -91,6 +91,21 @@ class Settings(BaseSettings):
     MATTERMOST_LINK_CODE_TTL_MINUTES: int = 10
     MATTERMOST_LINK_CODE_LENGTH: int = 8
 
+    # GitHub status-fetch (fase 2 van GitHub-werk-koppeling).
+    # Bij leeg token is status-fetch uitgeschakeld; UI toont links zonder
+    # state-icoon. Voor App-credentials komen later GITHUB_APP_ID +
+    # GITHUB_APP_PRIVATE_KEY + GITHUB_APP_INSTALLATION_ID erbij; de client
+    # kiest dan automatisch App boven PAT.
+    GITHUB_TOKEN: str = ""
+    GITHUB_API_BASE_URL: str = "https://api.github.com"
+    # Lazy-on-view TTL: bij elk lead-detail zien we welke github_links
+    # ouder dan dit zijn en triggeren een refresh in de achtergrond.
+    GITHUB_STATUS_TTL_SECONDS: int = 300
+    # Hoe lang we maximaal wachten op een GitHub-API-call binnen een
+    # request-handler. Zachte cap; bij timeout valt de fetch stil zonder
+    # de lead-detail-response te blokkeren.
+    GITHUB_FETCH_TIMEOUT_SECONDS: float = 3.0
+
     # Age encryption for database backups
     AGE_SECRET_KEY: str = ""  # Age secret key for decryption (set on production)
 

--- a/backend/bouwmeester/core/github_client.py
+++ b/backend/bouwmeester/core/github_client.py
@@ -1,0 +1,125 @@
+"""Dunne async-client voor de GitHub-API.
+
+Auth-modus:
+
+1. Als ``GITHUB_TOKEN`` (PAT) is gezet, wordt die gebruikt.
+2. App-credentials (``GITHUB_APP_ID``, ``GITHUB_APP_PRIVATE_KEY``,
+   ``GITHUB_APP_INSTALLATION_ID``) komen later — dan verschuift deze
+   factory naar JWT + installation-token zonder dat callers wijzigen.
+
+De client doet **geen** retries. Statusbepaling is een best-effort
+operatie binnen een lead-detail-request; bij een 5xx of timeout zetten
+we ``check_error`` en gaan we door. Polling/retry is werk voor fase 2b
+of fase 4 (worker).
+
+Conditional GETs gebruiken ``If-None-Match`` met de eerder opgeslagen
+ETag. 304-responses kosten geen rate-budget en komen hier terug als
+``GitHubResponse(status=304, etag=<oude etag>, data=None)``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from bouwmeester.core.config import get_settings
+
+
+@dataclass(frozen=True)
+class GitHubResponse:
+    status: int
+    data: dict[str, Any] | None
+    etag: str | None
+
+
+class GitHubAuthNotConfiguredError(Exception):
+    """Raised when no PAT/App is configured but a fetch is attempted."""
+
+
+class GitHubClient:
+    """Wrapper rond ``httpx.AsyncClient`` met GitHub-conventies.
+
+    De client is bewust niet als FastAPI-dependency geregistreerd; voor
+    elke fetch-burst maak je een nieuwe instance binnen een ``async
+    with``-block. Dat houdt de connection-pool kort en maakt mocken in
+    tests triviaal.
+    """
+
+    def __init__(
+        self,
+        *,
+        token: str | None = None,
+        base_url: str | None = None,
+        timeout: float | None = None,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        settings = get_settings()
+        self._token = token if token is not None else settings.GITHUB_TOKEN
+        self._base_url = (base_url or settings.GITHUB_API_BASE_URL).rstrip("/")
+        self._timeout = (
+            timeout if timeout is not None else settings.GITHUB_FETCH_TIMEOUT_SECONDS
+        )
+        self._transport = transport
+        self._client: httpx.AsyncClient | None = None
+
+    @property
+    def is_configured(self) -> bool:
+        """True als er een token is. UI/route kan deze flag gebruiken om
+        statusfetches over te slaan zonder errors te veroorzaken."""
+        return bool(self._token)
+
+    async def __aenter__(self) -> GitHubClient:
+        if not self.is_configured:
+            raise GitHubAuthNotConfiguredError(
+                "Geen GITHUB_TOKEN geconfigureerd. Status-fetch overgeslagen."
+            )
+        headers = {
+            "Authorization": f"Bearer {self._token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "bouwmeester-github-status",
+        }
+        self._client = httpx.AsyncClient(
+            base_url=self._base_url,
+            headers=headers,
+            timeout=self._timeout,
+            transport=self._transport,
+        )
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    async def get(self, path: str, *, etag: str | None = None) -> GitHubResponse:
+        """GET op een GitHub-API-pad. ``path`` mag absoluut of relatief zijn.
+
+        Bij ``etag`` wordt een conditional GET gedaan. 304 betekent: niets
+        veranderd, gebruik de gecachete data.
+        """
+        if self._client is None:
+            raise RuntimeError(
+                "GitHubClient niet geïnitialiseerd; gebruik 'async with'."
+            )
+
+        request_headers: dict[str, str] = {}
+        if etag:
+            request_headers["If-None-Match"] = etag
+
+        response = await self._client.get(path, headers=request_headers)
+        new_etag = response.headers.get("ETag")
+
+        if response.status_code == 304:
+            return GitHubResponse(status=304, data=None, etag=etag)
+
+        if response.status_code >= 400:
+            return GitHubResponse(status=response.status_code, data=None, etag=new_etag)
+
+        return GitHubResponse(
+            status=response.status_code,
+            data=response.json(),
+            etag=new_etag,
+        )

--- a/backend/bouwmeester/migrations/versions/a7b8c9d0e1f2_add_github_link_status_fields.py
+++ b/backend/bouwmeester/migrations/versions/a7b8c9d0e1f2_add_github_link_status_fields.py
@@ -1,0 +1,72 @@
+"""add github_link status fields
+
+Revision ID: a7b8c9d0e1f2
+Revises: f1a2b3c4d5e6
+Create Date: 2026-05-06 22:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "a7b8c9d0e1f2"
+down_revision: str | None = "f1a2b3c4d5e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "github_link",
+        sa.Column(
+            "state",
+            sa.String(length=32),
+            nullable=True,
+            comment="open|closed|merged|draft|completed|failure|...",
+        ),
+    )
+    op.add_column(
+        "github_link",
+        sa.Column(
+            "state_extra",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "github_link",
+        sa.Column("etag", sa.String(length=200), nullable=True),
+    )
+    op.add_column(
+        "github_link",
+        sa.Column(
+            "last_checked_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "github_link",
+        sa.Column(
+            "last_changed_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "github_link",
+        sa.Column("check_error", sa.String(length=500), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("github_link", "check_error")
+    op.drop_column("github_link", "last_changed_at")
+    op.drop_column("github_link", "last_checked_at")
+    op.drop_column("github_link", "etag")
+    op.drop_column("github_link", "state_extra")
+    op.drop_column("github_link", "state")

--- a/backend/bouwmeester/migrations/versions/a7b8c9d0e1f2_add_github_link_status_fields.py
+++ b/backend/bouwmeester/migrations/versions/a7b8c9d0e1f2_add_github_link_status_fields.py
@@ -1,7 +1,7 @@
 """add github_link status fields
 
 Revision ID: a7b8c9d0e1f2
-Revises: f1a2b3c4d5e6
+Revises: 1fe90cecedd9
 Create Date: 2026-05-06 22:00:00.000000
 
 """
@@ -14,7 +14,7 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision: str = "a7b8c9d0e1f2"
-down_revision: str | None = "f1a2b3c4d5e6"
+down_revision: str | None = "1fe90cecedd9"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/bouwmeester/models/github_link.py
+++ b/backend/bouwmeester/models/github_link.py
@@ -18,7 +18,7 @@ from sqlalchemy import (
     func,
     text,
 )
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from bouwmeester.core.database import Base
@@ -59,6 +59,25 @@ class GitHubLink(Base):
     repo: Mapped[str] = mapped_column(String(200), nullable=False)
     ref: Mapped[str | None] = mapped_column(String(500), nullable=True)
     title: Mapped[str | None] = mapped_column(String(500), nullable=True)
+
+    # Status-cache (fase 2). Allemaal nullable: een link zonder ooit een
+    # succesvolle fetch heeft state=None en check_error=None — UI toont
+    # die als "status onbekend".
+    state: Mapped[str | None] = mapped_column(
+        String(32),
+        nullable=True,
+        comment="open|closed|merged|draft|completed|failure|...",
+    )
+    state_extra: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    etag: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    last_checked_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_changed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    check_error: Mapped[str | None] = mapped_column(String(500), nullable=True)
+
     created_by_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("person.id", ondelete="SET NULL"),

--- a/backend/bouwmeester/schema/github_link.py
+++ b/backend/bouwmeester/schema/github_link.py
@@ -34,6 +34,11 @@ class GitHubLinkResponse(BaseModel):
     repo: str
     ref: str | None = None
     title: str | None = None
+    state: str | None = None
+    state_extra: dict | None = None
+    last_checked_at: datetime | None = None
+    last_changed_at: datetime | None = None
+    check_error: str | None = None
     created_by_id: UUID | None = None
     created_at: datetime
 

--- a/backend/bouwmeester/services/github_fetch.py
+++ b/backend/bouwmeester/services/github_fetch.py
@@ -1,0 +1,153 @@
+"""Status-fetch voor github_link records.
+
+Eén entry-point: ``refresh_link_status``. Het bepaalt op basis van
+``link_type`` welke API-call nodig is, vraagt 'm met de eventueel
+opgeslagen ``etag`` en updatet het record. Errors worden in
+``check_error`` gezet, niet teruggegooid: een falende fetch mag de
+lead-detail-render nooit blokkeren.
+
+Voor v1 alleen ``pull_request``. Branch/issue/repo/run komen later in
+deze module bij — pattern is identiek (eigen ``_fetch_*``-helper, eigen
+``state``-bepaling).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+
+from bouwmeester.core.github_client import (
+    GitHubAuthNotConfiguredError,
+    GitHubClient,
+    GitHubResponse,
+)
+from bouwmeester.models.github_link import GitHubLink
+
+logger = logging.getLogger(__name__)
+
+
+async def refresh_link_status(
+    link: GitHubLink,
+    *,
+    client: GitHubClient | None = None,
+) -> bool:
+    """Refresh ``link.state`` / ``state_extra`` / ``etag`` / timestamps.
+
+    Returns ``True`` als de state daadwerkelijk veranderd is (handig voor
+    fase 4: status-change → notification of trigger).
+
+    Schrijft naar het ORM-object maar doet **geen** ``flush``/``commit``;
+    de aanroeper bepaalt dat (typisch: gewoon de request-handler
+    waardoor ``get_db`` het bij success commit).
+    """
+    own_client = client is None
+    try:
+        if own_client:
+            client = GitHubClient()
+            await client.__aenter__()
+    except GitHubAuthNotConfiguredError:
+        # Geen token → niet falen, gewoon stilletjes overslaan. Het UI
+        # toont de link zonder status-icoon. Dit pad is normaal in dev
+        # zonder PAT.
+        return False
+
+    assert client is not None
+    try:
+        if link.link_type == "pull_request":
+            response = await _fetch_pr(client, link)
+        else:
+            # Andere types nog niet ondersteund — valt onder fase 2b.
+            return False
+
+        return _apply_response(link, response)
+    except httpx.TimeoutException:
+        link.check_error = "timeout"
+        link.last_checked_at = datetime.now(UTC)
+        return False
+    except Exception as exc:  # noqa: BLE001 — best-effort
+        logger.warning(
+            "github status fetch faalde voor %s/%s ref=%s: %s",
+            link.owner,
+            link.repo,
+            link.ref,
+            exc,
+        )
+        link.check_error = f"{type(exc).__name__}: {exc}"[:500]
+        link.last_checked_at = datetime.now(UTC)
+        return False
+    finally:
+        if own_client:
+            await client.__aexit__(None, None, None)
+
+
+async def _fetch_pr(client: GitHubClient, link: GitHubLink) -> GitHubResponse:
+    if not link.ref:
+        return GitHubResponse(status=400, data=None, etag=None)
+    path = f"/repos/{link.owner}/{link.repo}/pulls/{link.ref}"
+    return await client.get(path, etag=link.etag)
+
+
+def _apply_response(link: GitHubLink, response: GitHubResponse) -> bool:
+    """Schrijf de response op het link-record. Return True als state wijzigde."""
+    now = datetime.now(UTC)
+    link.last_checked_at = now
+
+    if response.status == 304:
+        # Niets veranderd — etag blijft, state blijft, geen check_error.
+        link.check_error = None
+        return False
+
+    if response.status == 404:
+        link.check_error = "not_found"
+        # We laten de oude state staan; UI kan zien dat last_checked_at
+        # recent is en check_error gezet — dat impliceert "verdwenen".
+        return False
+
+    if response.status == 401 or response.status == 403:
+        link.check_error = "no_access"
+        return False
+
+    if response.status >= 400:
+        link.check_error = f"http_{response.status}"
+        return False
+
+    if response.data is None:
+        link.check_error = "empty_response"
+        return False
+
+    new_state, extra = _pr_state_from_payload(response.data)
+    state_changed = new_state != link.state
+
+    link.state = new_state
+    link.state_extra = extra
+    link.etag = response.etag
+    link.check_error = None
+    if state_changed:
+        link.last_changed_at = now
+    return state_changed
+
+
+def _pr_state_from_payload(payload: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    """Map GitHub's PR-velden naar onze ``state``-string + extra."""
+    if payload.get("merged"):
+        state = "merged"
+    elif payload.get("draft"):
+        state = "draft"
+    elif payload.get("state") == "closed":
+        state = "closed"
+    else:
+        state = "open"
+
+    extra: dict[str, Any] = {
+        "title": payload.get("title"),
+        "head_ref": (payload.get("head") or {}).get("ref"),
+        "base_ref": (payload.get("base") or {}).get("ref"),
+        "merged_at": payload.get("merged_at"),
+        "html_url": payload.get("html_url"),
+    }
+    # Lege/None-waardes opruimen voor compactere JSONB.
+    extra = {k: v for k, v in extra.items() if v is not None}
+    return state, extra

--- a/backend/tests/test_github_fetch.py
+++ b/backend/tests/test_github_fetch.py
@@ -1,0 +1,254 @@
+"""Tests voor de GitHub-status-fetcher.
+
+Gebruikt ``httpx.MockTransport`` zodat we geen netwerk- of mock-libs
+nodig hebben. De ``GitHubClient`` accepteert een ``transport``-parameter
+specifiek voor dit doel.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import httpx
+import pytest
+
+from bouwmeester.core.github_client import GitHubClient
+from bouwmeester.models.github_link import SCOPE_LEAD, GitHubLink
+from bouwmeester.services.github_fetch import refresh_link_status
+
+
+def _make_link(**kwargs) -> GitHubLink:
+    defaults = dict(
+        id=uuid.uuid4(),
+        scope_type=SCOPE_LEAD,
+        scope_id=uuid.uuid4(),
+        url="https://github.com/foo/bar/pull/1",
+        link_type="pull_request",
+        owner="foo",
+        repo="bar",
+        ref="1",
+        title=None,
+        state=None,
+        state_extra=None,
+        etag=None,
+        last_checked_at=None,
+        last_changed_at=None,
+        check_error=None,
+    )
+    defaults.update(kwargs)
+    return GitHubLink(**defaults)
+
+
+def _transport(handler):
+    return httpx.MockTransport(handler)
+
+
+async def _client_with(handler) -> GitHubClient:
+    client = GitHubClient(token="testpat", transport=_transport(handler))
+    await client.__aenter__()
+    return client
+
+
+@pytest.mark.asyncio
+async def test_open_pr_sets_open_state():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/repos/foo/bar/pulls/1"
+        assert request.headers["Authorization"] == "Bearer testpat"
+        return httpx.Response(
+            200,
+            headers={"ETag": '"abc"'},
+            json={
+                "state": "open",
+                "merged": False,
+                "draft": False,
+                "title": "Add thing",
+                "head": {"ref": "feat/thing"},
+                "base": {"ref": "main"},
+                "html_url": "https://github.com/foo/bar/pull/1",
+            },
+        )
+
+    client = await _client_with(handler)
+    try:
+        link = _make_link()
+        changed = await refresh_link_status(link, client=client)
+        assert changed is True
+        assert link.state == "open"
+        assert link.etag == '"abc"'
+        assert link.check_error is None
+        assert link.last_checked_at is not None
+        assert link.last_changed_at is not None
+        assert link.state_extra["title"] == "Add thing"
+        assert link.state_extra["head_ref"] == "feat/thing"
+    finally:
+        await client.__aexit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_merged_pr_state():
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "state": "closed",
+                "merged": True,
+                "merged_at": "2026-01-01T00:00:00Z",
+                "draft": False,
+            },
+        )
+
+    client = await _client_with(handler)
+    try:
+        link = _make_link()
+        await refresh_link_status(link, client=client)
+        assert link.state == "merged"
+        assert link.state_extra.get("merged_at") == "2026-01-01T00:00:00Z"
+    finally:
+        await client.__aexit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_draft_pr_state():
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"state": "open", "merged": False, "draft": True},
+        )
+
+    client = await _client_with(handler)
+    try:
+        link = _make_link()
+        await refresh_link_status(link, client=client)
+        assert link.state == "draft"
+    finally:
+        await client.__aexit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_304_not_modified_keeps_state_clears_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["If-None-Match"] == '"abc"'
+        return httpx.Response(304)
+
+    client = await _client_with(handler)
+    try:
+        link = _make_link(
+            state="open",
+            etag='"abc"',
+            check_error="oude fout",
+            last_checked_at=datetime.now(UTC) - timedelta(hours=1),
+        )
+        old_changed = link.last_changed_at
+        changed = await refresh_link_status(link, client=client)
+        assert changed is False
+        assert link.state == "open"
+        assert link.etag == '"abc"'
+        assert link.check_error is None
+        assert link.last_changed_at == old_changed
+    finally:
+        await client.__aexit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_404_sets_not_found_error():
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404)
+
+    client = await _client_with(handler)
+    try:
+        link = _make_link(state="open")
+        changed = await refresh_link_status(link, client=client)
+        assert changed is False
+        assert link.check_error == "not_found"
+        # State blijft staan; UI ziet check_error.
+        assert link.state == "open"
+    finally:
+        await client.__aexit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_403_sets_no_access_error():
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403)
+
+    client = await _client_with(handler)
+    try:
+        link = _make_link()
+        await refresh_link_status(link, client=client)
+        assert link.check_error == "no_access"
+    finally:
+        await client.__aexit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_500_sets_http_500_error():
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500)
+
+    client = await _client_with(handler)
+    try:
+        link = _make_link()
+        await refresh_link_status(link, client=client)
+        assert link.check_error == "http_500"
+    finally:
+        await client.__aexit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_no_token_returns_false_without_raising():
+    """Zonder GITHUB_TOKEN moet de fetch stilletjes overgeslagen worden."""
+    link = _make_link()
+    # Geen client meegeven → factory probeert env-token; we forceren leeg.
+    client = GitHubClient(token="")
+    # Niet __aenter__'en; refresh_link_status doet dat zelf en moet
+    # GitHubAuthNotConfiguredError opvangen.
+    changed = await refresh_link_status(link, client=None)
+    assert changed is False
+    assert link.state is None
+    assert link.check_error is None
+    # Sanity: client.is_configured = False.
+    assert client.is_configured is False
+
+
+@pytest.mark.asyncio
+async def test_state_change_sets_last_changed_at():
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"state": "closed", "merged": True, "draft": False},
+        )
+
+    client = await _client_with(handler)
+    try:
+        before = datetime.now(UTC) - timedelta(days=1)
+        link = _make_link(
+            state="open",
+            last_changed_at=before,
+        )
+        changed = await refresh_link_status(link, client=client)
+        assert changed is True
+        assert link.state == "merged"
+        assert link.last_changed_at is not None
+        assert link.last_changed_at > before
+    finally:
+        await client.__aexit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_unchanged_state_keeps_last_changed_at():
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"state": "open", "merged": False, "draft": False},
+        )
+
+    client = await _client_with(handler)
+    try:
+        before = datetime.now(UTC) - timedelta(hours=2)
+        link = _make_link(state="open", last_changed_at=before)
+        changed = await refresh_link_status(link, client=client)
+        assert changed is False
+        assert link.last_changed_at == before
+    finally:
+        await client.__aexit__(None, None, None)

--- a/backend/tests/test_github_fetch.py
+++ b/backend/tests/test_github_fetch.py
@@ -196,19 +196,28 @@ async def test_500_sets_http_500_error():
 
 
 @pytest.mark.asyncio
-async def test_no_token_returns_false_without_raising():
-    """Zonder GITHUB_TOKEN moet de fetch stilletjes overgeslagen worden."""
+async def test_no_token_returns_false_without_raising(monkeypatch):
+    """Zonder GITHUB_TOKEN moet de fetch stilletjes overgeslagen worden.
+
+    Belangrijk: we dwingen het token af op leeg in de Settings-cache,
+    anders zou de test stilletjes slagen op CI (geen env-token) maar
+    falen op een dev-machine waar de PAT al in ``.env`` staat — en
+    dan zou de fetch echt richting api.github.com gaan.
+    """
+    from bouwmeester.core.config import get_settings as _get_settings
+
+    settings = _get_settings()
+    monkeypatch.setattr(settings, "GITHUB_TOKEN", "", raising=False)
+
     link = _make_link()
-    # Geen client meegeven → factory probeert env-token; we forceren leeg.
-    client = GitHubClient(token="")
-    # Niet __aenter__'en; refresh_link_status doet dat zelf en moet
-    # GitHubAuthNotConfiguredError opvangen.
     changed = await refresh_link_status(link, client=None)
     assert changed is False
     assert link.state is None
     assert link.check_error is None
-    # Sanity: client.is_configured = False.
-    assert client.is_configured is False
+
+    # Sanity: een verse client zonder argumenten moet ``is_configured = False``
+    # zien zodra GITHUB_TOKEN leeg is.
+    assert GitHubClient().is_configured is False
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_lead_github_links.py
+++ b/backend/tests/test_lead_github_links.py
@@ -231,6 +231,49 @@ async def test_created_by_id_is_set_when_authenticated(
         _test_app.dependency_overrides.pop(get_optional_user, None)
 
 
+class _UnconfiguredClient:
+    """Mock van GitHubClient zonder token: __aenter__ raised."""
+
+    async def __aenter__(self):
+        from bouwmeester.core.github_client import GitHubAuthNotConfiguredError
+
+        raise GitHubAuthNotConfiguredError("test: geen token")
+
+    async def __aexit__(self, *_):  # pragma: no cover — niet bereikt
+        return None
+
+
+async def test_refresh_returns_503_without_token(client, sample_lead, monkeypatch):
+    """Zonder GITHUB_TOKEN return de refresh-endpoint 503.
+
+    Anders zou een UI-knop 'Verversen' stilletjes geen verandering
+    opleveren — beter expliciet falen.
+    """
+    create = await client.post(
+        f"/api/leads/{sample_lead.id}/github-links",
+        json={"url": "https://github.com/foo/bar/pull/55"},
+    )
+    link_id = create.json()["id"]
+
+    monkeypatch.setattr(
+        "bouwmeester.api.routes.leads.GitHubClient",
+        lambda: _UnconfiguredClient(),
+    )
+
+    resp = await client.post(
+        f"/api/leads/{sample_lead.id}/github-links/{link_id}/refresh"
+    )
+    assert resp.status_code == 503
+
+
+async def test_refresh_unknown_link_returns_404(client, sample_lead):
+    fake_id = uuid.uuid4()
+    resp = await client.post(
+        f"/api/leads/{sample_lead.id}/github-links/{fake_id}/refresh"
+    )
+    assert resp.status_code == 404
+
+
 async def test_link_for_other_lead_returns_404(client, db_session, sample_lead):
     # Maak een link op sample_lead
     create = await client.post(

--- a/frontend/src/api/leads.ts
+++ b/frontend/src/api/leads.ts
@@ -223,3 +223,13 @@ export async function updateLeadGitHubLink(
 export async function deleteLeadGitHubLink(leadId: string, linkId: string): Promise<void> {
   return apiDelete(`/api/leads/${leadId}/github-links/${linkId}`);
 }
+
+export async function refreshLeadGitHubLink(
+  leadId: string,
+  linkId: string,
+): Promise<LeadGitHubLink> {
+  return apiPost<LeadGitHubLink>(
+    `/api/leads/${leadId}/github-links/${linkId}/refresh`,
+    {},
+  );
+}

--- a/frontend/src/components/leads/LeadGitHubLinks.tsx
+++ b/frontend/src/components/leads/LeadGitHubLinks.tsx
@@ -104,8 +104,13 @@ function statusTooltip(link: LeadGitHubLink): string {
   const lines: string[] = [];
   const extra = link.state_extra ?? {};
   if (typeof extra.title === 'string') lines.push(extra.title);
-  if (typeof extra.head_ref === 'string')
-    lines.push(`${extra.head_ref} → ${extra.base_ref ?? 'main'}`);
+  if (typeof extra.head_ref === 'string') {
+    if (typeof extra.base_ref === 'string') {
+      lines.push(`${extra.head_ref} → ${extra.base_ref}`);
+    } else {
+      lines.push(extra.head_ref);
+    }
+  }
   if (link.last_checked_at) {
     const when = new Date(link.last_checked_at).toLocaleString('nl-NL');
     lines.push(`Laatst gecheckt: ${when}`);

--- a/frontend/src/components/leads/LeadGitHubLinks.tsx
+++ b/frontend/src/components/leads/LeadGitHubLinks.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import {
   GitBranch,
   GitPullRequest,
+  GitMerge,
   CircleDot,
   Github,
   Play,
@@ -11,6 +12,8 @@ import {
   Check,
   X,
   Plus,
+  RefreshCw,
+  AlertCircle,
 } from 'lucide-react';
 import { Button } from '@/components/common/Button';
 import { DetailSection } from '@/components/common/DetailSection';
@@ -19,6 +22,7 @@ import {
   useAddLeadGitHubLink,
   useUpdateLeadGitHubLink,
   useDeleteLeadGitHubLink,
+  useRefreshLeadGitHubLink,
 } from '@/hooks/useLeads';
 import type { LeadGitHubLink, GitHubLinkType } from '@/types';
 
@@ -58,6 +62,60 @@ function shortRef(link: LeadGitHubLink): string {
   return '';
 }
 
+interface StatusBadge {
+  icon: React.ReactNode;
+  label: string;
+  className: string;
+}
+
+function pullRequestBadge(link: LeadGitHubLink): StatusBadge | null {
+  if (!link.state) return null;
+  switch (link.state) {
+    case 'merged':
+      return {
+        icon: <GitMerge className="h-3 w-3" />,
+        label: 'merged',
+        className: 'bg-purple-50 text-purple-700 ring-1 ring-purple-200',
+      };
+    case 'closed':
+      return {
+        icon: <X className="h-3 w-3" />,
+        label: 'closed',
+        className: 'bg-red-50 text-red-700 ring-1 ring-red-200',
+      };
+    case 'draft':
+      return {
+        icon: <GitPullRequest className="h-3 w-3" />,
+        label: 'draft',
+        className: 'bg-gray-100 text-gray-600 ring-1 ring-gray-200',
+      };
+    case 'open':
+      return {
+        icon: <GitPullRequest className="h-3 w-3" />,
+        label: 'open',
+        className: 'bg-green-50 text-green-700 ring-1 ring-green-200',
+      };
+    default:
+      return null;
+  }
+}
+
+function statusTooltip(link: LeadGitHubLink): string {
+  const lines: string[] = [];
+  const extra = link.state_extra ?? {};
+  if (typeof extra.title === 'string') lines.push(extra.title);
+  if (typeof extra.head_ref === 'string')
+    lines.push(`${extra.head_ref} → ${extra.base_ref ?? 'main'}`);
+  if (link.last_checked_at) {
+    const when = new Date(link.last_checked_at).toLocaleString('nl-NL');
+    lines.push(`Laatst gecheckt: ${when}`);
+  }
+  if (link.check_error) {
+    lines.push(`Fout: ${link.check_error}`);
+  }
+  return lines.join('\n');
+}
+
 export function LeadGitHubLinks({ leadId, links }: Props) {
   const [showForm, setShowForm] = useState(false);
   const [url, setUrl] = useState('');
@@ -65,10 +123,12 @@ export function LeadGitHubLinks({ leadId, links }: Props) {
   const [error, setError] = useState<string | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editingTitle, setEditingTitle] = useState('');
+  const [refreshingId, setRefreshingId] = useState<string | null>(null);
 
   const addLink = useAddLeadGitHubLink();
   const updateLink = useUpdateLeadGitHubLink();
   const deleteLink = useDeleteLeadGitHubLink();
+  const refreshLink = useRefreshLeadGitHubLink();
 
   const submit = async () => {
     setError(null);
@@ -111,6 +171,15 @@ export function LeadGitHubLinks({ leadId, links }: Props) {
       title: editingTitle.trim() || null,
     });
     setEditingId(null);
+  };
+
+  const onRefresh = async (link: LeadGitHubLink) => {
+    setRefreshingId(link.id);
+    try {
+      await refreshLink.mutateAsync({ leadId, linkId: link.id });
+    } finally {
+      setRefreshingId(null);
+    }
   };
 
   return (
@@ -180,6 +249,10 @@ export function LeadGitHubLinks({ leadId, links }: Props) {
             const display =
               link.title ??
               (ref ? `${link.owner}/${link.repo} ${ref}` : `${link.owner}/${link.repo}`);
+            const badge =
+              link.link_type === 'pull_request' ? pullRequestBadge(link) : null;
+            const tooltip = statusTooltip(link);
+            const showRefresh = link.link_type === 'pull_request';
             return (
               <div
                 key={link.id}
@@ -217,13 +290,42 @@ export function LeadGitHubLinks({ leadId, links }: Props) {
                       target="_blank"
                       rel="noreferrer"
                       className="flex-1 truncate text-primary-700 hover:underline"
-                      title={link.url}
+                      title={tooltip || link.url}
                     >
                       {display}
                     </a>
-                    <span className="text-[10px] uppercase tracking-wider text-text-secondary px-1.5 py-0.5 rounded bg-gray-100">
-                      {TYPE_LABELS[link.link_type]}
-                    </span>
+                    {badge ? (
+                      <span
+                        className={`inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 text-[10px] font-medium ${badge.className}`}
+                      >
+                        {badge.icon}
+                        {badge.label}
+                      </span>
+                    ) : (
+                      <span className="text-[10px] uppercase tracking-wider text-text-secondary px-1.5 py-0.5 rounded bg-gray-100">
+                        {TYPE_LABELS[link.link_type]}
+                      </span>
+                    )}
+                    {link.check_error && (
+                      <span
+                        title={`Status-fout: ${link.check_error}`}
+                        className="text-amber-500"
+                      >
+                        <AlertCircle className="h-3.5 w-3.5" />
+                      </span>
+                    )}
+                    {showRefresh && (
+                      <button
+                        onClick={() => onRefresh(link)}
+                        disabled={refreshingId === link.id}
+                        className="p-1 text-text-secondary hover:text-primary-600 disabled:opacity-50"
+                        title="Status verversen"
+                      >
+                        <RefreshCw
+                          className={`h-3.5 w-3.5 ${refreshingId === link.id ? 'animate-spin' : ''}`}
+                        />
+                      </button>
+                    )}
                     <button
                       onClick={() => startEdit(link)}
                       className="p-1 text-text-secondary hover:text-primary-600"

--- a/frontend/src/hooks/useLeads.ts
+++ b/frontend/src/hooks/useLeads.ts
@@ -21,6 +21,7 @@ import {
   addLeadGitHubLink,
   updateLeadGitHubLink,
   deleteLeadGitHubLink,
+  refreshLeadGitHubLink,
   parseLeadIntake,
   getCommunityGraph,
   getLeadTimeline,
@@ -316,6 +317,20 @@ export function useDeleteLeadGitHubLink() {
       linkId: string;
     }) => deleteLeadGitHubLink(leadId, linkId),
     errorMessage: 'Fout bij verwijderen GitHub-link',
+    invalidateKeys: [queryKeys.leads.all],
+  });
+}
+
+export function useRefreshLeadGitHubLink() {
+  return useMutationWithError({
+    mutationFn: ({
+      leadId,
+      linkId,
+    }: {
+      leadId: string;
+      linkId: string;
+    }) => refreshLeadGitHubLink(leadId, linkId),
+    errorMessage: 'Status verversen mislukt',
     invalidateKeys: [queryKeys.leads.all],
   });
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1772,6 +1772,11 @@ export interface LeadGitHubLink {
   repo: string;
   ref: string | null;
   title: string | null;
+  state: string | null;
+  state_extra: Record<string, unknown> | null;
+  last_checked_at: string | null;
+  last_changed_at: string | null;
+  check_error: string | null;
   created_by_id: string | null;
   created_at: string;
 }


### PR DESCRIPTION
## Wat

Lead-detail toont nu live PR-status (open/draft/closed/merged) bij gekoppelde GitHub-pull-requests, met type-icoon, kleurige badge, tooltip (PR-titel + branch-info + last_checked) en een verversen-knop. Volgende stap na #285.

Status wordt **lazy** gefetcht: bij elk detail-verzoek refreshen we links waarvan \`last_checked_at\` ouder is dan \`GITHUB_STATUS_TTL_SECONDS\` (default 5 min), of nooit gefetcht zijn. Conditional GETs met \`If-None-Match\` houden het rate-budget laag.

## Auth

Via \`GITHUB_TOKEN\` (PAT) als env-var. Code-shape is voorbereid op latere swap naar GitHub App zonder caller-wijzigingen — alleen \`GitHubClient.__aenter__\` krijgt later een tweede pad. Tot dat moment werkt fase 2 in dev/staging op een fine-grained PAT.

Zonder token gebeurt er **niets** kwalijks: lazy-fetch slaat stilletjes over (UI ziet links zonder badge), de expliciete refresh-endpoint return 503 zodat een knopdruk niet stilletjes faalt.

## Backend

- \`core/github_client.py\`: async \`httpx\`-wrapper, context-manager, optionele transport-injectie voor \`MockTransport\` in tests. Raised \`GitHubAuthNotConfiguredError\` bij ontbrekend token.
- \`services/github_fetch.py\`: \`refresh_link_status()\`, best-effort. Errors → \`check_error\`, geen exceptions naar boven. PR-state-mapping: merged > draft > closed > open.
- Migratie \`a7b8c9d0e1f2\`: \`state\`, \`state_extra\` (jsonb), \`etag\`, \`last_checked_at\`, \`last_changed_at\`, \`check_error\` op \`github_link\`. Allemaal nullable.
- \`POST /api/leads/{lead_id}/github-links/{link_id}/refresh\` — forceert fetch, 503 zonder token.
- Lead-detail-handler: \`_refresh_stale_github_links()\` vóór response-bouw, één gedeelde \`httpx\`-client voor de hele batch.

## Frontend

- \`LeadGitHubLink\`-type uitgebreid met de zes status-velden.
- \`LeadGitHubLinks\`-component:
  - Kleurige badge per state — groen open, paars merged, rood closed, grijs draft
  - Tooltip op de link met PR-titel + \`head → base\` + \`Laatst gecheckt\`
  - \`AlertCircle\` (amber) bij \`check_error\`
  - \`RefreshCw\`-knop met spin-animatie tijdens refresh

## Tests

- 10 fetcher-tests via \`httpx.MockTransport\` (200, 304, 404, 403, 500, state-changes, no-token-pad)
- 2 endpoint-tests voor refresh (503 zonder token, 404 op onbekende link)
- 59 tests groen (was 47), inventory groen, typecheck/lint/build groen

## Out of scope

- Branch/issue/repo/workflow_run-status (alleen PR's in v1, pattern in fetcher is voorbereid)
- App-credentials (PAT volstaat voor dev/staging)
- Achtergrond-worker/polling (lazy-on-view is genoeg voor v1)

## Test plan

- [ ] \`echo 'GITHUB_TOKEN=ghp_...' >> ~/bouwmeester/.env\`
- [ ] \`just reset-db && just up\`
- [ ] Plak een echte PR-URL op een lead; status-badge verschijnt na korte wachttijd
- [ ] Klik refresh — spin-animatie, status update zichtbaar
- [ ] Plak PR uit een privé-repo zonder token-toegang — \`AlertCircle\` met \`no_access\`
- [ ] Verwijder \`GITHUB_TOKEN\` uit .env, restart, refresh-knop → toast met 503-fout