### PR TITLE
Worker-heartbeat in Beheer > Systeem + unbuffered worker-logs

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -36,6 +36,11 @@ USER 1001
 # Activate venv via PATH — entrypoint uses python/alembic/uvicorn directly
 ENV PATH="/app/.venv/bin:$PATH"
 
+# Force unbuffered stdout/stderr — without this Python buffers when stdout
+# is not a TTY, so the worker's log lines (and crash tracebacks) sit in the
+# buffer until the process exits, making operational issues invisible.
+ENV PYTHONUNBUFFERED=1
+
 ARG GIT_SHA=""
 ARG BUILD_TIME=""
 ENV GIT_SHA=$GIT_SHA

--- a/backend/bouwmeester/api/routes/admin.py
+++ b/backend/bouwmeester/api/routes/admin.py
@@ -21,6 +21,7 @@ from bouwmeester.models.access_request import AccessRequest
 from bouwmeester.models.app_config import AppConfig
 from bouwmeester.models.person import Person
 from bouwmeester.models.whitelist_email import WhitelistEmail
+from bouwmeester.models.worker_heartbeat import WorkerHeartbeat
 from bouwmeester.schema.access_request import (
     AccessRequestResponse,
     AccessRequestReviewRequest,
@@ -37,6 +38,10 @@ from bouwmeester.schema.whitelist import (
     AdminUserResponse,
     WhitelistEmailCreate,
     WhitelistEmailResponse,
+)
+from bouwmeester.schema.worker_health import (
+    WorkerHealthResponse,
+    WorkerHeartbeatResponse,
 )
 from bouwmeester.services.activity_service import ActivityService
 
@@ -755,3 +760,115 @@ _VERSION_INFO = {
 async def version_info(admin: AdminUser) -> dict[str, str]:
     """Return backend git SHA, build time, and repo URL (admin only)."""
     return _VERSION_INFO
+
+
+# ---------------------------------------------------------------------------
+# Worker health
+# ---------------------------------------------------------------------------
+
+# Per-loop expected cadence in seconds. If last_tick_at is older than this
+# we mark the loop "stale"; older than 4× we mark it "down". These numbers
+# err on the side of "noisy when broken" rather than "quiet when broken".
+_WORKER_EXPECTED_CADENCE_SEC = {
+    "parlementair": 900,  # TK_POLL_INTERVAL_SECONDS default 15min
+    "mattermost_link": 60,  # MATTERMOST_POLL_INTERVAL_SECONDS default
+    "mattermost_websocket": 90,  # idle-heartbeat is once per 60s
+    "opdracht_task": 86400,  # daily — give it 4× before declaring down
+    "fcc_sync": 600,  # FCC_POLL_INTERVAL_SECONDS default 10min
+}
+
+# Loop names we expect to see. If a row never appears, the loop never started
+# (worker process probably crashed before `await health_tick("…", "starting")`).
+_EXPECTED_LOOPS = list(_WORKER_EXPECTED_CADENCE_SEC.keys())
+
+
+def _classify_health(status: str, seconds_since: float, expected_cadence: float) -> str:
+    """Map (status, age) to a coarse health bucket for the UI."""
+    if status == "disabled":
+        return "disabled"
+    if seconds_since > expected_cadence * 4:
+        return "down"
+    if seconds_since > expected_cadence:
+        return "stale"
+    if status in ("error", "reconnecting"):
+        return "stale"
+    return "healthy"
+
+
+@router.get("/workers", response_model=WorkerHealthResponse)
+async def workers_health(
+    admin: AdminUser,
+    db: AsyncSession = Depends(get_db),
+) -> WorkerHealthResponse:
+    """Return current heartbeat for every background worker loop.
+
+    Surfaced in Beheer > Systeem so operators can see at a glance whether the
+    worker process is alive without trailing container logs.
+    """
+    now = datetime.now(UTC)
+    rows = (
+        (await db.execute(select(WorkerHeartbeat).order_by(WorkerHeartbeat.loop_name)))
+        .scalars()
+        .all()
+    )
+    by_name = {row.loop_name: row for row in rows}
+
+    out: list[WorkerHeartbeatResponse] = []
+    for name in _EXPECTED_LOOPS:
+        cadence = _WORKER_EXPECTED_CADENCE_SEC[name]
+        row = by_name.get(name)
+        if row is None:
+            out.append(
+                WorkerHeartbeatResponse(
+                    loop_name=name,
+                    status="never_started",
+                    detail="No heartbeat row — worker process never reached this loop",
+                    last_tick_at=None,
+                    started_at=None,
+                    seconds_since_last_tick=None,
+                    health="down",
+                )
+            )
+            continue
+        last = row.last_tick_at
+        if last.tzinfo is None:
+            last = last.replace(tzinfo=UTC)
+        seconds_since = (now - last).total_seconds()
+        out.append(
+            WorkerHeartbeatResponse(
+                loop_name=row.loop_name,
+                status=row.status,
+                detail=row.detail,
+                last_tick_at=last,
+                started_at=row.started_at.replace(tzinfo=UTC)
+                if row.started_at.tzinfo is None
+                else row.started_at,
+                seconds_since_last_tick=seconds_since,
+                health=_classify_health(row.status, seconds_since, cadence),
+            )
+        )
+
+    # Surface any unexpected loop names too — future-proofing if someone adds
+    # a loop without updating _EXPECTED_LOOPS.
+    for name, row in by_name.items():
+        if name in _EXPECTED_LOOPS:
+            continue
+        last = row.last_tick_at
+        if last.tzinfo is None:
+            last = last.replace(tzinfo=UTC)
+        seconds_since = (now - last).total_seconds()
+        out.append(
+            WorkerHeartbeatResponse(
+                loop_name=row.loop_name,
+                status=row.status,
+                detail=row.detail,
+                last_tick_at=last,
+                started_at=row.started_at.replace(tzinfo=UTC)
+                if row.started_at.tzinfo is None
+                else row.started_at,
+                seconds_since_last_tick=seconds_since,
+                health=_classify_health(row.status, seconds_since, 300.0),
+            )
+        )
+
+    return WorkerHealthResponse(workers=out, server_now=now)

--- a/backend/bouwmeester/migrations/versions/a8c2f4b1e9d3_add_worker_heartbeat.py
+++ b/backend/bouwmeester/migrations/versions/a8c2f4b1e9d3_add_worker_heartbeat.py
@@ -1,0 +1,56 @@
+"""add worker_heartbeat table
+
+Revision ID: a8c2f4b1e9d3
+Revises: 1fe90cecedd9
+Create Date: 2026-05-06 22:00:00.000000
+
+Per worker-loop een rij met laatste tick-tijd en status, zodat de admin-UI
+kan tonen of de loops draaien zonder dat operators in container-logs hoeven
+te graven.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "a8c2f4b1e9d3"
+down_revision: str | None = "1fe90cecedd9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "worker_heartbeat",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("loop_name", sa.String(), nullable=False),
+        sa.Column(
+            "status", sa.String(), nullable=False, server_default=sa.text("'ok'")
+        ),
+        sa.Column("detail", sa.String(), nullable=True),
+        sa.Column(
+            "last_tick_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "started_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("loop_name", name="uq_worker_heartbeat_loop_name"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("worker_heartbeat")

--- a/backend/bouwmeester/models/__init__.py
+++ b/backend/bouwmeester/models/__init__.py
@@ -79,6 +79,7 @@ from bouwmeester.models.tag import LeadTag, NodeTag, Tag  # noqa: F401
 from bouwmeester.models.task import Task  # noqa: F401
 from bouwmeester.models.webauthn_credential import WebAuthnCredential  # noqa: F401
 from bouwmeester.models.whitelist_email import WhitelistEmail  # noqa: F401
+from bouwmeester.models.worker_heartbeat import WorkerHeartbeat  # noqa: F401
 
 __all__ = [
     "AccessRequest",
@@ -148,4 +149,5 @@ __all__ = [
     "Task",
     "WebAuthnCredential",
     "WhitelistEmail",
+    "WorkerHeartbeat",
 ]

--- a/backend/bouwmeester/models/worker_heartbeat.py
+++ b/backend/bouwmeester/models/worker_heartbeat.py
@@ -1,0 +1,35 @@
+"""WorkerHeartbeat model — last-tick registry for background worker loops.
+
+Each loop in ``bouwmeester.worker`` (parlementair, mattermost-link,
+mattermost-websocket, opdracht-task, fcc-sync) writes a row here on every
+iteration. The admin UI reads it to answer "is the worker alive?" without
+forcing operators to dig through container logs.
+"""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, String, func, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from bouwmeester.core.database import Base
+
+
+class WorkerHeartbeat(Base):
+    __tablename__ = "worker_heartbeat"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    loop_name: Mapped[str] = mapped_column(String, unique=True, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False, default="ok")
+    detail: Mapped[str | None] = mapped_column(String, nullable=True)
+    last_tick_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/bouwmeester/schema/__init__.py
+++ b/backend/bouwmeester/schema/__init__.py
@@ -289,6 +289,10 @@ from bouwmeester.schema.whitelist import (
     WhitelistEmailCreate,
     WhitelistEmailResponse,
 )
+from bouwmeester.schema.worker_health import (
+    WorkerHealthResponse,
+    WorkerHeartbeatResponse,
+)
 
 # Resolve forward references between corpus_node <-> edge schemas.
 CorpusNodeWithEdges.model_rebuild()
@@ -562,4 +566,7 @@ __all__ = [
     "WebAuthnCredentialResponse",
     "WhitelistEmailCreate",
     "WhitelistEmailResponse",
+    # worker_health
+    "WorkerHealthResponse",
+    "WorkerHeartbeatResponse",
 ]

--- a/backend/bouwmeester/schema/worker_health.py
+++ b/backend/bouwmeester/schema/worker_health.py
@@ -1,0 +1,26 @@
+"""Pydantic schemas for worker heartbeat/health endpoints."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class WorkerHeartbeatResponse(BaseModel):
+    """Status van één worker-loop, zoals getoond in Beheer > Systeem."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    loop_name: str
+    status: str
+    detail: str | None
+    last_tick_at: datetime | None
+    started_at: datetime | None
+    seconds_since_last_tick: float | None
+    health: str  # "healthy" | "stale" | "down" | "disabled"
+
+
+class WorkerHealthResponse(BaseModel):
+    """Aggregate response for ``GET /api/admin/workers``."""
+
+    workers: list[WorkerHeartbeatResponse]
+    server_now: datetime

--- a/backend/bouwmeester/services/mattermost_websocket_service.py
+++ b/backend/bouwmeester/services/mattermost_websocket_service.py
@@ -29,6 +29,7 @@ from bouwmeester.services.mattermost_service import (
     _load_mattermost_config,
     _validate_mattermost_url,
 )
+from bouwmeester.services.worker_health import tick as health_tick
 
 logger = logging.getLogger(__name__)
 
@@ -100,6 +101,11 @@ class MattermostWebsocketService:
                     config = await _load_mattermost_config(bootstrap)
                 enabled = (config.get("MATTERMOST_ENABLED") or "").lower()
                 if enabled in ("", "false", "0"):
+                    await health_tick(
+                        "mattermost_websocket",
+                        status="disabled",
+                        detail="MATTERMOST_ENABLED is false",
+                    )
                     await asyncio.sleep(_RECONNECT_BACKOFF_MAX)
                     continue
 
@@ -107,6 +113,11 @@ class MattermostWebsocketService:
                 token = config.get("MATTERMOST_BOT_TOKEN", "")
                 if not http_url or not token:
                     logger.debug("Mattermost niet geconfigureerd, skip websocket-loop")
+                    await health_tick(
+                        "mattermost_websocket",
+                        status="disabled",
+                        detail="MATTERMOST_URL or token missing",
+                    )
                     await asyncio.sleep(_RECONNECT_BACKOFF_MAX)
                     continue
 
@@ -122,15 +133,25 @@ class MattermostWebsocketService:
                     connected_at = time.monotonic()
                     await self._authenticate(ws, token)
                     await self._resolve_bot_user_id()
+                    await health_tick(
+                        "mattermost_websocket",
+                        status="connected",
+                        detail=f"connected to {ws_url}",
+                    )
                     await self._recover_missed_posts()
                     await self._read_loop(ws)
                     backoff = _RECONNECT_BACKOFF_BASE
             except asyncio.CancelledError:
                 logger.info("Mattermost websocket: loop cancelled")
                 raise
-            except Exception:
+            except Exception as exc:
                 logger.exception(
                     "Mattermost websocket: error, reconnect in %.1fs", backoff
+                )
+                await health_tick(
+                    "mattermost_websocket",
+                    status="reconnecting",
+                    detail=f"{type(exc).__name__}: {exc!s}"[:500],
                 )
 
             if self._stop:
@@ -194,6 +215,7 @@ class MattermostWebsocketService:
 
     async def _read_loop(self, ws) -> None:
         last_activity = time.monotonic()
+        last_heartbeat = 0.0
         while not self._stop:
             try:
                 raw = await asyncio.wait_for(ws.recv(), timeout=_HEARTBEAT_INTERVAL)
@@ -204,6 +226,16 @@ class MattermostWebsocketService:
                 # bij langdurige stilte (>2x interval) breken we de connectie.
                 if time.monotonic() - last_activity > _HEARTBEAT_INTERVAL * 2:
                     raise RuntimeError("Mattermost websocket: idle timeout")
+                # Idle but still under threshold — refresh the heartbeat row
+                # so the admin UI can distinguish "connected, just quiet" from
+                # "connected then died". Once per minute is plenty.
+                if time.monotonic() - last_heartbeat > 60.0:
+                    last_heartbeat = time.monotonic()
+                    await health_tick(
+                        "mattermost_websocket",
+                        status="connected",
+                        detail="idle (no events)",
+                    )
                 continue
 
             try:
@@ -211,6 +243,13 @@ class MattermostWebsocketService:
             except json.JSONDecodeError:
                 continue
             await self._dispatch(msg)
+            if time.monotonic() - last_heartbeat > 60.0:
+                last_heartbeat = time.monotonic()
+                await health_tick(
+                    "mattermost_websocket",
+                    status="connected",
+                    detail=f"last event: {msg.get('event', '?')}",
+                )
 
     async def _dispatch(self, msg: dict) -> None:
         event = msg.get("event")

--- a/backend/bouwmeester/services/worker_health.py
+++ b/backend/bouwmeester/services/worker_health.py
@@ -1,0 +1,65 @@
+"""Worker-heartbeat helpers.
+
+Background loops in :mod:`bouwmeester.worker` (and the long-lived Mattermost
+websocket service) call :func:`tick` to record they are alive. The admin
+``/api/admin/workers`` endpoint reads the table to surface status in the UI.
+
+Each loop owns one row, keyed on ``loop_name``. Writes are upserts so the
+worker doesn't need a separate "init" step. Heartbeats are best-effort: a
+DB failure here must never crash the loop.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bouwmeester.core.database import async_session
+from bouwmeester.models.worker_heartbeat import WorkerHeartbeat
+
+logger = logging.getLogger(__name__)
+
+
+async def tick(
+    loop_name: str,
+    *,
+    status: str = "ok",
+    detail: str | None = None,
+) -> None:
+    """Record a heartbeat for ``loop_name``. Best-effort: errors are logged
+    and swallowed so a flaky DB never kills a worker loop."""
+    try:
+        async with async_session() as session:
+            await _upsert(session, loop_name, status=status, detail=detail)
+            await session.commit()
+    except Exception:
+        logger.exception("worker_health.tick failed for %s", loop_name)
+
+
+async def _upsert(
+    session: AsyncSession,
+    loop_name: str,
+    *,
+    status: str,
+    detail: str | None,
+) -> None:
+    now = datetime.now(UTC)
+    stmt = insert(WorkerHeartbeat).values(
+        loop_name=loop_name,
+        status=status,
+        detail=detail,
+        last_tick_at=now,
+        started_at=now,
+    )
+    stmt = stmt.on_conflict_do_update(
+        index_elements=[WorkerHeartbeat.loop_name],
+        set_={
+            "status": stmt.excluded.status,
+            "detail": stmt.excluded.detail,
+            "last_tick_at": stmt.excluded.last_tick_at,
+        },
+    )
+    await session.execute(stmt)

--- a/backend/bouwmeester/worker.py
+++ b/backend/bouwmeester/worker.py
@@ -3,11 +3,19 @@ and polling Mattermost for link codes."""
 
 import asyncio
 import logging
+import os
 import time
+import traceback
 from collections import OrderedDict
 
 from bouwmeester.core.config import get_settings
 from bouwmeester.core.database import async_session
+from bouwmeester.services.worker_health import tick as health_tick
+
+# Force unbuffered stdout/stderr so log lines surface in container logs
+# immediately (without this, Python buffers stdout when not a TTY and
+# operators see nothing until the buffer fills or the process exits).
+os.environ.setdefault("PYTHONUNBUFFERED", "1")
 
 logging.basicConfig(
     level=logging.INFO,
@@ -16,8 +24,15 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
+def _short_error(exc: BaseException) -> str:
+    """One-line summary of an exception for the heartbeat detail field."""
+    tb = traceback.format_exception_only(type(exc), exc)
+    return "".join(tb).strip()[:500]
+
+
 async def _parlementair_loop(settings) -> None:  # type: ignore[no-untyped-def]
     """Poll TK/EK APIs for parliamentary items."""
+    await health_tick("parlementair", status="starting")
     while True:
         try:
             async with async_session() as session:
@@ -28,8 +43,10 @@ async def _parlementair_loop(settings) -> None:  # type: ignore[no-untyped-def]
                 service = ParlementairImportService(session)
                 count = await service.poll_and_import()
                 logger.info(f"Import cycle complete: {count} items imported")
-        except Exception:
+            await health_tick("parlementair", detail=f"{count} items imported")
+        except Exception as exc:
             logger.exception("Error in parlementair import cycle")
+            await health_tick("parlementair", status="error", detail=_short_error(exc))
 
         await asyncio.sleep(settings.TK_POLL_INTERVAL_SECONDS)
 
@@ -45,6 +62,7 @@ async def _mattermost_link_loop(settings) -> None:  # type: ignore[no-untyped-de
     # OrderedDict preserves insertion order for correct eviction.
     seen_post_ids: OrderedDict[str, None] = OrderedDict()
 
+    await health_tick("mattermost_link", status="starting")
     while True:
         mm = None
         try:
@@ -58,6 +76,11 @@ async def _mattermost_link_loop(settings) -> None:  # type: ignore[no-untyped-de
                     if started:
                         logger.info("Mattermost integration disabled, pausing poller")
                         started = False
+                    await health_tick(
+                        "mattermost_link",
+                        status="disabled",
+                        detail="MATTERMOST_ENABLED is false",
+                    )
                     await asyncio.sleep(settings.MATTERMOST_POLL_INTERVAL_SECONDS)
                     continue
 
@@ -91,8 +114,14 @@ async def _mattermost_link_loop(settings) -> None:  # type: ignore[no-untyped-de
                     seen_post_ids.popitem(last=False)
 
                 await session.commit()
-        except Exception:
+            await health_tick(
+                "mattermost_link", detail=f"{len(new_posts)} new dm posts"
+            )
+        except Exception as exc:
             logger.exception("Error in Mattermost link poll cycle")
+            await health_tick(
+                "mattermost_link", status="error", detail=_short_error(exc)
+            )
         finally:
             if mm:
                 await mm.close()
@@ -102,6 +131,7 @@ async def _mattermost_link_loop(settings) -> None:  # type: ignore[no-untyped-de
 
 async def _opdracht_task_loop(settings) -> None:  # type: ignore[no-untyped-def]
     """Daily check for deadline-approaching and budget-preparation tasks."""
+    await health_tick("opdracht_task", status="starting")
     while True:
         try:
             async with async_session() as session:
@@ -117,14 +147,20 @@ async def _opdracht_task_loop(settings) -> None:  # type: ignore[no-untyped-def]
                     f"Opdracht task cycle complete: "
                     f"{deadline_count} deadline, {budget_count} budget tasks"
                 )
-        except Exception:
+            await health_tick(
+                "opdracht_task",
+                detail=f"{deadline_count} deadline, {budget_count} budget",
+            )
+        except Exception as exc:
             logger.exception("Error in opdracht task cycle")
+            await health_tick("opdracht_task", status="error", detail=_short_error(exc))
 
         await asyncio.sleep(settings.OPDRACHT_TASK_INTERVAL_SECONDS)
 
 
 async def _fcc_sync_loop(settings) -> None:  # type: ignore[no-untyped-def]
     """Bidirectional sync with Fortes Change Cloud."""
+    await health_tick("fcc_sync", status="starting")
     while True:
         try:
             async with async_session() as session:
@@ -138,6 +174,11 @@ async def _fcc_sync_loop(settings) -> None:  # type: ignore[no-untyped-def]
                 )
                 entry = result.scalar_one_or_none()
                 if not entry or decrypt_value(entry.value) != "true":
+                    await health_tick(
+                        "fcc_sync",
+                        status="disabled",
+                        detail="FCC_SYNC_ENABLED is false",
+                    )
                     await asyncio.sleep(settings.FCC_POLL_INTERVAL_SECONDS)
                     continue
 
@@ -180,8 +221,13 @@ async def _fcc_sync_loop(settings) -> None:  # type: ignore[no-untyped-def]
                             )
                     except Exception:
                         logger.exception("Error in contact matching after FCC sync")
-        except Exception:
+            await health_tick(
+                "fcc_sync",
+                detail=f"{pull_count} pulled, {push_count} pushed",
+            )
+        except Exception as exc:
             logger.exception("Error in FCC sync cycle")
+            await health_tick("fcc_sync", status="error", detail=_short_error(exc))
 
         await asyncio.sleep(settings.FCC_POLL_INTERVAL_SECONDS)
 
@@ -192,6 +238,7 @@ async def _mattermost_websocket_loop(settings) -> None:  # type: ignore[no-untyp
     Service heeft eigen reconnect/backoff binnen ``run()``. Deze loop vangt
     alleen onverwachte exceptions op en herstart dan na een korte pauze.
     """
+    await health_tick("mattermost_websocket", status="starting")
     while True:
         try:
             from bouwmeester.services.mattermost_websocket_service import (
@@ -200,8 +247,13 @@ async def _mattermost_websocket_loop(settings) -> None:  # type: ignore[no-untyp
 
             service = MattermostWebsocketService()
             await service.run()
-        except Exception:
+            # run() only returns when stop() is called from the outside.
+            await health_tick("mattermost_websocket", status="stopped")
+        except Exception as exc:
             logger.exception("Mattermost websocket loop crashed, restart in 5s")
+            await health_tick(
+                "mattermost_websocket", status="error", detail=_short_error(exc)
+            )
         await asyncio.sleep(5)
 
 

--- a/backend/bouwmeester/worker.py
+++ b/backend/bouwmeester/worker.py
@@ -3,7 +3,6 @@ and polling Mattermost for link codes."""
 
 import asyncio
 import logging
-import os
 import time
 import traceback
 from collections import OrderedDict
@@ -12,10 +11,10 @@ from bouwmeester.core.config import get_settings
 from bouwmeester.core.database import async_session
 from bouwmeester.services.worker_health import tick as health_tick
 
-# Force unbuffered stdout/stderr so log lines surface in container logs
-# immediately (without this, Python buffers stdout when not a TTY and
-# operators see nothing until the buffer fills or the process exits).
-os.environ.setdefault("PYTHONUNBUFFERED", "1")
+# Note on stdout buffering: PYTHONUNBUFFERED=1 lives in the Dockerfile and
+# entrypoint.sh runs us with `python -u`. Setting it from inside Python is
+# pointless (the runtime reads the env var at startup, before this module
+# runs).
 
 logging.basicConfig(
     level=logging.INFO,

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -30,10 +30,13 @@ echo "Worker PID=$WORKER_PID"
 # If the worker dies, log it loudly so the cause is visible in container
 # logs instead of failing silently. We don't restart from here — Beheer >
 # Systeem now surfaces the loop status, so the right fix is operator-driven.
+# `kill -0` polling works across shells (busybox sh, dash, bash) where
+# `wait` on a non-direct-child can fail.
 (
-    wait "$WORKER_PID"
-    rc=$?
-    echo "[entrypoint] WORKER EXITED rc=$rc — Mattermost meelezen, FCC sync, parlementair-import en opdracht-taken zijn nu uit. Zie Beheer > Systeem."
+    while kill -0 "$WORKER_PID" 2>/dev/null; do
+        sleep 30
+    done
+    echo "[entrypoint] WORKER PID $WORKER_PID EXITED — Mattermost meelezen, FCC sync, parlementair-import en opdracht-taken zijn nu uit. Zie Beheer > Systeem."
 ) &
 
 echo "Starting uvicorn..."

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -20,8 +20,21 @@ rm -f /data/bijlagen/chat/.write_test_$$ 2>/dev/null || true
 echo "Running database migrations..."
 alembic upgrade head
 
-echo "Starting parlementair import worker..."
-python -m bouwmeester.worker &
+echo "Starting background worker..."
+# `-u` forces unbuffered stdout/stderr so worker logs surface immediately
+# in container logs, even before the buffer would normally flush.
+python -u -m bouwmeester.worker &
+WORKER_PID=$!
+echo "Worker PID=$WORKER_PID"
+
+# If the worker dies, log it loudly so the cause is visible in container
+# logs instead of failing silently. We don't restart from here — Beheer >
+# Systeem now surfaces the loop status, so the right fix is operator-driven.
+(
+    wait "$WORKER_PID"
+    rc=$?
+    echo "[entrypoint] WORKER EXITED rc=$rc — Mattermost meelezen, FCC sync, parlementair-import en opdracht-taken zijn nu uit. Zie Beheer > Systeem."
+) &
 
 echo "Starting uvicorn..."
 exec uvicorn bouwmeester.core.app:create_app --factory --host 0.0.0.0 --port 8080 --proxy-headers --forwarded-allow-ips='127.0.0.1'

--- a/backend/tests/test_worker_health.py
+++ b/backend/tests/test_worker_health.py
@@ -1,0 +1,116 @@
+"""Tests for worker-health upsert and the /api/admin/workers classifier."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+
+from bouwmeester.api.routes.admin import _classify_health
+from bouwmeester.models.worker_heartbeat import WorkerHeartbeat
+from bouwmeester.services.worker_health import _upsert
+
+
+class TestClassifyHealth:
+    """The classifier maps (status, age, cadence) to a UI bucket."""
+
+    def test_recent_ok_is_healthy(self):
+        assert (
+            _classify_health("ok", seconds_since=10, expected_cadence=60) == "healthy"
+        )
+
+    def test_disabled_short_circuits(self):
+        # Even with a stale tick, "disabled" stays disabled.
+        assert (
+            _classify_health("disabled", seconds_since=99999, expected_cadence=60)
+            == "disabled"
+        )
+
+    def test_slightly_late_is_stale(self):
+        assert _classify_health("ok", seconds_since=120, expected_cadence=60) == "stale"
+
+    def test_very_late_is_down(self):
+        assert _classify_health("ok", seconds_since=300, expected_cadence=60) == "down"
+
+    def test_error_status_marks_stale_even_when_recent(self):
+        # We tick on error, so the row is fresh; surface it as stale not
+        # healthy so operators see something is off.
+        assert (
+            _classify_health("error", seconds_since=5, expected_cadence=60) == "stale"
+        )
+
+    def test_reconnecting_marks_stale(self):
+        assert (
+            _classify_health("reconnecting", seconds_since=5, expected_cadence=60)
+            == "stale"
+        )
+
+
+@pytest.mark.asyncio
+class TestUpsert:
+    """`_upsert` writes a row on first call and updates it on subsequent calls."""
+
+    async def test_first_tick_creates_row(self, db_session):
+        await _upsert(db_session, "test_loop", status="ok", detail="first")
+        row = (
+            await db_session.execute(
+                select(WorkerHeartbeat).where(WorkerHeartbeat.loop_name == "test_loop")
+            )
+        ).scalar_one()
+        assert row.status == "ok"
+        assert row.detail == "first"
+        assert row.started_at is not None
+
+    async def test_second_tick_updates_in_place(self, db_session):
+        await _upsert(db_session, "test_loop", status="starting", detail=None)
+        first = (
+            await db_session.execute(
+                select(WorkerHeartbeat).where(WorkerHeartbeat.loop_name == "test_loop")
+            )
+        ).scalar_one()
+        first_id = first.id
+        first_started = first.started_at
+
+        await _upsert(db_session, "test_loop", status="ok", detail="cycle complete")
+        # Drop identity-map cache — the upsert ran via raw SQL so the
+        # ORM doesn't know the row's status field changed.
+        db_session.expire_all()
+        second = (
+            await db_session.execute(
+                select(WorkerHeartbeat).where(WorkerHeartbeat.loop_name == "test_loop")
+            )
+        ).scalar_one()
+        # Same row (id stable, started_at preserved); status/detail/last_tick updated.
+        assert second.id == first_id
+        assert second.started_at == first_started
+        assert second.status == "ok"
+        assert second.detail == "cycle complete"
+
+    async def test_tick_advances_last_tick_at(self, db_session):
+        await _upsert(db_session, "test_loop", status="ok", detail=None)
+        first = (
+            await db_session.execute(
+                select(WorkerHeartbeat).where(WorkerHeartbeat.loop_name == "test_loop")
+            )
+        ).scalar_one()
+        first_tick = first.last_tick_at
+
+        await _upsert(db_session, "test_loop", status="ok", detail="next")
+        db_session.expire_all()
+        second = (
+            await db_session.execute(
+                select(WorkerHeartbeat).where(WorkerHeartbeat.loop_name == "test_loop")
+            )
+        ).scalar_one()
+        # last_tick should not move backwards; on a fast machine two ticks
+        # may share a microsecond, so we just assert non-decreasing.
+        a = first_tick if first_tick.tzinfo else first_tick.replace(tzinfo=UTC)
+        b = (
+            second.last_tick_at
+            if second.last_tick_at.tzinfo
+            else second.last_tick_at.replace(tzinfo=UTC)
+        )
+        assert b >= a
+        # And the gap to "now" is small (we just wrote it).
+        assert (datetime.now(UTC) - b) < timedelta(seconds=10)

--- a/frontend/src/components/admin/SystemInfo.tsx
+++ b/frontend/src/components/admin/SystemInfo.tsx
@@ -1,5 +1,6 @@
 import { AlertTriangle, ExternalLink } from 'lucide-react';
 import { useVersionInfo } from '@/hooks/useAdmin';
+import { WorkerHealthTable } from './WorkerHealthTable';
 
 const FRONTEND_GIT_SHA = (import.meta.env.VITE_GIT_SHA ?? '') as string;
 const FRONTEND_BUILD_TIME = (import.meta.env.VITE_BUILD_TIME ?? '') as string;
@@ -51,11 +52,12 @@ export function SystemInfo() {
   const drift = backendSha && FRONTEND_GIT_SHA && backendSha !== FRONTEND_GIT_SHA;
 
   return (
-    <div className="space-y-6 max-w-2xl">
+    <div className="space-y-8 max-w-3xl">
       <div>
         <h2 className="text-lg font-semibold mb-1">Systeem</h2>
         <p className="text-sm text-text-secondary">
-          Welke versie van Bouwmeester draait er nu in deze omgeving.
+          Welke versie van Bouwmeester draait er nu, en zijn de
+          achtergrondprocessen gezond.
         </p>
       </div>
 
@@ -91,6 +93,8 @@ export function SystemInfo() {
           </dl>
         </>
       )}
+
+      <WorkerHealthTable />
     </div>
   );
 }

--- a/frontend/src/components/admin/WorkerHealthTable.tsx
+++ b/frontend/src/components/admin/WorkerHealthTable.tsx
@@ -1,0 +1,147 @@
+import { CheckCircle2, AlertTriangle, XCircle, MinusCircle } from 'lucide-react';
+import { useWorkerHealth, type WorkerHealth, type WorkerHeartbeat } from '@/hooks/useAdmin';
+
+const LOOP_LABELS: Record<string, string> = {
+  parlementair: 'Parlementaire import',
+  mattermost_link: 'Mattermost: account-koppeling (DM-poller)',
+  mattermost_websocket: 'Mattermost: meelezen in kanalen (websocket)',
+  opdracht_task: 'Opdracht-taken (deadlines, budget)',
+  fcc_sync: 'Fortes Change Cloud sync',
+};
+
+function formatAge(seconds: number | null): string {
+  if (seconds === null) return '–';
+  if (seconds < 90) return `${Math.round(seconds)}s geleden`;
+  if (seconds < 3600) return `${Math.round(seconds / 60)} min geleden`;
+  if (seconds < 86400) return `${Math.round(seconds / 3600)} uur geleden`;
+  return `${Math.round(seconds / 86400)} dagen geleden`;
+}
+
+function HealthBadge({ health }: { health: WorkerHealth }) {
+  const config: Record<WorkerHealth, { Icon: typeof CheckCircle2; cls: string; label: string }> = {
+    healthy: {
+      Icon: CheckCircle2,
+      cls: 'bg-green-100 text-green-800 border-green-200',
+      label: 'Draait',
+    },
+    stale: {
+      Icon: AlertTriangle,
+      cls: 'bg-amber-100 text-amber-900 border-amber-200',
+      label: 'Vertraagd',
+    },
+    down: {
+      Icon: XCircle,
+      cls: 'bg-red-100 text-red-800 border-red-200',
+      label: 'Niet actief',
+    },
+    disabled: {
+      Icon: MinusCircle,
+      cls: 'bg-gray-100 text-gray-700 border-gray-200',
+      label: 'Uitgeschakeld',
+    },
+  };
+  const { Icon, cls, label } = config[health];
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium ${cls}`}
+    >
+      <Icon className="h-3.5 w-3.5" />
+      {label}
+    </span>
+  );
+}
+
+function WorkerRow({ worker }: { worker: WorkerHeartbeat }) {
+  const label = LOOP_LABELS[worker.loop_name] ?? worker.loop_name;
+  return (
+    <tr className="border-t border-border align-top">
+      <td className="py-2 pr-4">
+        <div className="font-medium">{label}</div>
+        <div className="font-mono text-xs text-text-secondary">{worker.loop_name}</div>
+      </td>
+      <td className="py-2 pr-4">
+        <HealthBadge health={worker.health} />
+      </td>
+      <td className="py-2 pr-4 text-sm">{formatAge(worker.seconds_since_last_tick)}</td>
+      <td className="py-2 pr-4 text-sm text-text-secondary">
+        {worker.status === 'never_started' ? (
+          <span className="text-red-700">Nooit gestart</span>
+        ) : (
+          worker.status
+        )}
+        {worker.detail ? (
+          <div className="mt-0.5 text-xs text-text-secondary">{worker.detail}</div>
+        ) : null}
+      </td>
+    </tr>
+  );
+}
+
+export function WorkerHealthTable() {
+  const { data, isLoading, error } = useWorkerHealth();
+
+  if (isLoading) {
+    return <div className="text-sm text-text-secondary">Workers laden…</div>;
+  }
+  if (error) {
+    return (
+      <div className="text-sm text-red-700">
+        Kon worker-status niet ophalen.
+      </div>
+    );
+  }
+  if (!data || data.workers.length === 0) {
+    return (
+      <div className="text-sm text-text-secondary">
+        Geen worker-data beschikbaar.
+      </div>
+    );
+  }
+
+  const anyDown = data.workers.some((w) => w.health === 'down');
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <h3 className="text-base font-semibold">Achtergrondprocessen</h3>
+        <p className="text-sm text-text-secondary">
+          De worker draait naast de webserver en doet polling, sync en de
+          Mattermost-websocket. Elke loop schrijft hier een hartslag.
+        </p>
+      </div>
+
+      {anyDown ? (
+        <div className="flex items-start gap-2 rounded-md border border-red-300 bg-red-50 p-3 text-sm text-red-900">
+          <XCircle className="h-4 w-4 mt-0.5 shrink-0" />
+          <div>
+            Een of meer worker-loops draaien niet. Functionaliteit zoals
+            Mattermost-meelezen of FCC-sync werkt nu mogelijk niet. Check de
+            container-logs voor de oorzaak.
+          </div>
+        </div>
+      ) : null}
+
+      <div className="overflow-x-auto">
+        <table className="w-full text-left">
+          <thead>
+            <tr className="text-xs uppercase tracking-wide text-text-secondary">
+              <th className="py-2 pr-4 font-medium">Loop</th>
+              <th className="py-2 pr-4 font-medium">Status</th>
+              <th className="py-2 pr-4 font-medium">Laatste hartslag</th>
+              <th className="py-2 pr-4 font-medium">Detail</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.workers.map((w) => (
+              <WorkerRow key={w.loop_name} worker={w} />
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <p className="text-xs text-text-secondary">
+        Server-tijd: {new Date(data.server_now).toLocaleString('nl-NL')}. Auto-refresh elke 15 sec.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/hooks/queryKeys.ts
+++ b/frontend/src/hooks/queryKeys.ts
@@ -127,6 +127,7 @@ export const queryKeys = {
     eenheidRoleAssignments: (eenheidId: string | null) =>
       ['admin', 'eenheid-role-assignments', eenheidId] as const,
     version: () => ['admin', 'version'] as const,
+    workers: () => ['admin', 'workers'] as const,
   },
 
   // --- Org Placements ---

--- a/frontend/src/hooks/useAdmin.ts
+++ b/frontend/src/hooks/useAdmin.ts
@@ -100,3 +100,32 @@ export function useVersionInfo() {
     staleTime: 5 * 60 * 1000,
   });
 }
+
+// ---------------------------------------------------------------------------
+// Worker health
+// ---------------------------------------------------------------------------
+
+export type WorkerHealth = 'healthy' | 'stale' | 'down' | 'disabled';
+
+export interface WorkerHeartbeat {
+  loop_name: string;
+  status: string;
+  detail: string | null;
+  last_tick_at: string | null;
+  started_at: string | null;
+  seconds_since_last_tick: number | null;
+  health: WorkerHealth;
+}
+
+export interface WorkerHealthResponse {
+  workers: WorkerHeartbeat[];
+  server_now: string;
+}
+
+export function useWorkerHealth() {
+  return useQuery({
+    queryKey: queryKeys.admin.workers(),
+    queryFn: () => apiGet<WorkerHealthResponse>('/api/admin/workers'),
+    refetchInterval: 15_000,
+  });
+}


### PR DESCRIPTION
## Aanleiding

De Mattermost meelees-feature (PR #278) faalde stilletjes in productie:
geen notitie in een gekoppeld kanaal, geen log-regels, geen indicator in
de UI. Er was geen manier om te zien of de websocket draaide zonder in
container-logs te graven — en de worker-output bleek bovendien gebufferd,
dus tracebacks bij een crash kwamen niet door.

## Wat verandert er

**Heartbeat-tabel + admin-endpoint.** Elke loop in `bouwmeester.worker`
(parlementair, mattermost-link, mattermost-websocket, opdracht-task,
fcc-sync) tickt nu in `worker_heartbeat` bij start, na elke iteratie en
bij exception. `GET /api/admin/workers` leest die rijen en classificeert
ze als healthy / stale / down / disabled op basis van de verwachte
cadence per loop.

**Beheer > Systeem-uitbreiding.** De bestaande Systeem-pagina (versie/git
SHA) toont nu een tabel met per loop een status-badge, leeftijd van de
laatste hartslag en detail-tekst. Auto-refresh elke 15 sec. Bij een
"down"-loop verschijnt een rode banner.

**Mattermost-websocket meet ook de verbinding.** De websocket-service
zelf tickt nu op connect (`status=connected`), bij elke reconnect
(`status=reconnecting`) en periodiek tijdens idle. De UI maakt zo
onderscheid tussen "loop draait" en "websocket staat daadwerkelijk
verbonden".

**Logs zichtbaarder.** `PYTHONUNBUFFERED=1` in de Dockerfile en
`python -u -m bouwmeester.worker` in `entrypoint.sh` voorkomen dat de
worker-stdout in een buffer blijft hangen. Een `wait`-watcher achter de
worker echoot een duidelijke regel als het proces crasht, zodat
operators direct zien dat Mattermost-meelezen, FCC-sync, parlementair
en opdracht-taken stilliggen.

## Test plan

- [ ] `just reset-db && just up` — verifieer dat het `worker_heartbeat`
      record voor elke loop binnen een minuut verschijnt
- [ ] Open Beheer > Systeem; alle vijf de loops staan op "Draait" met
      een verse hartslag
- [ ] Stop de worker (`docker compose stop worker`) — binnen enkele
      minuten kleuren rijen oranje, en daarna rood, met een banner
- [ ] Mattermost: post in een gekoppeld kanaal en verifieer dat de
      "Mattermost: meelezen…"-rij detail toont met `last event: posted`
- [ ] `pytest backend/tests/test_worker_health.py` blijft groen