### PR TITLE
Voeg commissie en raad toe aan samenwerkingsverband-types

### DIFF
--- a/backend/bouwmeester/models/samenwerkingsverband.py
+++ b/backend/bouwmeester/models/samenwerkingsverband.py
@@ -1,7 +1,7 @@
 """Samenwerkingsverband model: ad-hoc samenwerkingsvormen los van de
 hierarchische OrganisatieEenheid-boom (programma, werkgroep,
 opschalingsticket, ketenproject, stuurgroep, taskforce, innovatiebudget,
-community_of_practice, pilot, convenant)."""
+community_of_practice, pilot, convenant, commissie, raad)."""
 
 import uuid
 from datetime import date, datetime
@@ -33,7 +33,8 @@ class Samenwerkingsverband(Base):
         index=True,
         comment=(
             "programma|werkgroep|opschalingsticket|ketenproject|stuurgroep|"
-            "taskforce|innovatiebudget|community_of_practice|pilot|convenant"
+            "taskforce|innovatiebudget|community_of_practice|pilot|convenant|"
+            "commissie|raad"
         ),
     )
     beschrijving: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -2133,7 +2133,9 @@ export type SamenwerkingsverbandType =
   | 'innovatiebudget'
   | 'community_of_practice'
   | 'pilot'
-  | 'convenant';
+  | 'convenant'
+  | 'commissie'
+  | 'raad';
 
 export const SAMENWERKINGSVERBAND_TYPE_LABELS: Record<string, string> = {
   programma: 'Programma',
@@ -2146,6 +2148,8 @@ export const SAMENWERKINGSVERBAND_TYPE_LABELS: Record<string, string> = {
   community_of_practice: 'Community of Practice',
   pilot: 'Pilot',
   convenant: 'Convenant',
+  commissie: 'Commissie',
+  raad: 'Raad',
 };
 
 export const SAMENWERKINGSVERBAND_TYPE_BADGE_COLORS: Record<string, BadgeVariant> = {
@@ -2159,6 +2163,8 @@ export const SAMENWERKINGSVERBAND_TYPE_BADGE_COLORS: Record<string, BadgeVariant
   community_of_practice: 'blue',
   pilot: 'orange',
   convenant: 'slate',
+  commissie: 'rose',
+  raad: 'gray',
 };
 
 export const SAMENWERKINGSVERBAND_TYPE_OPTIONS: { value: string; label: string }[] =


### PR DESCRIPTION
## Summary
- Twee nieuwe types in `SamenwerkingsverbandType`: `commissie` (rose badge) en `raad` (gray badge)
- Labels en badge-kleuren in `frontend/src/types/index.ts` aangevuld
- Comment in het backend-model `Samenwerkingsverband` bijgewerkt; geen migratie nodig (kolom is een vrije string)

## Test plan
- [ ] Nieuw samenwerkingsverband aanmaken met type "Commissie" en type "Raad" via de UI
- [ ] Badge-kleuren kloppen in lijst en detailweergave