### PR TITLE
Fix Mattermost-websocket: behoud sub-pad in URL

### DIFF
--- a/backend/bouwmeester/services/mattermost_websocket_service.py
+++ b/backend/bouwmeester/services/mattermost_websocket_service.py
@@ -41,11 +41,17 @@ _BACKOFF_RESET_AFTER_HEALTHY_SEC = 120.0
 
 
 def _ws_url_from_http(http_url: str) -> str:
-    """Vervang het scheme zodat http(s) → ws(s) en plak `/api/v4/websocket`."""
+    """Vervang het scheme zodat http(s) → ws(s) en plak `/api/v4/websocket`.
+
+    Behoudt het pad uit ``http_url`` — Mattermost achter een reverse-proxy
+    op een sub-pad (bv. ``https://host/chat``) heeft de websocket-endpoint
+    op ``wss://host/chat/api/v4/websocket``. Zonder het pad krijg je een
+    HTTP 404 terug van de proxy.
+    """
     parsed = urlparse(http_url.rstrip("/"))
     scheme = "wss" if parsed.scheme == "https" else "ws"
-    netloc = parsed.netloc
-    return f"{scheme}://{netloc}/api/v4/websocket"
+    base_path = parsed.path.rstrip("/")
+    return f"{scheme}://{parsed.netloc}{base_path}/api/v4/websocket"
 
 
 async def disable_channel_link(

--- a/backend/tests/test_mattermost_websocket.py
+++ b/backend/tests/test_mattermost_websocket.py
@@ -18,8 +18,45 @@ from bouwmeester.services.mattermost_service import (
 )
 from bouwmeester.services.mattermost_websocket_service import (
     MattermostWebsocketService,
+    _ws_url_from_http,
     disable_channel_link,
 )
+
+
+class TestWsUrlFromHttp:
+    """The ws-URL builder must preserve any sub-path on the Mattermost host."""
+
+    def test_root_install(self):
+        assert (
+            _ws_url_from_http("https://mm.example.com")
+            == "wss://mm.example.com/api/v4/websocket"
+        )
+
+    def test_root_install_with_trailing_slash(self):
+        assert (
+            _ws_url_from_http("https://mm.example.com/")
+            == "wss://mm.example.com/api/v4/websocket"
+        )
+
+    def test_subpath_install(self):
+        # Mattermost achter reverse-proxy op /chat — het pad moet meegaan,
+        # anders krijgen we HTTP 404 van de proxy.
+        assert (
+            _ws_url_from_http("https://digilab.overheid.nl/chat")
+            == "wss://digilab.overheid.nl/chat/api/v4/websocket"
+        )
+
+    def test_subpath_install_with_trailing_slash(self):
+        assert (
+            _ws_url_from_http("https://digilab.overheid.nl/chat/")
+            == "wss://digilab.overheid.nl/chat/api/v4/websocket"
+        )
+
+    def test_http_becomes_ws(self):
+        assert (
+            _ws_url_from_http("http://localhost:8065")
+            == "ws://localhost:8065/api/v4/websocket"
+        )
 
 
 def _id() -> str:


### PR DESCRIPTION
## Aanleiding

Direct na de deploy van #292 toont Beheer > Systeem de oorzaak van het
hhnk-test-probleem:

```
mattermost_websocket → reconnecting
InvalidStatus: server rejected WebSocket connection: HTTP 404
```

`_ws_url_from_http` bouwde de URL met alleen scheme + netloc + suffix,
waardoor het pad-deel uit `MATTERMOST_URL` (in productie:
`https://digilab.overheid.nl/chat`) werd gestript. De connect-poging ging
naar `wss://digilab.overheid.nl/api/v4/websocket` en kreeg 404 van de
reverse-proxy.

De REST-client liep hier niet tegenaan omdat httpx het pad uit `base_url`
zelf meeneemt — alleen de websocket-helper bouwde de URL handmatig.

## Fix

`_ws_url_from_http` behoudt nu het pad. Vijf nieuwe tests pinnen het
gedrag voor root-installs, sub-pad-installs en met/zonder trailing slash.

## Test plan

- [ ] `pytest backend/tests/test_mattermost_websocket.py` blijft groen
- [ ] Na deploy: Beheer > Systeem toont `mattermost_websocket` op
      "Draait" met detail "connected to wss://digilab.overheid.nl/chat/api/v4/websocket"
- [ ] Post een testbericht in een gekoppeld kanaal en verifieer dat er
      een notitie verschijnt op de lead