### PR TITLE
Toon auteur-naam op lead-activiteiten

### DIFF
--- a/backend/bouwmeester/schema/lead.py
+++ b/backend/bouwmeester/schema/lead.py
@@ -206,6 +206,26 @@ class LeadActivityResponse(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
+    @model_validator(mode="before")
+    @classmethod
+    def _fill_author_naam(cls, data: Any) -> Any:
+        # Vul ``author_naam`` uit de relationship als die mee-geladen is.
+        # Het ORM-object heeft geen `author_naam` kolom, dus zonder deze
+        # validator blijft het veld in de response altijd None — een
+        # latente bug die zichtbaar werd toen Mattermost-imports leidden
+        # tot notes zonder zichtbare auteur.
+        if hasattr(data, "author") and getattr(data, "author", None):
+            if not getattr(data, "author_naam", None):
+                # Pydantic v2 model_validator(before) geeft het ORM-object
+                # zelf — we zetten een attribuut zodat from_attributes het
+                # oppikt. Geen DB-write; deze instantie wordt na de
+                # response weggegooid.
+                try:
+                    data.author_naam = data.author.naam
+                except AttributeError:
+                    pass
+        return data
+
 
 # ---------------------------------------------------------------------------
 # Lead response (list) and detail response

--- a/backend/tests/test_lead_activity_response_author.py
+++ b/backend/tests/test_lead_activity_response_author.py
@@ -1,0 +1,55 @@
+"""Tests dat LeadActivityResponse de auteur-naam vult uit de relationship.
+
+Latente bug die zichtbaar werd toen Mattermost-imports leidden tot notes
+zonder zichtbare auteur in de UI: het schema-veld ``author_naam`` bestond,
+maar werd nergens gevuld.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+from bouwmeester.schema.lead import LeadActivityResponse
+
+
+class _StubAuthor:
+    def __init__(self, naam: str) -> None:
+        self.naam = naam
+
+
+def _orm_stub(*, author=None, author_id=None):
+    """Mimic an ORM LeadActivity instance with the attributes the schema reads."""
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        lead_id=uuid.uuid4(),
+        author_id=author_id,
+        author=author,
+        content="hello",
+        activity_type="note",
+        metadata_={},
+        uitkomst=None,
+        vervolgacties=None,
+        created_at=datetime.now(UTC),
+    )
+
+
+def test_author_naam_filled_from_relationship():
+    obj = _orm_stub(author=_StubAuthor("Anne Schuth"), author_id=uuid.uuid4())
+    resp = LeadActivityResponse.model_validate(obj)
+    assert resp.author_naam == "Anne Schuth"
+
+
+def test_no_author_keeps_naam_none():
+    obj = _orm_stub(author=None, author_id=None)
+    resp = LeadActivityResponse.model_validate(obj)
+    assert resp.author_naam is None
+
+
+def test_existing_naam_is_not_overwritten():
+    # Defensive: if a caller pre-fills author_naam, we shouldn't clobber it.
+    obj = _orm_stub(author=_StubAuthor("From Relationship"), author_id=uuid.uuid4())
+    obj.author_naam = "Pre-filled"
+    resp = LeadActivityResponse.model_validate(obj)
+    assert resp.author_naam == "Pre-filled"


### PR DESCRIPTION
## Aanleiding

Notes vanuit Mattermost (en eigenlijk alle handmatige notes) toonden geen
auteur in de UI. Het `LeadActivityResponse.author_naam` veld bestaat,
maar werd nergens ingevuld — het ORM-object heeft geen `author_naam`
kolom, alleen een `author` relationship. Dat werd zichtbaar nadat #294
de Mattermost-meelees-flow stabiel maakte: het oogje verscheen, de note
ontstond, maar wie het had gezegd bleef onzichtbaar.

## Fix

`model_validator(before)` op `LeadActivityResponse` vult `author_naam`
uit `author.naam` als de relationship mee-geladen is. De repo's laden
`LeadActivity.author` al via `selectinload`, dus dit kost geen extra
queries.

## Test plan

- [ ] `pytest backend/tests/test_lead_activity_response_author.py` — drie
      cases (uit relationship, geen auteur, niet overschrijven)
- [ ] `pytest backend/tests/test_lead_activity.py` blijft groen
- [ ] Na deploy: post een bericht in een gekoppeld kanaal — note toont
      "Anne Schuth" via de `mattermost_user`-mapping
- [ ] Maak een handmatige note op een lead — eigen naam zichtbaar