### PR TITLE
Fix dubbel Organisatie-eenheid label in NewContactPersonFields

### DIFF
--- a/frontend/src/components/leads/NewContactPersonFields.tsx
+++ b/frontend/src/components/leads/NewContactPersonFields.tsx
@@ -134,15 +134,11 @@ export function NewContactPersonFields({
           disabled={disabled}
         />
       </div>
-      <div>
-        <label className="block text-sm font-medium text-text mb-1">
-          Organisatie-eenheid (optioneel)
-        </label>
-        <CascadingOrgSelect
-          value={state.organisatieEenheidId}
-          onChange={(v) => set('organisatieEenheidId', v)}
-        />
-      </div>
+      <CascadingOrgSelect
+        label="Organisatie-eenheid (optioneel)"
+        value={state.organisatieEenheidId}
+        onChange={(v) => set('organisatieEenheidId', v)}
+      />
       {samenwerkingsverbanden.length > 0 && (
         <SwvCheckboxList
           samenwerkingsverbanden={samenwerkingsverbanden}


### PR DESCRIPTION
## Summary
- `CascadingOrgSelect` rendert zelf al een label, dus de wrapper-`<div>` met een eigen `<label>` produceerde een dubbele "Organisatie-eenheid" boven het veld.
- Wrapper weggehaald en het label via de `label`-prop doorgegeven aan `CascadingOrgSelect`.

## Test plan
- [ ] Open een lead, klik op contactpersoon toevoegen → "Nieuwe contactpersoon" modal: één label "Organisatie-eenheid (optioneel)" boven de ministerie-select.