### PR TITLE
Mattermost link-poller via websocket ipv 15s polling

### DIFF
--- a/backend/bouwmeester/api/routes/admin.py
+++ b/backend/bouwmeester/api/routes/admin.py
@@ -779,7 +779,6 @@ async def version_info(admin: AdminUser) -> dict[str, str]:
 # err on the side of "noisy when broken" rather than "quiet when broken".
 _WORKER_EXPECTED_CADENCE_SEC = {
     "parlementair": 900,  # TK_POLL_INTERVAL_SECONDS default 15min
-    "mattermost_link": 60,  # MATTERMOST_POLL_INTERVAL_SECONDS default
     "mattermost_websocket": 90,  # idle-heartbeat is once per 60s
     "opdracht_task": 86400,  # daily — give it 4× before declaring down
     "fcc_sync": 600,  # FCC_POLL_INTERVAL_SECONDS default 10min

--- a/backend/bouwmeester/core/config.py
+++ b/backend/bouwmeester/core/config.py
@@ -87,7 +87,6 @@ class Settings(BaseSettings):
     MATTERMOST_NOTIFICATION_CHANNEL_ID: str = ""
     # Token to verify incoming slash commands
     MATTERMOST_WEBHOOK_TOKEN: str = ""
-    MATTERMOST_POLL_INTERVAL_SECONDS: int = 15
     MATTERMOST_LINK_CODE_TTL_MINUTES: int = 10
     MATTERMOST_LINK_CODE_LENGTH: int = 8
 

--- a/backend/bouwmeester/services/mattermost_ingest_service.py
+++ b/backend/bouwmeester/services/mattermost_ingest_service.py
@@ -46,6 +46,37 @@ from bouwmeester.services.mattermost_doc_link_extractor import (
 logger = logging.getLogger(__name__)
 
 
+async def handle_dm_post(post: dict, *, bot_user_id: str | None = None) -> None:
+    """Verwerk een DM naar de bot: zoek link-code, koppel account.
+
+    Draait in een eigen ``async_session`` zodat fouten in
+    ``MattermostLinkPoller`` (bijvoorbeeld een ``IntegrityError`` op een
+    race-conditie bij ``create_mapping``) niet doorslaan naar de session
+    waar de caller in zit. Bij een crash is alleen deze ene DM verloren.
+
+    Skip bot-eigen DMs als ``bot_user_id`` bekend is — anti
+    feedback-loop voor bevestigingsreplies van de bot zelf.
+    """
+    if bot_user_id and post.get("user_id") == bot_user_id:
+        return
+
+    from bouwmeester.services.mattermost_link_poller import MattermostLinkPoller
+    from bouwmeester.services.mattermost_service import MattermostService
+
+    async with async_session() as dm_session:
+        mm_service = MattermostService(dm_session)
+        try:
+            poller = MattermostLinkPoller(dm_session, mm_service=mm_service)
+            try:
+                await poller.process_posts([post])
+                await dm_session.commit()
+            except Exception:
+                await dm_session.rollback()
+                logger.exception("DM-handling faalde voor post %s", post.get("id"))
+        finally:
+            await mm_service.close()
+
+
 class MattermostIngestService:
     """Stateless verwerking — instantieer per session, gooi daarna weg."""
 
@@ -201,29 +232,10 @@ class MattermostIngestService:
             await self._react(post_id, "eyes")
 
     async def _handle_dm(self, post: dict) -> None:
-        """Verwerk een DM naar de bot: zoek link-code, koppel account.
-
-        Draait in een eigen ``async_session`` zodat fouten in
-        ``MattermostLinkPoller`` (bijvoorbeeld ``IntegrityError`` op een
-        race-conditie bij ``create_mapping``) de outer-session van de
-        WS-loop niet in aborted-state achterlaten. Bij een crash is
-        alleen deze ene DM verloren — de WS-loop draait door.
-        """
-        from bouwmeester.services.mattermost_link_poller import MattermostLinkPoller
-        from bouwmeester.services.mattermost_service import MattermostService
-
-        async with async_session() as dm_session:
-            mm_service = MattermostService(dm_session)
-            try:
-                poller = MattermostLinkPoller(dm_session, mm_service=mm_service)
-                try:
-                    await poller.process_posts([post])
-                    await dm_session.commit()
-                except Exception:
-                    await dm_session.rollback()
-                    logger.exception("DM-handling faalde voor post %s", post.get("id"))
-            finally:
-                await mm_service.close()
+        """Backwards-compat shim — delegate naar de module-level helper
+        zodat ``handle_dm_post`` ook direct vanuit de WS-loop aanroepbaar
+        is zonder een ``MattermostIngestService`` te instantiëren."""
+        await handle_dm_post(post, bot_user_id=self.bot_user_id)
 
     async def _is_noise(self, message: str) -> bool:
         """Vraag VLAM of dit een triviaal/ack-bericht is.

--- a/backend/bouwmeester/services/mattermost_ingest_service.py
+++ b/backend/bouwmeester/services/mattermost_ingest_service.py
@@ -59,10 +59,16 @@ class MattermostIngestService:
         self.bot_user_id = bot_user_id
         self.mm_base_url = mm_base_url.rstrip("/") if mm_base_url else None
 
-    async def ingest_post(self, post: dict) -> None:
+    async def ingest_post(self, post: dict, *, channel_type: str | None = None) -> None:
         """Verwerk één Mattermost-post.
 
         De caller is verantwoordelijk voor commit/rollback van de session.
+
+        ``channel_type`` komt uit de ``data.channel_type`` van het Mattermost
+        ``posted``-event: ``"D"`` = 1-op-1 DM (link-code-pad),
+        ``"G"`` = group-DM (genegeerd, consistent met legacy poller-gedrag),
+        andere waardes (``"O"`` open, ``"P"`` private) of ``None`` vallen
+        door naar de channel-link-flow.
         """
         post_id = post.get("id")
         channel_id = post.get("channel_id")
@@ -74,6 +80,12 @@ class MattermostIngestService:
 
         # Skip bot's eigen posts (anti feedback-loop).
         if self.bot_user_id and mm_user_id == self.bot_user_id:
+            return
+
+        if channel_type == "D":
+            await self._handle_dm(post)
+            return
+        if channel_type == "G":
             return
 
         link_repo = MattermostChannelLinkRepository(self.session)
@@ -186,6 +198,24 @@ class MattermostIngestService:
         # note staat al.
         if lead_activity_id is not None:
             await self._react(post_id, "eyes")
+
+    async def _handle_dm(self, post: dict) -> None:
+        """Verwerk een DM naar de bot: zoek link-code, koppel account.
+
+        Dit pad verving de oude 15s-polling-loop. ``MattermostLinkPoller``
+        is idempotent (verify_code → delete_code, IntegrityError op
+        dubbele mapping), dus een dubbele call door WS+recovery-race
+        loopt stilletjes dood.
+        """
+        from bouwmeester.services.mattermost_link_poller import MattermostLinkPoller
+        from bouwmeester.services.mattermost_service import MattermostService
+
+        mm_service = MattermostService(self.session)
+        try:
+            poller = MattermostLinkPoller(self.session, mm_service=mm_service)
+            await poller.process_posts([post])
+        finally:
+            await mm_service.close()
 
     async def _is_noise(self, message: str) -> bool:
         """Vraag VLAM of dit een triviaal/ack-bericht is.

--- a/backend/bouwmeester/services/mattermost_ingest_service.py
+++ b/backend/bouwmeester/services/mattermost_ingest_service.py
@@ -46,7 +46,7 @@ from bouwmeester.services.mattermost_doc_link_extractor import (
 logger = logging.getLogger(__name__)
 
 
-async def handle_dm_post(post: dict, *, bot_user_id: str | None = None) -> None:
+async def handle_dm_post(post: dict, *, bot_user_id: str | None = None) -> bool:
     """Verwerk een DM naar de bot: zoek link-code, koppel account.
 
     Draait in een eigen ``async_session`` zodat fouten in
@@ -55,10 +55,16 @@ async def handle_dm_post(post: dict, *, bot_user_id: str | None = None) -> None:
     waar de caller in zit. Bij een crash is alleen deze ene DM verloren.
 
     Skip bot-eigen DMs als ``bot_user_id`` bekend is — anti
-    feedback-loop voor bevestigingsreplies van de bot zelf.
+    feedback-loop voor bevestigingsreplies van de bot zelf. Bot-skips
+    tellen als ``True`` (niets te doen, geslaagd).
+
+    Returns ``True`` als de post zonder fouten is doorgelopen, ``False``
+    als er een exception was. De caller gebruikt dit om te beslissen
+    of de post in een dedup-cache mag — een mislukte DM moet bij
+    recovery opnieuw kunnen worden geprobeerd.
     """
     if bot_user_id and post.get("user_id") == bot_user_id:
-        return
+        return True
 
     from bouwmeester.services.mattermost_link_poller import MattermostLinkPoller
     from bouwmeester.services.mattermost_service import MattermostService
@@ -70,9 +76,11 @@ async def handle_dm_post(post: dict, *, bot_user_id: str | None = None) -> None:
             try:
                 await poller.process_posts([post])
                 await dm_session.commit()
+                return True
             except Exception:
                 await dm_session.rollback()
                 logger.exception("DM-handling faalde voor post %s", post.get("id"))
+                return False
         finally:
             await mm_service.close()
 
@@ -115,7 +123,7 @@ class MattermostIngestService:
             return
 
         if channel_type == "D":
-            await self._handle_dm(post)
+            await handle_dm_post(post, bot_user_id=self.bot_user_id)
             return
         if channel_type == "G":
             return
@@ -230,12 +238,6 @@ class MattermostIngestService:
         # note staat al.
         if lead_activity_id is not None:
             await self._react(post_id, "eyes")
-
-    async def _handle_dm(self, post: dict) -> None:
-        """Backwards-compat shim — delegate naar de module-level helper
-        zodat ``handle_dm_post`` ook direct vanuit de WS-loop aanroepbaar
-        is zonder een ``MattermostIngestService`` te instantiëren."""
-        await handle_dm_post(post, bot_user_id=self.bot_user_id)
 
     async def _is_noise(self, message: str) -> bool:
         """Vraag VLAM of dit een triviaal/ack-bericht is.

--- a/backend/bouwmeester/services/mattermost_ingest_service.py
+++ b/backend/bouwmeester/services/mattermost_ingest_service.py
@@ -20,6 +20,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from bouwmeester.core.database import async_session
 from bouwmeester.models.initiatief import Initiatief
 from bouwmeester.models.lead import Lead
 from bouwmeester.models.lead_activity import LeadActivity
@@ -202,20 +203,27 @@ class MattermostIngestService:
     async def _handle_dm(self, post: dict) -> None:
         """Verwerk een DM naar de bot: zoek link-code, koppel account.
 
-        Dit pad verving de oude 15s-polling-loop. ``MattermostLinkPoller``
-        is idempotent (verify_code → delete_code, IntegrityError op
-        dubbele mapping), dus een dubbele call door WS+recovery-race
-        loopt stilletjes dood.
+        Draait in een eigen ``async_session`` zodat fouten in
+        ``MattermostLinkPoller`` (bijvoorbeeld ``IntegrityError`` op een
+        race-conditie bij ``create_mapping``) de outer-session van de
+        WS-loop niet in aborted-state achterlaten. Bij een crash is
+        alleen deze ene DM verloren — de WS-loop draait door.
         """
         from bouwmeester.services.mattermost_link_poller import MattermostLinkPoller
         from bouwmeester.services.mattermost_service import MattermostService
 
-        mm_service = MattermostService(self.session)
-        try:
-            poller = MattermostLinkPoller(self.session, mm_service=mm_service)
-            await poller.process_posts([post])
-        finally:
-            await mm_service.close()
+        async with async_session() as dm_session:
+            mm_service = MattermostService(dm_session)
+            try:
+                poller = MattermostLinkPoller(dm_session, mm_service=mm_service)
+                try:
+                    await poller.process_posts([post])
+                    await dm_session.commit()
+                except Exception:
+                    await dm_session.rollback()
+                    logger.exception("DM-handling faalde voor post %s", post.get("id"))
+            finally:
+                await mm_service.close()
 
     async def _is_noise(self, message: str) -> bool:
         """Vraag VLAM of dit een triviaal/ack-bericht is.

--- a/backend/bouwmeester/services/mattermost_link_poller.py
+++ b/backend/bouwmeester/services/mattermost_link_poller.py
@@ -83,13 +83,17 @@ class MattermostLinkPoller:
             username = await self.mm_service.get_username(mm_user_id)
 
             # Create the mapping — handle race condition where another path
-            # already linked this user or person concurrently.
+            # already linked this user or person concurrently. Het savepoint
+            # zorgt dat de IntegrityError de outer-transactie niet in
+            # aborted-state achterlaat zodat een volgende post (of de
+            # ``commit()`` van de caller) niet faalt.
             try:
-                await self.repo.create_mapping(
-                    person_id=link_code.person_id,
-                    mattermost_user_id=mm_user_id,
-                    mattermost_username=username,
-                )
+                async with self.session.begin_nested():
+                    await self.repo.create_mapping(
+                        person_id=link_code.person_id,
+                        mattermost_user_id=mm_user_id,
+                        mattermost_username=username,
+                    )
             except IntegrityError:
                 await self._safe_reply(
                     channel_id,

--- a/backend/bouwmeester/services/mattermost_link_poller.py
+++ b/backend/bouwmeester/services/mattermost_link_poller.py
@@ -119,7 +119,3 @@ class MattermostLinkPoller:
             )
 
         return links_created
-
-    async def cleanup(self) -> None:
-        """Clean up expired codes."""
-        await self.repo.cleanup_expired_codes()

--- a/backend/bouwmeester/services/mattermost_websocket_service.py
+++ b/backend/bouwmeester/services/mattermost_websocket_service.py
@@ -14,6 +14,7 @@ import asyncio
 import json
 import logging
 import time
+from collections import OrderedDict
 from urllib.parse import urlparse
 
 import httpx
@@ -38,6 +39,13 @@ _HEARTBEAT_INTERVAL = 30.0  # sec
 _RECONNECT_BACKOFF_BASE = 2.0
 _RECONNECT_BACKOFF_MAX = 60.0
 _BACKOFF_RESET_AFTER_HEALTHY_SEC = 120.0
+# Cold-start-window voor DM-recovery bij eerste connect — dekt de paar
+# seconden tussen worker-restart en WS-connect. Bij elke volgende reconnect
+# kijken we vanaf het vorige recovery-tijdstip terug.
+_DM_COLD_START_WINDOW_MS = 120_000
+# Cap op de in-memory cache van recent-verwerkte DM-post-ids; voorkomt
+# dubbele processing bij race tussen WS-event en recovery-loop.
+_RECENT_DM_CACHE_CAP = 500
 
 
 def _ws_url_from_http(http_url: str) -> str:
@@ -96,6 +104,8 @@ class MattermostWebsocketService:
         self._stop = False
         self._bot_user_id: str | None = None
         self._mm_base_url: str | None = None
+        self._last_dm_recovery_ms: int | None = None
+        self._recent_dm_post_ids: OrderedDict[str, None] = OrderedDict()
 
     async def run(self) -> None:
         """Hoofdloop: connect, auth, lees events, reconnect bij disconnect."""
@@ -283,6 +293,9 @@ class MattermostWebsocketService:
         post_raw = data.get("post")
         if not post_raw:
             return
+        # ``channel_type`` zit op ``data``, niet op de geparste ``post`` —
+        # ``"D"`` markeert een 1-op-1 DM (link-code-pad), ``"G"`` group-DM.
+        channel_type = data.get("channel_type") if isinstance(data, dict) else None
         try:
             post = json.loads(post_raw) if isinstance(post_raw, str) else post_raw
         except json.JSONDecodeError:
@@ -294,24 +307,33 @@ class MattermostWebsocketService:
         if not post_id or not channel_id:
             return
 
+        # DM-events kunnen ook via _recover_missed_posts binnenkomen vlak
+        # na een reconnect — skip als we 'm net hebben verwerkt.
+        if channel_type == "D" and self._dm_already_processed(post_id):
+            return
+
         # Hard signaal in productie-logs dat een bericht überhaupt is
         # aangekomen via de websocket — voorkomt giswerk wanneer een note
         # uitblijft. Korte regel zodat 'm niet snel uit het log-venster
         # rolt door noise.
         logger.info(
-            "Mattermost posted event: channel=%s post=%s len=%d",
+            "Mattermost posted event: channel=%s post=%s type=%s len=%d",
             channel_id,
             post_id,
+            channel_type or "?",
             len(post.get("message") or ""),
         )
 
         async with async_session() as session:
             try:
-                await self._record_post(session, post)
+                await self._record_post(session, post, channel_type=channel_type)
                 await session.commit()
             except Exception:
                 await session.rollback()
                 logger.exception("Fout bij verwerken Mattermost-post %s", post_id)
+            else:
+                if channel_type == "D":
+                    self._mark_dm_processed(post_id)
 
     async def _dispatch_channel_lost(self, event: str, msg: dict) -> None:
         """Markeer kanaal-koppelingen als ``disabled_at`` wanneer de bot
@@ -354,21 +376,40 @@ class MattermostWebsocketService:
             )
         return None
 
-    async def _record_post(self, session: AsyncSession, post: dict) -> None:
+    async def _record_post(
+        self,
+        session: AsyncSession,
+        post: dict,
+        *,
+        channel_type: str | None = None,
+    ) -> None:
         """Verwerk één Mattermost-post via :class:`MattermostIngestService`."""
         ingest = MattermostIngestService(
             session,
             bot_user_id=self._bot_user_id,
             mm_base_url=self._mm_base_url,
         )
-        await ingest.ingest_post(post)
+        await ingest.ingest_post(post, channel_type=channel_type)
+
+    def _dm_already_processed(self, post_id: str) -> bool:
+        return post_id in self._recent_dm_post_ids
+
+    def _mark_dm_processed(self, post_id: str) -> None:
+        self._recent_dm_post_ids[post_id] = None
+        while len(self._recent_dm_post_ids) > _RECENT_DM_CACHE_CAP:
+            self._recent_dm_post_ids.popitem(last=False)
 
     async def _recover_missed_posts(self) -> None:
         """Haal posts op die binnenkwamen terwijl we offline waren.
 
-        We doen dit per gekoppeld kanaal, vanaf ``last_seen_post_at``.
-        Posts die we al hadden (unique post_id) worden door de
-        IntegrityError-handler in ``_record_post`` afgevangen.
+        Twee paden:
+        1. Per gekoppeld kanaal vanaf ``last_seen_post_at`` (meelees-flow).
+        2. Bot-DMs voor link-codes vanaf ``_last_dm_recovery_ms`` (bij
+           cold start: laatste 2 minuten).
+
+        Dubbele posts (zowel via WS-event als recovery) worden afgevangen
+        door de unique constraint op ``mattermost_post_link.post_id`` voor
+        kanaal-posts en door de in-memory dedup-cache voor DM-posts.
         """
         async with async_session() as session:
             stmt = select(MattermostChannelLink).where(
@@ -377,13 +418,11 @@ class MattermostWebsocketService:
             result = await session.execute(stmt)
             links = list(result.scalars().all())
 
-            if not links:
-                return
-
             service = MattermostService(session)
             try:
                 if not await service.is_enabled():
                     return
+
                 for link in links:
                     since = link.last_seen_post_at or 0
                     if since == 0:
@@ -406,6 +445,45 @@ class MattermostWebsocketService:
                             logger.exception(
                                 "Recovery: fout bij post %s", post.get("id")
                             )
+
+                await self._recover_dm_posts(session, service)
+
                 await session.commit()
             finally:
                 await service.close()
+
+    async def _recover_dm_posts(
+        self, session: AsyncSession, service: MattermostService
+    ) -> None:
+        """Eenmalige REST-poll van bot-DMs sinds laatste recovery-tijdstip.
+
+        Vangnet voor link-codes die binnenkwamen tijdens een korte
+        WS-disconnect. Bij cold start: 2 minuten terug.
+        """
+        now_ms = int(time.time() * 1000)
+        since_ms = self._last_dm_recovery_ms
+        if since_ms is None:
+            since_ms = now_ms - _DM_COLD_START_WINDOW_MS
+
+        try:
+            posts = await service.get_bot_dm_posts(since=since_ms)
+        except httpx.HTTPError:
+            logger.exception("DM-recovery faalde")
+            return
+
+        recovered = 0
+        for post in posts:
+            post_id = post.get("id")
+            if not post_id or self._dm_already_processed(post_id):
+                continue
+            try:
+                await self._record_post(session, post, channel_type="D")
+            except Exception:
+                logger.exception("DM-recovery: fout bij post %s", post_id)
+                continue
+            self._mark_dm_processed(post_id)
+            recovered += 1
+
+        self._last_dm_recovery_ms = now_ms
+        if recovered:
+            logger.info("DM-recovery: %d posts opnieuw verwerkt", recovered)

--- a/backend/bouwmeester/services/mattermost_websocket_service.py
+++ b/backend/bouwmeester/services/mattermost_websocket_service.py
@@ -324,6 +324,21 @@ class MattermostWebsocketService:
             len(post.get("message") or ""),
         )
 
+        # DM-events doen al hun werk in een eigen session via
+        # ``handle_dm_post`` — open hier geen outer session voor niets.
+        if channel_type == "D":
+            from bouwmeester.services.mattermost_ingest_service import (
+                handle_dm_post,
+            )
+
+            try:
+                await handle_dm_post(post, bot_user_id=self._bot_user_id)
+            except Exception:
+                logger.exception("Fout bij verwerken Mattermost DM %s", post_id)
+            else:
+                self._mark_dm_processed(post_id)
+            return
+
         async with async_session() as session:
             try:
                 await self._record_post(session, post, channel_type=channel_type)
@@ -331,9 +346,6 @@ class MattermostWebsocketService:
             except Exception:
                 await session.rollback()
                 logger.exception("Fout bij verwerken Mattermost-post %s", post_id)
-            else:
-                if channel_type == "D":
-                    self._mark_dm_processed(post_id)
 
     async def _dispatch_channel_lost(self, event: str, msg: dict) -> None:
         """Markeer kanaal-koppelingen als ``disabled_at`` wanneer de bot
@@ -472,6 +484,7 @@ class MattermostWebsocketService:
             return
 
         recovered = 0
+        failures = 0
         for post in posts:
             post_id = post.get("id")
             if not post_id or self._dm_already_processed(post_id):
@@ -480,10 +493,18 @@ class MattermostWebsocketService:
                 await self._record_post(session, post, channel_type="D")
             except Exception:
                 logger.exception("DM-recovery: fout bij post %s", post_id)
+                failures += 1
                 continue
             self._mark_dm_processed(post_id)
             recovered += 1
 
-        self._last_dm_recovery_ms = now_ms
+        # Schuif de cursor alleen door bij volledig succes — anders willen
+        # we mislukte posts bij de volgende reconnect opnieuw zien.
+        if failures == 0:
+            self._last_dm_recovery_ms = now_ms
         if recovered:
             logger.info("DM-recovery: %d posts opnieuw verwerkt", recovered)
+        if failures:
+            logger.warning(
+                "DM-recovery: %d posts mislukt, cursor blijft staan", failures
+            )

--- a/backend/bouwmeester/services/mattermost_websocket_service.py
+++ b/backend/bouwmeester/services/mattermost_websocket_service.py
@@ -331,11 +331,11 @@ class MattermostWebsocketService:
                 handle_dm_post,
             )
 
-            try:
-                await handle_dm_post(post, bot_user_id=self._bot_user_id)
-            except Exception:
-                logger.exception("Fout bij verwerken Mattermost DM %s", post_id)
-            else:
+            # ``handle_dm_post`` swallowt eigen exceptions en returnt
+            # False bij fouten. Alleen geslaagde DMs in de dedup-cache
+            # zetten — anders mist de recovery-loop ze later.
+            ok = await handle_dm_post(post, bot_user_id=self._bot_user_id)
+            if ok:
                 self._mark_dm_processed(post_id)
             return
 

--- a/backend/bouwmeester/worker.py
+++ b/backend/bouwmeester/worker.py
@@ -176,12 +176,36 @@ async def _mattermost_websocket_loop(settings) -> None:  # type: ignore[no-untyp
         await asyncio.sleep(5)
 
 
+async def _cleanup_obsolete_heartbeats() -> None:
+    """Verwijder heartbeat-rijen van loops die niet meer bestaan.
+
+    De ``mattermost_link``-rij bleef hangen toen we die loop schrapten,
+    waardoor de admin-UI 'm als 'unexpected, down' bleef tonen. Run-once
+    bij worker-startup is genoeg — best-effort, fout wordt gelogd.
+    """
+    from sqlalchemy import delete
+
+    from bouwmeester.models.worker_heartbeat import WorkerHeartbeat
+
+    obsolete = ["mattermost_link"]
+    try:
+        async with async_session() as session:
+            await session.execute(
+                delete(WorkerHeartbeat).where(WorkerHeartbeat.loop_name.in_(obsolete))
+            )
+            await session.commit()
+    except Exception:
+        logger.exception("Cleanup obsolete heartbeats faalde")
+
+
 async def main() -> None:
     settings = get_settings()
     logger.info(
         f"Worker started. Parlementair poll interval: "
         f"{settings.TK_POLL_INTERVAL_SECONDS}s"
     )
+
+    await _cleanup_obsolete_heartbeats()
 
     tasks = [
         asyncio.create_task(_parlementair_loop(settings)),

--- a/backend/bouwmeester/worker.py
+++ b/backend/bouwmeester/worker.py
@@ -1,11 +1,9 @@
 """Background worker for polling TK/EK APIs, importing parliamentary items,
-and polling Mattermost for link codes."""
+and running the persistent Mattermost websocket."""
 
 import asyncio
 import logging
-import time
 import traceback
-from collections import OrderedDict
 
 from bouwmeester.core.config import get_settings
 from bouwmeester.core.database import async_session
@@ -48,84 +46,6 @@ async def _parlementair_loop(settings) -> None:  # type: ignore[no-untyped-def]
             await health_tick("parlementair", status="error", detail=_short_error(exc))
 
         await asyncio.sleep(settings.TK_POLL_INTERVAL_SECONDS)
-
-
-async def _mattermost_link_loop(settings) -> None:  # type: ignore[no-untyped-def]
-    """Poll Mattermost bot DMs for link codes.
-
-    Checks DB config each iteration so the poller starts automatically
-    when MATTERMOST_ENABLED is toggled to true in Beheer > Instellingen.
-    """
-    started = False
-    last_poll_ms: int = int(time.time() * 1000)
-    # OrderedDict preserves insertion order for correct eviction.
-    seen_post_ids: OrderedDict[str, None] = OrderedDict()
-
-    await health_tick("mattermost_link", status="starting")
-    while True:
-        mm = None
-        try:
-            async with async_session() as session:
-                from bouwmeester.services.mattermost_service import (
-                    MattermostService,
-                )
-
-                mm = MattermostService(session)
-                if not await mm.is_enabled():
-                    if started:
-                        logger.info("Mattermost integration disabled, pausing poller")
-                        started = False
-                    await health_tick(
-                        "mattermost_link",
-                        status="disabled",
-                        detail="MATTERMOST_ENABLED is false",
-                    )
-                    await asyncio.sleep(settings.MATTERMOST_POLL_INTERVAL_SECONDS)
-                    continue
-
-                if not started:
-                    logger.info("Mattermost link poller started")
-                    started = True
-
-                since = last_poll_ms
-                last_poll_ms = int(time.time() * 1000)
-
-                posts = await mm.get_bot_dm_posts(since=since)
-                # Filter out posts we've already processed (Mattermost's
-                # `since` API also returns posts whose threads were updated).
-                new_posts = [p for p in posts if p.get("id") not in seen_post_ids]
-                for p in new_posts:
-                    seen_post_ids[p.get("id", "")] = None
-
-                if new_posts:
-                    from bouwmeester.services.mattermost_link_poller import (
-                        MattermostLinkPoller,
-                    )
-
-                    poller = MattermostLinkPoller(session, mm_service=mm)
-                    count = await poller.process_posts(new_posts)
-                    if count:
-                        logger.info(f"Mattermost link poll: {count} accounts linked")
-                    await poller.cleanup()
-
-                # Cap the dict size — evict oldest entries first.
-                while len(seen_post_ids) > 1000:
-                    seen_post_ids.popitem(last=False)
-
-                await session.commit()
-            await health_tick(
-                "mattermost_link", detail=f"{len(new_posts)} new dm posts"
-            )
-        except Exception as exc:
-            logger.exception("Error in Mattermost link poll cycle")
-            await health_tick(
-                "mattermost_link", status="error", detail=_short_error(exc)
-            )
-        finally:
-            if mm:
-                await mm.close()
-
-        await asyncio.sleep(settings.MATTERMOST_POLL_INTERVAL_SECONDS)
 
 
 async def _opdracht_task_loop(settings) -> None:  # type: ignore[no-untyped-def]
@@ -265,7 +185,6 @@ async def main() -> None:
 
     tasks = [
         asyncio.create_task(_parlementair_loop(settings)),
-        asyncio.create_task(_mattermost_link_loop(settings)),
         asyncio.create_task(_mattermost_websocket_loop(settings)),
         asyncio.create_task(_opdracht_task_loop(settings)),
         asyncio.create_task(_fcc_sync_loop(settings)),

--- a/backend/tests/test_mattermost_ingest.py
+++ b/backend/tests/test_mattermost_ingest.py
@@ -409,6 +409,37 @@ async def test_initiatief_channel_writes_only_post_link(db_session, sample_initi
 # ---------------------------------------------------------------------------
 
 
+def _patch_dm_session(db_session):
+    """Patch ``async_session`` in ``mattermost_ingest_service`` zodat
+    ``_handle_dm`` op de test-session werkt ipv een eigen verbinding.
+
+    ``commit()`` en ``rollback()`` op de inner session worden no-op
+    gemaakt zodat de outer test-rollback alle DM-writes afvoert en een
+    inner-rollback de outer-session niet vernielt — in productie zou
+    ``_handle_dm`` op een aparte session werken, dus de outer-session
+    moet ongeacht inner-uitkomst bruikbaar blijven.
+    """
+    from contextlib import asynccontextmanager
+    from unittest.mock import AsyncMock, patch
+
+    @asynccontextmanager
+    async def _fake_session():
+        original_commit = db_session.commit
+        original_rollback = db_session.rollback
+        db_session.commit = AsyncMock(return_value=None)
+        db_session.rollback = AsyncMock(return_value=None)
+        try:
+            yield db_session
+        finally:
+            db_session.commit = original_commit
+            db_session.rollback = original_rollback
+
+    return patch(
+        "bouwmeester.services.mattermost_ingest_service.async_session",
+        new=_fake_session,
+    )
+
+
 async def test_dm_post_with_valid_code_creates_mapping(db_session, create_person):
     """Een DM met een geldige BM-code koppelt het Mattermost-account aan
     de bijbehorende persoon — dezelfde uitkomst als de oude poller, maar
@@ -432,6 +463,7 @@ async def test_dm_post_with_valid_code_creates_mapping(db_session, create_person
 
     ingest = MattermostIngestService(db_session)
     with (
+        _patch_dm_session(db_session),
         patch(
             "bouwmeester.services.mattermost_link_poller."
             "MattermostLinkPoller._safe_reply",
@@ -478,9 +510,13 @@ async def test_dm_post_with_unknown_code_does_not_create_mapping(db_session):
 
     safe_reply = AsyncMock(return_value=None)
     ingest = MattermostIngestService(db_session)
-    with patch(
-        "bouwmeester.services.mattermost_link_poller.MattermostLinkPoller._safe_reply",
-        new=safe_reply,
+    with (
+        _patch_dm_session(db_session),
+        patch(
+            "bouwmeester.services.mattermost_link_poller."
+            "MattermostLinkPoller._safe_reply",
+            new=safe_reply,
+        ),
     ):
         await ingest.ingest_post(post, channel_type="D")
 
@@ -534,6 +570,94 @@ async def test_group_dm_is_ignored(db_session):
     ) as handle_dm:
         await ingest.ingest_post(post, channel_type="G")
     handle_dm.assert_not_called()
+
+
+async def test_link_poller_integrity_error_keeps_session_usable(
+    db_session, create_person
+):
+    """Bij een race waar dezelfde Mattermost-user al elders is gekoppeld,
+    moet de poller de IntegrityError netjes binnen een savepoint
+    afvangen zodat de session bruikbaar blijft voor een volgende query.
+    Voor de fix zat de session na de IntegrityError in aborted-state."""
+    from unittest.mock import AsyncMock, patch
+
+    from bouwmeester.repositories.mattermost_user import MattermostUserRepository
+    from bouwmeester.services.mattermost_link_poller import MattermostLinkPoller
+    from bouwmeester.services.mattermost_service import MattermostService
+
+    p1 = await create_person(naam="P1", prefix="p1")
+    p2 = await create_person(naam="P2", prefix="p2")
+
+    repo = MattermostUserRepository(db_session)
+    code = await repo.create_link_code(p2.id)
+
+    # P1 is al gekoppeld aan een Mattermost-user; we proberen nu P2 te
+    # koppelen aan dezelfde MM-user → IntegrityError op unique mm_user_id.
+    shared_mm_uid = _id()
+    await repo.create_mapping(
+        person_id=p1.id,
+        mattermost_user_id=shared_mm_uid,
+        mattermost_username="p1",
+    )
+
+    post = {
+        "id": _id(),
+        "channel_id": _id(),
+        "user_id": shared_mm_uid,
+        "create_at": 1_700_000_000_000,
+        "message": f"hier is mijn code: {code.code}",
+    }
+
+    mm_service = MattermostService(db_session)
+    poller = MattermostLinkPoller(db_session, mm_service=mm_service)
+    with (
+        patch.object(poller, "_safe_reply", new=AsyncMock(return_value=None)),
+        patch.object(
+            mm_service, "get_username", new=AsyncMock(return_value="duplicate")
+        ),
+    ):
+        await poller.process_posts([post])
+
+    # Session moet nog werken na de afgevangen IntegrityError.
+    refreshed = await db_session.get(type(p1), p1.id)
+    assert refreshed is not None
+    # P1's mapping bestaat nog steeds, P2 heeft géén nieuwe mapping.
+    assert (await repo.get_by_mattermost_user_id(shared_mm_uid)).person_id == p1.id
+
+
+async def test_dm_handling_failure_does_not_break_outer_session(
+    db_session, create_person
+):
+    """Een onverwachte exception in ``_handle_dm`` mag de outer-session
+    van de WS-loop niet kapot maken. We forceren een fout en checken dat
+    de outer-session daarna nog gewone queries kan uitvoeren."""
+    from unittest.mock import AsyncMock, patch
+
+    person = await create_person(naam="Outer", prefix="outer")
+    post = {
+        "id": _id(),
+        "channel_id": _id(),
+        "user_id": _id(),
+        "create_at": 1_700_000_000_000,
+        "message": "BM-irrelevantcode",
+    }
+
+    ingest = MattermostIngestService(db_session)
+    with (
+        _patch_dm_session(db_session),
+        patch(
+            "bouwmeester.services.mattermost_link_poller."
+            "MattermostLinkPoller.process_posts",
+            new=AsyncMock(side_effect=RuntimeError("simulated crash")),
+        ),
+    ):
+        # Mag NIET propageren — _handle_dm vangt het op.
+        await ingest.ingest_post(post, channel_type="D")
+
+    # Outer-session is nog bruikbaar voor een vervolgquery.
+    refreshed = await db_session.get(type(person), person.id)
+    assert refreshed is not None
+    assert refreshed.naam == "Outer"
 
 
 async def test_channel_post_without_channel_type_unaffected(db_session, sample_lead):

--- a/backend/tests/test_mattermost_ingest.py
+++ b/backend/tests/test_mattermost_ingest.py
@@ -402,3 +402,170 @@ async def test_initiatief_channel_writes_only_post_link(db_session, sample_initi
     ).scalar_one()
     assert post_link.lead_activity_id is None
     assert post_link.scope_type == SCOPE_INITIATIEF
+
+
+# ---------------------------------------------------------------------------
+# DM-pad: link-codes via websocket-event ipv polling
+# ---------------------------------------------------------------------------
+
+
+async def test_dm_post_with_valid_code_creates_mapping(db_session, create_person):
+    """Een DM met een geldige BM-code koppelt het Mattermost-account aan
+    de bijbehorende persoon — dezelfde uitkomst als de oude poller, maar
+    nu via het websocket-pad in ``ingest_post``."""
+    from unittest.mock import AsyncMock, patch
+
+    from bouwmeester.repositories.mattermost_user import MattermostUserRepository
+
+    person = await create_person(naam="DM Tester", prefix="dm")
+    repo = MattermostUserRepository(db_session)
+    code = await repo.create_link_code(person.id)
+
+    mm_uid = _id()
+    post = {
+        "id": _id(),
+        "channel_id": _id(),
+        "user_id": mm_uid,
+        "create_at": 1_700_000_000_000,
+        "message": f"hoi, mijn code is {code.code}",
+    }
+
+    ingest = MattermostIngestService(db_session)
+    with (
+        patch(
+            "bouwmeester.services.mattermost_link_poller."
+            "MattermostLinkPoller._safe_reply",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "bouwmeester.services.mattermost_service.MattermostService.get_username",
+            new=AsyncMock(return_value="dm_user"),
+        ),
+    ):
+        await ingest.ingest_post(post, channel_type="D")
+
+    mapping = await repo.get_by_mattermost_user_id(mm_uid)
+    assert mapping is not None
+    assert mapping.person_id == person.id
+    assert mapping.mattermost_username == "dm_user"
+    # Code is verbruikt.
+    assert await repo.verify_code(code.code) is None
+    # Geen MattermostPostLink voor DMs — dat record is alleen voor
+    # gekoppelde channels.
+    post_link = (
+        await db_session.execute(
+            select(MattermostPostLink).where(MattermostPostLink.post_id == post["id"])
+        )
+    ).scalar_one_or_none()
+    assert post_link is None
+
+
+async def test_dm_post_with_unknown_code_does_not_create_mapping(db_session):
+    """Een DM met een code die niet in de DB staat resulteert in een
+    nette reply en géén mapping."""
+    from unittest.mock import AsyncMock, patch
+
+    from bouwmeester.repositories.mattermost_user import MattermostUserRepository
+
+    mm_uid = _id()
+    post = {
+        "id": _id(),
+        "channel_id": _id(),
+        "user_id": mm_uid,
+        "create_at": 1_700_000_000_000,
+        "message": "BM-doesnotexist klopt dit?",
+    }
+
+    safe_reply = AsyncMock(return_value=None)
+    ingest = MattermostIngestService(db_session)
+    with patch(
+        "bouwmeester.services.mattermost_link_poller.MattermostLinkPoller._safe_reply",
+        new=safe_reply,
+    ):
+        await ingest.ingest_post(post, channel_type="D")
+
+    repo = MattermostUserRepository(db_session)
+    assert await repo.get_by_mattermost_user_id(mm_uid) is None
+    safe_reply.assert_called_once()
+    _, _, message = safe_reply.call_args.args
+    assert "code herken ik niet" in message
+
+
+async def test_dm_post_from_bot_itself_is_ignored(db_session):
+    """Bot-eigen DM-posts (anti feedback-loop) worden vroeg geskipt — dus
+    we moeten geen MattermostLinkPoller instantiëren."""
+    from unittest.mock import patch
+
+    bot_id = _id()
+    ingest = MattermostIngestService(db_session, bot_user_id=bot_id)
+    post = {
+        "id": _id(),
+        "channel_id": _id(),
+        "user_id": bot_id,
+        "create_at": 1_700_000_000_000,
+        "message": "BM-something",
+    }
+
+    with patch(
+        "bouwmeester.services.mattermost_ingest_service."
+        "MattermostIngestService._handle_dm"
+    ) as handle_dm:
+        await ingest.ingest_post(post, channel_type="D")
+    handle_dm.assert_not_called()
+
+
+async def test_group_dm_is_ignored(db_session):
+    """Group-DMs (channel_type='G') vallen niet onder de link-flow én niet
+    onder de channel-link-flow."""
+    from unittest.mock import patch
+
+    post = {
+        "id": _id(),
+        "channel_id": _id(),
+        "user_id": _id(),
+        "create_at": 1_700_000_000_000,
+        "message": "BM-someothercode",
+    }
+
+    ingest = MattermostIngestService(db_session)
+    with patch(
+        "bouwmeester.services.mattermost_ingest_service."
+        "MattermostIngestService._handle_dm"
+    ) as handle_dm:
+        await ingest.ingest_post(post, channel_type="G")
+    handle_dm.assert_not_called()
+
+
+async def test_channel_post_without_channel_type_unaffected(db_session, sample_lead):
+    """Bestaande aanroepen zonder ``channel_type`` blijven door de
+    channel-link-flow lopen — backward compat met bestaande tests."""
+    cid = _id()
+    db_session.add(
+        MattermostChannelLink(
+            channel_id=cid,
+            channel_name="proj",
+            channel_display_name="Project",
+            scope_type=SCOPE_LEAD,
+            scope_id=sample_lead.id,
+            auto_note_enabled=True,
+        )
+    )
+    await db_session.flush()
+
+    ingest = MattermostIngestService(db_session)
+    post = {
+        "id": _id(),
+        "channel_id": cid,
+        "user_id": _id(),
+        "create_at": 1_700_000_000_000,
+        "message": "Een gewone update over het project.",
+    }
+    # Default channel_type=None — moet door channel-link-flow vallen.
+    await ingest.ingest_post(post)
+
+    activity = (
+        await db_session.execute(
+            select(LeadActivity).where(LeadActivity.lead_id == sample_lead.id)
+        )
+    ).scalar_one()
+    assert activity.activity_type == "note"

--- a/backend/tests/test_mattermost_ingest.py
+++ b/backend/tests/test_mattermost_ingest.py
@@ -411,12 +411,12 @@ async def test_initiatief_channel_writes_only_post_link(db_session, sample_initi
 
 def _patch_dm_session(db_session):
     """Patch ``async_session`` in ``mattermost_ingest_service`` zodat
-    ``_handle_dm`` op de test-session werkt ipv een eigen verbinding.
+    ``handle_dm_post`` op de test-session werkt ipv een eigen verbinding.
 
     ``commit()`` en ``rollback()`` op de inner session worden no-op
     gemaakt zodat de outer test-rollback alle DM-writes afvoert en een
     inner-rollback de outer-session niet vernielt — in productie zou
-    ``_handle_dm`` op een aparte session werken, dus de outer-session
+    ``handle_dm_post`` op een aparte session werken, dus de outer-session
     moet ongeacht inner-uitkomst bruikbaar blijven.
     """
     from contextlib import asynccontextmanager
@@ -543,8 +543,7 @@ async def test_dm_post_from_bot_itself_is_ignored(db_session):
     }
 
     with patch(
-        "bouwmeester.services.mattermost_ingest_service."
-        "MattermostIngestService._handle_dm"
+        "bouwmeester.services.mattermost_ingest_service.handle_dm_post"
     ) as handle_dm:
         await ingest.ingest_post(post, channel_type="D")
     handle_dm.assert_not_called()
@@ -565,8 +564,7 @@ async def test_group_dm_is_ignored(db_session):
 
     ingest = MattermostIngestService(db_session)
     with patch(
-        "bouwmeester.services.mattermost_ingest_service."
-        "MattermostIngestService._handle_dm"
+        "bouwmeester.services.mattermost_ingest_service.handle_dm_post"
     ) as handle_dm:
         await ingest.ingest_post(post, channel_type="G")
     handle_dm.assert_not_called()
@@ -628,9 +626,10 @@ async def test_link_poller_integrity_error_keeps_session_usable(
 async def test_dm_handling_failure_does_not_break_outer_session(
     db_session, create_person
 ):
-    """Een onverwachte exception in ``_handle_dm`` mag de outer-session
-    van de WS-loop niet kapot maken. We forceren een fout en checken dat
-    de outer-session daarna nog gewone queries kan uitvoeren."""
+    """Een onverwachte exception in ``handle_dm_post`` mag de
+    outer-session van de WS-loop niet kapot maken. We forceren een fout
+    en checken dat de outer-session daarna nog gewone queries kan
+    uitvoeren."""
     from unittest.mock import AsyncMock, patch
 
     person = await create_person(naam="Outer", prefix="outer")
@@ -651,7 +650,7 @@ async def test_dm_handling_failure_does_not_break_outer_session(
             new=AsyncMock(side_effect=RuntimeError("simulated crash")),
         ),
     ):
-        # Mag NIET propageren — _handle_dm vangt het op.
+        # Mag NIET propageren — handle_dm_post vangt het op.
         await ingest.ingest_post(post, channel_type="D")
 
     # Outer-session is nog bruikbaar voor een vervolgquery.

--- a/backend/tests/test_mattermost_websocket.py
+++ b/backend/tests/test_mattermost_websocket.py
@@ -581,6 +581,32 @@ async def test_patch_reenable_false_rejected_by_pydantic(client, linked_channel)
 # ---------------------------------------------------------------------------
 
 
+async def test_dispatch_posted_does_not_mark_failed_dm_as_processed():
+    """Als ``handle_dm_post`` False returnt (interne fout), mag de post
+    NIET in de dedup-cache komen — anders kan de recovery-loop hem niet
+    later opnieuw oppakken."""
+    import json
+    from unittest.mock import AsyncMock, patch
+
+    svc = MattermostWebsocketService()
+    msg = {
+        "event": "posted",
+        "data": {
+            "channel_type": "D",
+            "post": json.dumps(
+                {"id": "fail1", "channel_id": "c1", "user_id": "u1", "message": "BM-x"}
+            ),
+        },
+    }
+    with patch(
+        "bouwmeester.services.mattermost_ingest_service.handle_dm_post",
+        new=AsyncMock(return_value=False),
+    ):
+        await svc._dispatch_posted(msg)
+
+    assert "fail1" not in svc._recent_dm_post_ids
+
+
 async def test_dispatch_posted_dms_routed_to_handle_dm_post():
     """``data.channel_type=='D'`` triggert de module-level
     ``handle_dm_post`` zonder een outer session te openen — kortste pad
@@ -594,6 +620,7 @@ async def test_dispatch_posted_dms_routed_to_handle_dm_post():
     async def fake_handle_dm_post(post, *, bot_user_id=None):
         captured["post_id"] = post.get("id")
         captured["bot_user_id"] = bot_user_id
+        return True
 
     msg = {
         "event": "posted",

--- a/backend/tests/test_mattermost_websocket.py
+++ b/backend/tests/test_mattermost_websocket.py
@@ -581,18 +581,19 @@ async def test_patch_reenable_false_rejected_by_pydantic(client, linked_channel)
 # ---------------------------------------------------------------------------
 
 
-async def test_dispatch_posted_extracts_channel_type():
-    """``data.channel_type`` (niet ``post.channel_type``) wordt doorgegeven
-    aan ``_record_post`` zodat ``ingest_post`` de DM-flow kan kiezen."""
+async def test_dispatch_posted_dms_routed_to_handle_dm_post():
+    """``data.channel_type=='D'`` triggert de module-level
+    ``handle_dm_post`` zonder een outer session te openen — kortste pad
+    voor link-codes."""
     import json
     from unittest.mock import AsyncMock, patch
 
     svc = MattermostWebsocketService()
     captured: dict = {}
 
-    async def fake_record_post(session, post, *, channel_type=None):
-        captured["channel_type"] = channel_type
+    async def fake_handle_dm_post(post, *, bot_user_id=None):
         captured["post_id"] = post.get("id")
+        captured["bot_user_id"] = bot_user_id
 
     msg = {
         "event": "posted",
@@ -603,10 +604,22 @@ async def test_dispatch_posted_extracts_channel_type():
             ),
         },
     }
-    with patch.object(svc, "_record_post", new=AsyncMock(side_effect=fake_record_post)):
+    svc._bot_user_id = "bot-id"
+    record_post = AsyncMock(return_value=None)
+    with (
+        patch(
+            "bouwmeester.services.mattermost_ingest_service.handle_dm_post",
+            new=AsyncMock(side_effect=fake_handle_dm_post),
+        ),
+        patch.object(svc, "_record_post", new=record_post),
+    ):
         await svc._dispatch_posted(msg)
 
-    assert captured == {"channel_type": "D", "post_id": "p1"}
+    assert captured == {"post_id": "p1", "bot_user_id": "bot-id"}
+    # DM-pad gaat NIET via _record_post — outer session wordt niet geopend.
+    record_post.assert_not_called()
+    # Post is gemarkeerd als verwerkt zodat een recovery-loop 'm skipt.
+    assert "p1" in svc._recent_dm_post_ids
 
 
 async def test_dispatch_posted_with_channel_type_o_falls_through():
@@ -760,6 +773,37 @@ async def test_recover_dm_posts_skips_already_processed_post():
     assert record_post.await_count == 1
     posted_ids = [call.args[1]["id"] for call in record_post.call_args_list]
     assert posted_ids == ["dm-new"]
+
+
+async def test_recover_dm_posts_does_not_advance_cursor_on_failure():
+    """Bij een mislukte ``_record_post`` moet de cursor blijven staan
+    zodat de mislukte post bij de volgende recovery opnieuw verschijnt."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    svc = MattermostWebsocketService()
+    svc._last_dm_recovery_ms = 1_700_000_000_000
+
+    service = MagicMock()
+    service.get_bot_dm_posts = AsyncMock(
+        return_value=[
+            {"id": "good", "user_id": "u1"},
+            {"id": "bad", "user_id": "u2"},
+        ]
+    )
+    session = MagicMock()
+
+    async def flaky_record(_session, post, *, channel_type=None):
+        if post["id"] == "bad":
+            raise RuntimeError("DB-glitch")
+
+    with patch.object(svc, "_record_post", new=AsyncMock(side_effect=flaky_record)):
+        await svc._recover_dm_posts(session, service)
+
+    # Cursor staat nog op het oude punt — anders mist "bad" bij volgende run.
+    assert svc._last_dm_recovery_ms == 1_700_000_000_000
+    # De geslaagde post zit wel in de cache zodat hij niet dubbel komt.
+    assert "good" in svc._recent_dm_post_ids
+    assert "bad" not in svc._recent_dm_post_ids
 
 
 async def test_recover_dm_posts_uses_last_recovery_ms_on_subsequent_runs():

--- a/backend/tests/test_mattermost_websocket.py
+++ b/backend/tests/test_mattermost_websocket.py
@@ -574,3 +574,207 @@ async def test_patch_reenable_false_rejected_by_pydantic(client, linked_channel)
         json={"reenable": False},
     )
     assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# DM-pad: channel_type uit posted-event + recovery + dedup-cache
+# ---------------------------------------------------------------------------
+
+
+async def test_dispatch_posted_extracts_channel_type():
+    """``data.channel_type`` (niet ``post.channel_type``) wordt doorgegeven
+    aan ``_record_post`` zodat ``ingest_post`` de DM-flow kan kiezen."""
+    import json
+    from unittest.mock import AsyncMock, patch
+
+    svc = MattermostWebsocketService()
+    captured: dict = {}
+
+    async def fake_record_post(session, post, *, channel_type=None):
+        captured["channel_type"] = channel_type
+        captured["post_id"] = post.get("id")
+
+    msg = {
+        "event": "posted",
+        "data": {
+            "channel_type": "D",
+            "post": json.dumps(
+                {"id": "p1", "channel_id": "c1", "user_id": "u1", "message": "hoi"}
+            ),
+        },
+    }
+    with patch.object(svc, "_record_post", new=AsyncMock(side_effect=fake_record_post)):
+        await svc._dispatch_posted(msg)
+
+    assert captured == {"channel_type": "D", "post_id": "p1"}
+
+
+async def test_dispatch_posted_with_channel_type_o_falls_through():
+    """Open channel (``channel_type='O'``) hoort de oude channel-link-flow
+    in te gaan, niet de DM-flow. We verifiëren door te kijken dat
+    ``channel_type`` ongewijzigd wordt doorgegeven."""
+    import json
+    from unittest.mock import AsyncMock, patch
+
+    svc = MattermostWebsocketService()
+    captured: dict = {}
+
+    async def fake_record_post(session, post, *, channel_type=None):
+        captured["channel_type"] = channel_type
+
+    msg = {
+        "event": "posted",
+        "data": {
+            "channel_type": "O",
+            "post": json.dumps(
+                {"id": "p2", "channel_id": "c2", "user_id": "u1", "message": "x"}
+            ),
+        },
+    }
+    with patch.object(svc, "_record_post", new=AsyncMock(side_effect=fake_record_post)):
+        await svc._dispatch_posted(msg)
+
+    assert captured["channel_type"] == "O"
+
+
+async def test_dispatch_posted_skips_recently_processed_dm():
+    """Een DM-post-id die al in de in-memory cache zit, wordt niet opnieuw
+    aan ``_record_post`` doorgegeven (race-mitigatie tussen WS-event en
+    DM-recovery)."""
+    import json
+    from unittest.mock import AsyncMock, patch
+
+    svc = MattermostWebsocketService()
+    svc._mark_dm_processed("p3")
+
+    record_post = AsyncMock(return_value=None)
+    msg = {
+        "event": "posted",
+        "data": {
+            "channel_type": "D",
+            "post": json.dumps(
+                {"id": "p3", "channel_id": "c1", "user_id": "u1", "message": "BM-x"}
+            ),
+        },
+    }
+    with patch.object(svc, "_record_post", new=record_post):
+        await svc._dispatch_posted(msg)
+
+    record_post.assert_not_called()
+
+
+def test_recent_dm_cache_evicts_oldest_over_cap():
+    """OrderedDict-cache: bij overflow valt de oudste post-id eruit."""
+    from bouwmeester.services.mattermost_websocket_service import (
+        _RECENT_DM_CACHE_CAP,
+    )
+
+    svc = MattermostWebsocketService()
+    for i in range(_RECENT_DM_CACHE_CAP + 5):
+        svc._mark_dm_processed(f"post-{i}")
+
+    assert len(svc._recent_dm_post_ids) == _RECENT_DM_CACHE_CAP
+    # Oudste 5 zijn weg, jongste 5 zijn er nog.
+    assert "post-0" not in svc._recent_dm_post_ids
+    assert "post-4" not in svc._recent_dm_post_ids
+    assert f"post-{_RECENT_DM_CACHE_CAP + 4}" in svc._recent_dm_post_ids
+
+
+async def test_recover_dm_posts_uses_cold_start_window_on_first_run():
+    """Eerste recovery (``_last_dm_recovery_ms`` is ``None``) moet 2 minuten
+    terug kijken via ``get_bot_dm_posts``."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from bouwmeester.services.mattermost_websocket_service import (
+        _DM_COLD_START_WINDOW_MS,
+    )
+
+    svc = MattermostWebsocketService()
+    service = MagicMock()
+    service.get_bot_dm_posts = AsyncMock(return_value=[])
+    session = MagicMock()
+
+    import time as time_mod
+
+    before = int(time_mod.time() * 1000)
+    await svc._recover_dm_posts(session, service)
+    after = int(time_mod.time() * 1000)
+
+    service.get_bot_dm_posts.assert_called_once()
+    since = service.get_bot_dm_posts.call_args.kwargs["since"]
+    # since moet ~2 min vóór nu liggen.
+    assert before - _DM_COLD_START_WINDOW_MS - 100 <= since
+    assert since <= after - _DM_COLD_START_WINDOW_MS + 100
+    # Na recovery is _last_dm_recovery_ms gezet.
+    assert svc._last_dm_recovery_ms is not None
+    assert before <= svc._last_dm_recovery_ms <= after
+
+
+async def test_recover_dm_posts_processes_each_post_and_marks_seen():
+    """Recovered posts worden doorgegeven aan ``_record_post`` met
+    ``channel_type='D'`` en in de dedup-cache gezet."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    svc = MattermostWebsocketService()
+    service = MagicMock()
+    service.get_bot_dm_posts = AsyncMock(
+        return_value=[
+            {"id": "dm1", "user_id": "u1"},
+            {"id": "dm2", "user_id": "u2"},
+        ]
+    )
+    session = MagicMock()
+
+    record_post = AsyncMock(return_value=None)
+    with patch.object(svc, "_record_post", new=record_post):
+        await svc._recover_dm_posts(session, service)
+
+    assert record_post.await_count == 2
+    for call in record_post.call_args_list:
+        assert call.kwargs["channel_type"] == "D"
+    assert "dm1" in svc._recent_dm_post_ids
+    assert "dm2" in svc._recent_dm_post_ids
+
+
+async def test_recover_dm_posts_skips_already_processed_post():
+    """Als een post al in de dedup-cache zit (vroeg WS-event), wordt 'ie
+    niet opnieuw verwerkt door de recovery-loop."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    svc = MattermostWebsocketService()
+    svc._mark_dm_processed("dm-already-seen")
+
+    service = MagicMock()
+    service.get_bot_dm_posts = AsyncMock(
+        return_value=[
+            {"id": "dm-already-seen", "user_id": "u1"},
+            {"id": "dm-new", "user_id": "u2"},
+        ]
+    )
+    session = MagicMock()
+
+    record_post = AsyncMock(return_value=None)
+    with patch.object(svc, "_record_post", new=record_post):
+        await svc._recover_dm_posts(session, service)
+
+    assert record_post.await_count == 1
+    posted_ids = [call.args[1]["id"] for call in record_post.call_args_list]
+    assert posted_ids == ["dm-new"]
+
+
+async def test_recover_dm_posts_uses_last_recovery_ms_on_subsequent_runs():
+    """Tweede recovery kijkt vanaf ``_last_dm_recovery_ms``, niet vanaf
+    de cold-start-window."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    svc = MattermostWebsocketService()
+    svc._last_dm_recovery_ms = 1_700_000_000_000
+
+    service = MagicMock()
+    service.get_bot_dm_posts = AsyncMock(return_value=[])
+    session = MagicMock()
+
+    await svc._recover_dm_posts(session, service)
+
+    service.get_bot_dm_posts.assert_called_once()
+    assert service.get_bot_dm_posts.call_args.kwargs["since"] == 1_700_000_000_000

--- a/frontend/src/components/admin/WorkerHealthTable.tsx
+++ b/frontend/src/components/admin/WorkerHealthTable.tsx
@@ -3,8 +3,7 @@ import { useWorkerHealth, type WorkerHealth, type WorkerHeartbeat } from '@/hook
 
 const LOOP_LABELS: Record<string, string> = {
   parlementair: 'Parlementaire import',
-  mattermost_link: 'Mattermost: account-koppeling (DM-poller)',
-  mattermost_websocket: 'Mattermost: meelezen in kanalen (websocket)',
+  mattermost_websocket: 'Mattermost: websocket (kanaal-meelezen + DM-koppeling)',
   opdracht_task: 'Opdracht-taken (deadlines, budget)',
   fcc_sync: 'Fortes Change Cloud sync',
 };


### PR DESCRIPTION
## Samenvatting

De DM-poller draaide elke 15s door alle bot-DM-channels heen om link-codes (`BM-...`) op te pikken. Dat zijn ~5760 onnodige Mattermost API-calls per dag, terwijl die DM-events al binnenkwamen via de bestaande websocket — alleen werden ze in `MattermostIngestService.ingest_post` gedropt omdat een DM geen `MattermostChannelLink` heeft.

Deze PR routeert DM-posts naar `MattermostLinkPoller` via een nieuwe `channel_type=\"D\"`-tak in `ingest_post`. De polling-loop is volledig weg.

## Wat is er veranderd

- **`MattermostIngestService.ingest_post`** accepteert `channel_type`. `\"D\"` → `_handle_dm` → bestaande `MattermostLinkPoller`. `\"G\"` (group-DM) wordt genegeerd. Andere waardes / `None` vallen door naar de channel-link-flow.
- **`MattermostWebsocketService._dispatch_posted`** pakt `data.channel_type` uit het Mattermost-event en geeft het door aan `_record_post`.
- **DM-recovery in `_recover_missed_posts`**: bij cold start 2 min terug, daarna vanaf vorige recovery. Vangnet voor link-codes die binnenkomen tijdens een korte WS-disconnect.
- **In-memory dedup-cache** (`_recent_dm_post_ids`, cap 500) mitigeert de race tussen WS-event en recovery-loop bij reconnect — voorkomt een tweede \"code herken ik niet\"-reply na succesvolle koppeling.
- **Polling-loop weg**: `_mattermost_link_loop`, `MATTERMOST_POLL_INTERVAL_SECONDS`, `mattermost_link` heartbeat-key. De resterende `mattermost_websocket`-heartbeat dekt nu beide functies; de label in `WorkerHealthTable.tsx` is aangepast.

## Test plan

- [ ] CI groen (ruff, eslint, tsc, pytest)
- [ ] `just up` met Mattermost-config aan; logs tonen `Mattermost websocket: connected`, géén `Mattermost link poller started`
- [ ] Genereer link-code in Settings → plak in DM naar bot → koppeling binnen ~1s, bot-reply met `:white_check_mark:`
- [ ] Onbekende code in DM → reply \"code herken ik niet\", géén mapping
- [ ] `docker compose restart worker` terwijl een DM met code onderweg is → 2-min recovery-window pakt 'm op (zoek log `DM-recovery: N posts opnieuw verwerkt`)
- [ ] Bestaand kanaal-meelezen (auto-note op lead-channels) blijft werken
- [ ] Beheer > Systeem toont websocket-row als healthy, geen losse `mattermost_link`-row meer