### PR TITLE
Mattermost meelees-zichtbaarheid + websocket-ping

### DIFF
--- a/backend/bouwmeester/api/routes/admin.py
+++ b/backend/bouwmeester/api/routes/admin.py
@@ -19,6 +19,13 @@ from bouwmeester.core.query_utils import normalize_email
 from bouwmeester.core.whitelist import refresh_whitelist_cache, seed_admins_from_file
 from bouwmeester.models.access_request import AccessRequest
 from bouwmeester.models.app_config import AppConfig
+from bouwmeester.models.initiatief import Initiatief
+from bouwmeester.models.lead import Lead
+from bouwmeester.models.mattermost_channel_link import (
+    SCOPE_INITIATIEF,
+    SCOPE_LEAD,
+    MattermostChannelLink,
+)
 from bouwmeester.models.person import Person
 from bouwmeester.models.whitelist_email import WhitelistEmail
 from bouwmeester.models.worker_heartbeat import WorkerHeartbeat
@@ -40,6 +47,7 @@ from bouwmeester.schema.whitelist import (
     WhitelistEmailResponse,
 )
 from bouwmeester.schema.worker_health import (
+    MattermostChannelOverview,
     WorkerHealthResponse,
     WorkerHeartbeatResponse,
 )
@@ -872,3 +880,78 @@ async def workers_health(
         )
 
     return WorkerHealthResponse(workers=out, server_now=now)
