### PR TITLE
Leads-netwerk: externe contactpersonen tussen organisatie en interne persoon

### DIFF
--- a/frontend/src/components/leads/LeadGraphView.tsx
+++ b/frontend/src/components/leads/LeadGraphView.tsx
@@ -70,8 +70,8 @@ const RANK_ORGANISATION = 0;
 const RANK_CORPUS_NODE = 1;
 const RANK_LEAD = 2;
 const RANK_SAMENWERKINGSVERBAND = 3;
-const RANK_PERSON_INTERN = 4;
-const RANK_PERSON_EXTERN = 5;
+const RANK_PERSON_EXTERN = 4;
+const RANK_PERSON_INTERN = 5;
 const RANK_DEFAULT = RANK_LEAD;
 
 const LANE_Y: Record<number, number> = {
@@ -79,8 +79,8 @@ const LANE_Y: Record<number, number> = {
   [RANK_CORPUS_NODE]: 240,
   [RANK_LEAD]: 440,
   [RANK_SAMENWERKINGSVERBAND]: 640,
-  [RANK_PERSON_INTERN]: 840,
-  [RANK_PERSON_EXTERN]: 1040,
+  [RANK_PERSON_EXTERN]: 840,
+  [RANK_PERSON_INTERN]: 1040,
 };
 
 function getNodeRank(node: CommunityGraphNode): number {


### PR DESCRIPTION
## Summary
- In de leads-netwerk visualisatie hingen externe contactpersonen onder interne personen.
- In focus-mode ("Waar werkt Ravi aan?") staat de interne focus-persoon onderaan en is het logischer dat de externe contactpersoon tussen die persoon en de organisatie hangt.
- Lane 4 en 5 omgewisseld in `LeadGraphView.tsx`: `RANK_PERSON_EXTERN=4`, `RANK_PERSON_INTERN=5`.

## Test plan
- [ ] Open Leads > Netwerk
- [ ] Klik op een interne persoon (zoals Ravi) om focus-mode te activeren
- [ ] Controleer dat de verticale volgorde nu is: organisatie (boven) → externe contactpersoon → interne persoon (onder)