+
+
+# ---------------------------------------------------------------------------
+# Mattermost channel overview
+# ---------------------------------------------------------------------------
+
+
+@router.get("/mattermost-channels", response_model=list[MattermostChannelOverview])
+async def mattermost_channel_overview(
+    admin: AdminUser,
+    db: AsyncSession = Depends(get_db),
+) -> list[MattermostChannelOverview]:
+    """Lijst alle gekoppelde Mattermost-kanalen met hun scope-label.
+
+    Beheer > Systeem gebruikt dit om in één oogopslag te zien naar welke
+    kanalen de bot meeleest en hoe lang het geleden is dat er een post is
+    binnengekomen.
+    """
+    rows = (
+        (
+            await db.execute(
+                select(MattermostChannelLink).order_by(
+                    MattermostChannelLink.disabled_at.is_(None).desc(),
+                    MattermostChannelLink.channel_display_name,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    # Bulk-resolve scope-labels in twee queries (1× per scope-type) ipv N+1.
+    lead_ids = [r.scope_id for r in rows if r.scope_type == SCOPE_LEAD]
+    init_ids = [r.scope_id for r in rows if r.scope_type == SCOPE_INITIATIEF]
+    lead_titles: dict[UUID, str] = {}
+    init_names: dict[UUID, str] = {}
+    if lead_ids:
+        result = await db.execute(
+            select(Lead.id, Lead.title).where(Lead.id.in_(lead_ids))
+        )
+        lead_titles = {r.id: r.title for r in result.all()}
+    if init_ids:
+        result = await db.execute(
+            select(Initiatief.id, Initiatief.naam).where(Initiatief.id.in_(init_ids))
+        )
+        init_names = {r.id: r.naam for r in result.all()}
+
+    out: list[MattermostChannelOverview] = []
+    for r in rows:
+        if r.scope_type == SCOPE_LEAD:
+            label = lead_titles.get(r.scope_id)
+        elif r.scope_type == SCOPE_INITIATIEF:
+            label = init_names.get(r.scope_id)
+        else:
+            label = None
+        last_seen = None
+        if r.last_seen_post_at is not None:
+            last_seen = datetime.fromtimestamp(r.last_seen_post_at / 1000.0, tz=UTC)
+        out.append(
+            MattermostChannelOverview(
+                id=r.id,
+                channel_id=r.channel_id,
+                channel_display_name=r.channel_display_name,
+                channel_name=r.channel_name,
+                scope_type=r.scope_type,
+                scope_id=r.scope_id,
+                scope_label=label,
+                auto_note_enabled=r.auto_note_enabled,
+                suggest_leads_enabled=r.suggest_leads_enabled,
+                last_seen_post_at=last_seen,
+                disabled_at=r.disabled_at,
+                created_at=r.created_at,
+            )
+        )
+    return out

--- a/backend/bouwmeester/schema/__init__.py
+++ b/backend/bouwmeester/schema/__init__.py
@@ -290,6 +290,7 @@ from bouwmeester.schema.whitelist import (
     WhitelistEmailResponse,
 )
 from bouwmeester.schema.worker_health import (
+    MattermostChannelOverview,
     WorkerHealthResponse,
     WorkerHeartbeatResponse,
 )
@@ -567,6 +568,7 @@ __all__ = [
     "WhitelistEmailCreate",
     "WhitelistEmailResponse",
     # worker_health
+    "MattermostChannelOverview",
     "WorkerHealthResponse",
     "WorkerHeartbeatResponse",
 ]

--- a/backend/bouwmeester/schema/worker_health.py
+++ b/backend/bouwmeester/schema/worker_health.py
@@ -1,6 +1,7 @@
 """Pydantic schemas for worker heartbeat/health endpoints."""
 
 from datetime import datetime
+from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict
 
@@ -24,3 +25,22 @@ class WorkerHealthResponse(BaseModel):
 
     workers: list[WorkerHeartbeatResponse]
     server_now: datetime
+
+
+class MattermostChannelOverview(BaseModel):
+    """Eén gekoppeld kanaal in Beheer > Systeem."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    channel_id: str
+    channel_display_name: str
+    channel_name: str
+    scope_type: str  # "lead" | "initiatief"
+    scope_id: UUID
+    scope_label: str | None
+    auto_note_enabled: bool
+    suggest_leads_enabled: bool
+    last_seen_post_at: datetime | None
+    disabled_at: datetime | None
+    created_at: datetime

--- a/backend/bouwmeester/services/mattermost_ingest_service.py
+++ b/backend/bouwmeester/services/mattermost_ingest_service.py
@@ -119,6 +119,10 @@ class MattermostIngestService:
                     post_id=post_id,
                     channel_id=channel_id,
                 )
+                # Subtiele bevestiging in Mattermost: oogje als reactie op
+                # het oorspronkelijke bericht. Faalt deze stap, dan is dat
+                # niet fataal — de note staat al.
+                await self._react(post_id, "eyes")
         elif (
             channel_link.scope_type == SCOPE_INITIATIEF
             and channel_link.suggest_leads_enabled
@@ -157,6 +161,23 @@ class MattermostIngestService:
         except IntegrityError:
             # Race-condition op unique post_id — andere worker was sneller.
             return
+
+        # Eén regel per verwerkte post in production logs zodat we
+        # kunnen zien waarom een note wel/niet ontstaat zonder DB-query.
+        outcome = (
+            f"note={lead_activity_id}"
+            if lead_activity_id
+            else f"suggested={suggested_lead_id}"
+            if suggested_lead_id
+            else f"skipped={skipped_reason or 'none'}"
+        )
+        logger.info(
+            "Ingest %s scope=%s/%s %s",
+            post_id,
+            channel_link.scope_type,
+            channel_link.scope_id,
+            outcome,
+        )
 
         # Bump last_seen_post_at zodat recovery na reconnect klopt.
         create_at = post.get("create_at")
@@ -464,3 +485,19 @@ class MattermostIngestService:
         if not self.mm_base_url:
             return None
         return f"{self.mm_base_url}/_redirect/pl/{post_id}"
+
+    async def _react(self, post_id: str, emoji_name: str) -> None:
+        """Plak een emoji-reactie op een Mattermost-post (best-effort)."""
+        from bouwmeester.services.mattermost_service import MattermostService
+
+        service = MattermostService(self.session)
+        try:
+            if not await service.is_enabled():
+                return
+            await service.add_reaction(post_id, emoji_name)
+        except Exception:
+            logger.exception(
+                "Kon reactie %s niet plaatsen op post %s", emoji_name, post_id
+            )
+        finally:
+            await service.close()

--- a/backend/bouwmeester/services/mattermost_ingest_service.py
+++ b/backend/bouwmeester/services/mattermost_ingest_service.py
@@ -119,10 +119,6 @@ class MattermostIngestService:
                     post_id=post_id,
                     channel_id=channel_id,
                 )
-                # Subtiele bevestiging in Mattermost: oogje als reactie op
-                # het oorspronkelijke bericht. Faalt deze stap, dan is dat
-                # niet fataal — de note staat al.
-                await self._react(post_id, "eyes")
         elif (
             channel_link.scope_type == SCOPE_INITIATIEF
             and channel_link.suggest_leads_enabled
@@ -183,6 +179,13 @@ class MattermostIngestService:
         create_at = post.get("create_at")
         if isinstance(create_at, int):
             await link_repo.update_last_seen(channel_link, create_at)
+
+        # Subtiele bevestiging in Mattermost: oogje op het oorspronkelijke
+        # bericht. Pas na de DB-write zodat een trage HTTP-call de ingest
+        # niet blokkeert. Faalt deze stap, dan is dat niet fataal — de
+        # note staat al.
+        if lead_activity_id is not None:
+            await self._react(post_id, "eyes")
 
     async def _is_noise(self, message: str) -> bool:
         """Vraag VLAM of dit een triviaal/ack-bericht is.

--- a/backend/bouwmeester/services/mattermost_service.py
+++ b/backend/bouwmeester/services/mattermost_service.py
@@ -479,6 +479,35 @@ class MattermostService:
             logger.exception("Failed to reply to post %s", root_id)
             return None
 
+    async def add_reaction(self, post_id: str, emoji_name: str) -> bool:
+        """Plak een reactie-emoji op een post.
+
+        Wordt door de ingest-service gebruikt om subtiel te bevestigen dat
+        een bericht is verwerkt. We hebben de bot-user-id nodig — de
+        Mattermost-API verwacht die in de payload, niet als query-param.
+        Returns ``True`` bij succes, ``False`` bij fout (geen retry).
+        """
+        bot_user_id = await self.get_bot_user_id()
+        if not bot_user_id:
+            return False
+        client = await self._get_client()
+        try:
+            resp = await client.post(
+                "/api/v4/reactions",
+                json={
+                    "user_id": bot_user_id,
+                    "post_id": post_id,
+                    "emoji_name": emoji_name,
+                },
+            )
+            resp.raise_for_status()
+            return True
+        except httpx.HTTPError:
+            logger.exception(
+                "Failed to add reaction %s to post %s", emoji_name, post_id
+            )
+            return False
+
     async def update_post(
         self, post_id: str, message: str, props: dict | None = None
     ) -> bool:

--- a/backend/bouwmeester/services/mattermost_websocket_service.py
+++ b/backend/bouwmeester/services/mattermost_websocket_service.py
@@ -257,13 +257,14 @@ class MattermostWebsocketService:
                 msg = json.loads(raw)
             except json.JSONDecodeError:
                 continue
+            event_name = msg.get("event") or msg.get("seq_reply") or "(unknown)"
             await self._dispatch(msg)
             if time.monotonic() - last_heartbeat > 60.0:
                 last_heartbeat = time.monotonic()
                 await health_tick(
                     "mattermost_websocket",
                     status="connected",
-                    detail=f"last event: {msg.get('event', '?')}",
+                    detail=f"last event: {event_name}",
                 )
 
     async def _dispatch(self, msg: dict) -> None:
@@ -292,6 +293,17 @@ class MattermostWebsocketService:
         channel_id = post.get("channel_id")
         if not post_id or not channel_id:
             return
+
+        # Hard signaal in productie-logs dat een bericht überhaupt is
+        # aangekomen via de websocket — voorkomt giswerk wanneer een note
+        # uitblijft. Korte regel zodat 'm niet snel uit het log-venster
+        # rolt door noise.
+        logger.info(
+            "Mattermost posted event: channel=%s post=%s len=%d",
+            channel_id,
+            post_id,
+            len(post.get("message") or ""),
+        )
 
         async with async_session() as session:
             try:

--- a/backend/bouwmeester/services/mattermost_websocket_service.py
+++ b/backend/bouwmeester/services/mattermost_websocket_service.py
@@ -133,8 +133,17 @@ class MattermostWebsocketService:
                 self._mm_base_url = http_url.rstrip("/")
                 ws_url = _ws_url_from_http(http_url)
                 logger.info("Mattermost websocket: connect %s", ws_url)
+                # Ping elke 20s — zonder pings sluit een reverse-proxy
+                # (zoals die voor digilab.overheid.nl) een idle websocket
+                # binnen ~1min met "ConnectionClosedError: no close frame".
+                # ping_timeout iets lager dan ons idle-timeout zodat een
+                # gemiste pong eerder een reconnect triggert dan de
+                # heartbeat-loop dat zou doen.
                 async with websockets.connect(
-                    ws_url, ping_interval=None, max_size=2 * 1024 * 1024
+                    ws_url,
+                    ping_interval=20,
+                    ping_timeout=20,
+                    max_size=2 * 1024 * 1024,
                 ) as ws:
                     connected_at = time.monotonic()
                     await self._authenticate(ws, token)

--- a/frontend/src/components/admin/MattermostChannelOverview.tsx
+++ b/frontend/src/components/admin/MattermostChannelOverview.tsx
@@ -1,0 +1,118 @@
+import { CheckCircle2, MinusCircle, XCircle } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import {
+  useMattermostChannelOverview,
+  type MattermostChannelOverview as Channel,
+} from '@/hooks/useAdmin';
+
+function formatRelative(iso: string | null): string {
+  if (!iso) return 'nog niets gezien';
+  const ms = Date.now() - new Date(iso).getTime();
+  if (ms < 60_000) return `${Math.round(ms / 1000)}s geleden`;
+  if (ms < 3_600_000) return `${Math.round(ms / 60_000)} min geleden`;
+  if (ms < 86_400_000) return `${Math.round(ms / 3_600_000)} uur geleden`;
+  return `${Math.round(ms / 86_400_000)} dagen geleden`;
+}
+
+function ScopeLink({ channel }: { channel: Channel }) {
+  const label = channel.scope_label ?? '(niet gevonden)';
+  const href =
+    channel.scope_type === 'lead'
+      ? `/leads/${channel.scope_id}`
+      : `/initiatieven/${channel.scope_id}`;
+  const prefix = channel.scope_type === 'lead' ? 'Lead' : 'Initiatief';
+  return (
+    <Link to={href} className="text-primary-700 hover:underline">
+      {prefix}: {label}
+    </Link>
+  );
+}
+
+function ChannelRow({ channel }: { channel: Channel }) {
+  return (
+    <tr className="border-t border-border align-top">
+      <td className="py-2 pr-4">
+        <div className="font-medium">#{channel.channel_display_name}</div>
+        <div className="font-mono text-xs text-text-secondary">{channel.channel_name}</div>
+      </td>
+      <td className="py-2 pr-4 text-sm">
+        <ScopeLink channel={channel} />
+      </td>
+      <td className="py-2 pr-4 text-sm">
+        {channel.disabled_at ? (
+          <span className="inline-flex items-center gap-1 text-red-700">
+            <XCircle className="h-3.5 w-3.5" /> Uitgeschakeld
+          </span>
+        ) : channel.auto_note_enabled || channel.suggest_leads_enabled ? (
+          <span className="inline-flex items-center gap-1 text-green-800">
+            <CheckCircle2 className="h-3.5 w-3.5" />
+            {channel.auto_note_enabled ? 'Notities' : ''}
+            {channel.auto_note_enabled && channel.suggest_leads_enabled ? ' + ' : ''}
+            {channel.suggest_leads_enabled ? 'Lead-suggesties' : ''}
+          </span>
+        ) : (
+          <span className="inline-flex items-center gap-1 text-text-secondary">
+            <MinusCircle className="h-3.5 w-3.5" /> Niets actief
+          </span>
+        )}
+      </td>
+      <td className="py-2 pr-4 text-sm text-text-secondary">
+        {formatRelative(channel.last_seen_post_at)}
+      </td>
+    </tr>
+  );
+}
+
+export function MattermostChannelOverviewTable() {
+  const { data, isLoading, error } = useMattermostChannelOverview();
+
+  if (isLoading) {
+    return <div className="text-sm text-text-secondary">Kanalen laden…</div>;
+  }
+  if (error) {
+    return (
+      <div className="text-sm text-red-700">Kon kanaaloverzicht niet ophalen.</div>
+    );
+  }
+  if (!data || data.length === 0) {
+    return (
+      <div className="space-y-2">
+        <h3 className="text-base font-semibold">Mattermost-kanalen</h3>
+        <p className="text-sm text-text-secondary">
+          Nog geen kanalen gekoppeld. Koppel er eentje vanuit een lead of
+          initiatief om hier een overzicht te zien.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <h3 className="text-base font-semibold">Mattermost-kanalen</h3>
+        <p className="text-sm text-text-secondary">
+          Gekoppelde kanalen waar de bot meeleest. "Laatste post" is de meest
+          recente verwerkte post; ontbreekt deze, dan is er sinds de koppeling
+          niets binnengekomen — of de websocket loopt niet.
+        </p>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full text-left">
+          <thead>
+            <tr className="text-xs uppercase tracking-wide text-text-secondary">
+              <th className="py-2 pr-4 font-medium">Kanaal</th>
+              <th className="py-2 pr-4 font-medium">Gekoppeld aan</th>
+              <th className="py-2 pr-4 font-medium">Modus</th>
+              <th className="py-2 pr-4 font-medium">Laatste post</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((c) => (
+              <ChannelRow key={c.id} channel={c} />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/admin/MattermostChannelOverview.tsx
+++ b/frontend/src/components/admin/MattermostChannelOverview.tsx
@@ -1,5 +1,4 @@
 import { CheckCircle2, MinusCircle, XCircle } from 'lucide-react';
-import { Link } from 'react-router-dom';
 import {
   useMattermostChannelOverview,
   type MattermostChannelOverview as Channel,
@@ -14,17 +13,13 @@ function formatRelative(iso: string | null): string {
   return `${Math.round(ms / 86_400_000)} dagen geleden`;
 }
 
-function ScopeLink({ channel }: { channel: Channel }) {
+function ScopeLabel({ channel }: { channel: Channel }) {
   const label = channel.scope_label ?? '(niet gevonden)';
-  const href =
-    channel.scope_type === 'lead'
-      ? `/leads/${channel.scope_id}`
-      : `/initiatieven/${channel.scope_id}`;
   const prefix = channel.scope_type === 'lead' ? 'Lead' : 'Initiatief';
   return (
-    <Link to={href} className="text-primary-700 hover:underline">
-      {prefix}: {label}
-    </Link>
+    <span>
+      <span className="text-text-secondary">{prefix}:</span> {label}
+    </span>
   );
 }
 
@@ -36,7 +31,7 @@ function ChannelRow({ channel }: { channel: Channel }) {
         <div className="font-mono text-xs text-text-secondary">{channel.channel_name}</div>
       </td>
       <td className="py-2 pr-4 text-sm">
-        <ScopeLink channel={channel} />
+        <ScopeLabel channel={channel} />
       </td>
       <td className="py-2 pr-4 text-sm">
         {channel.disabled_at ? (

--- a/frontend/src/components/admin/SystemInfo.tsx
+++ b/frontend/src/components/admin/SystemInfo.tsx
@@ -1,5 +1,6 @@
 import { AlertTriangle, ExternalLink } from 'lucide-react';
 import { useVersionInfo } from '@/hooks/useAdmin';
+import { MattermostChannelOverviewTable } from './MattermostChannelOverview';
 import { WorkerHealthTable } from './WorkerHealthTable';
 
 const FRONTEND_GIT_SHA = (import.meta.env.VITE_GIT_SHA ?? '') as string;
@@ -95,6 +96,8 @@ export function SystemInfo() {
       )}
 
       <WorkerHealthTable />
+
+      <MattermostChannelOverviewTable />
     </div>
   );
 }

--- a/frontend/src/hooks/queryKeys.ts
+++ b/frontend/src/hooks/queryKeys.ts
@@ -128,6 +128,7 @@ export const queryKeys = {
       ['admin', 'eenheid-role-assignments', eenheidId] as const,
     version: () => ['admin', 'version'] as const,
     workers: () => ['admin', 'workers'] as const,
+    mattermostChannels: () => ['admin', 'mattermost-channels'] as const,
   },
 
   // --- Org Placements ---

--- a/frontend/src/hooks/useAdmin.ts
+++ b/frontend/src/hooks/useAdmin.ts
@@ -129,3 +129,30 @@ export function useWorkerHealth() {
     refetchInterval: 15_000,
   });
 }
+
+// ---------------------------------------------------------------------------
+// Mattermost channel overview
+// ---------------------------------------------------------------------------
+
+export interface MattermostChannelOverview {
+  id: string;
+  channel_id: string;
+  channel_display_name: string;
+  channel_name: string;
+  scope_type: 'lead' | 'initiatief';
+  scope_id: string;
+  scope_label: string | null;
+  auto_note_enabled: boolean;
+  suggest_leads_enabled: boolean;
+  last_seen_post_at: string | null;
+  disabled_at: string | null;
+  created_at: string;
+}
+
+export function useMattermostChannelOverview() {
+  return useQuery({
+    queryKey: queryKeys.admin.mattermostChannels(),
+    queryFn: () => apiGet<MattermostChannelOverview[]>('/api/admin/mattermost-channels'),
+    refetchInterval: 30_000,
+  });
+}


### PR DESCRIPTION
## Aanleiding

Na #292 + #293 staat de Mattermost-websocket op groen, maar een
testbericht in `project-hhnk` leverde nog geen notitie op. "Last event:
?" in de heartbeat-detail bleef oningevuld én er was geen manier om in
de UI te zien naar welke kanalen de bot kijkt.

## Wat verandert er

**Ack-emoji op verwerkte berichten.** Na een succesvolle note plakt de
bot `:eyes:` op het oorspronkelijke Mattermost-bericht via een nieuwe
`MattermostService.add_reaction`. Faalt deze stap, dan is dat niet
fataal — de note staat al in Bouwmeester.

**Kanaaloverzicht in Beheer > Systeem.** Nieuw endpoint
`GET /api/admin/mattermost-channels` plus UI-tabel onder de Workers-
tabel. Toont per kanaal de scope (lead/initiatief), de modus
(`Notities` / `Lead-suggesties`), de tijd sinds de laatste verwerkte
post en een `disabled` indicator.

**Hard signaal in productie-logs.** Eén INFO-regel per binnenkomend
`posted`-event in de websocket-service en één per verwerkte post in de
ingest-service, met outcome (note / suggested / skipped=reden). Geen
DB-query meer nodig om te zien waarom een bericht niet als notitie
verschijnt.

**Websocket-ping aan.** `ping_interval=20, ping_timeout=20` voorkomt
dat een reverse-proxy (zoals voor digilab) een idle connectie sluit met
`ConnectionClosedError: no close frame received or sent`.

**`last event` detail-fix.** Toont nu `(unknown)` i.p.v. `?` als het
event-veld ontbreekt.

## Test plan

- [ ] `pytest backend/tests/test_mattermost_websocket.py backend/tests/test_mattermost_ingest.py backend/tests/test_worker_health.py` blijft groen
- [ ] Na deploy: Beheer > Systeem toont een rij voor `project-hhnk` met
      "Notities" en linkt naar de gekoppelde lead
- [ ] Post een testbericht in een gekoppeld kanaal — verwacht: `:eyes:`
      reactie verschijnt op het bericht én een note op de lead
- [ ] Productie-logs tonen `Mattermost posted event: channel=… post=… len=…`
      en `Ingest … note=…`