### PR TITLE
Mattermost @username → echte mentions in lead-notes

### DIFF
--- a/backend/bouwmeester/repositories/mattermost_user.py
+++ b/backend/bouwmeester/repositories/mattermost_user.py
@@ -32,6 +32,15 @@ class MattermostUserRepository:
         result = await self.session.execute(stmt)
         return result.scalar_one_or_none()
 
+    async def get_by_mattermost_username(
+        self, mattermost_username: str
+    ) -> MattermostUser | None:
+        stmt = select(MattermostUser).where(
+            MattermostUser.mattermost_username == mattermost_username
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
     async def create_mapping(
         self,
         person_id: UUID,

--- a/backend/bouwmeester/services/mattermost_ingest_service.py
+++ b/backend/bouwmeester/services/mattermost_ingest_service.py
@@ -41,6 +41,10 @@ from bouwmeester.services.mattermost_doc_link_extractor import (
     derive_attachment_label,
     extract_doc_links,
 )
+from bouwmeester.services.mattermost_mention_renderer import (
+    render_mattermost_message_to_tiptap,
+)
+from bouwmeester.services.mention_helper import sync_and_notify_mentions
 
 logger = logging.getLogger(__name__)
 
@@ -236,7 +240,16 @@ class MattermostIngestService:
         prefix = ""
         if author_person_id is None and mm_user_id:
             prefix = f"_(via mm:@{mm_user_id})_  \n"
-        content = prefix + body
+        plain_content = prefix + body
+
+        # Probeer @username-vermeldingen om te zetten naar TipTap-mentions
+        # zodat het frontend ze als klikbare badge rendert. Als geen enkele
+        # username aan een Person gekoppeld is, vallen we terug op platte
+        # tekst (bestaand gedrag).
+        tiptap_json, mentioned_ids = await render_mattermost_message_to_tiptap(
+            self.session, plain_content
+        )
+        content = tiptap_json or plain_content
 
         metadata = {
             "source": "mattermost",
@@ -260,6 +273,22 @@ class MattermostIngestService:
         self.session.add(activity)
         await self.session.flush()
         await self.session.refresh(activity)
+
+        # Sync mentions + notify gementionde personen. Geen-op als content
+        # geen TipTap-JSON is (sync_mentions parsed dan een lege lijst).
+        if mentioned_ids:
+            lead = await self.session.get(Lead, lead_id)
+            lead_title = lead.title if lead is not None else "Mattermost-bericht"
+            await sync_and_notify_mentions(
+                self.session,
+                "lead_activity",
+                activity.id,
+                content,
+                lead_title,
+                sender_id=author_person_id,
+                source_lead_id=lead_id,
+                exclude_person_id=author_person_id,
+            )
 
         for link in extract_doc_links(message):
             url = link["url"]

--- a/backend/bouwmeester/services/mattermost_mention_renderer.py
+++ b/backend/bouwmeester/services/mattermost_mention_renderer.py
@@ -1,0 +1,100 @@
+"""Bouw TipTap-JSON uit een Mattermost-bericht met @username-vermeldingen.
+
+Mattermost levert een mention als platte tekst ``@username``. Wij willen die
+als klikbare TipTap-mention tonen — mits de username gekoppeld is aan een
+``Person``. Onbekende mentions blijven gewoon tekst staan.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bouwmeester.models.mattermost_user import MattermostUser
+from bouwmeester.models.person import Person
+
+# Mattermost-usernames: 3-22 tekens, ``a-z0-9._-``. We accepteren ook iets
+# langere strings (sommige instances staan tot 64 toe) en filteren bekende
+# kanaalnamen later op DB-lookup.
+_MENTION_RE = re.compile(r"@([a-z0-9][a-z0-9._-]{1,63})")
+
+
+async def _resolve_usernames(
+    session: AsyncSession, usernames: set[str]
+) -> dict[str, tuple[UUID, str]]:
+    """Map Mattermost-username → (person_id, person_naam) via DB-lookup."""
+    if not usernames:
+        return {}
+    stmt = (
+        select(
+            MattermostUser.mattermost_username,
+            MattermostUser.person_id,
+            Person.naam,
+        )
+        .join(Person, Person.id == MattermostUser.person_id)
+        .where(MattermostUser.mattermost_username.in_(usernames))
+    )
+    rows = (await session.execute(stmt)).all()
+    return {row[0]: (row[1], row[2]) for row in rows}
+
+
+def _build_paragraph(line: str, resolved: dict[str, tuple[UUID, str]]) -> dict:
+    """Bouw één TipTap-paragraph; vervang bekende ``@username`` door mention-nodes."""
+    children: list[dict] = []
+    cursor = 0
+    for match in _MENTION_RE.finditer(line):
+        username = match.group(1)
+        hit = resolved.get(username)
+        if hit is None:
+            continue
+        person_id, naam = hit
+        # Tekst voor de mention.
+        if match.start() > cursor:
+            children.append({"type": "text", "text": line[cursor : match.start()]})
+        children.append(
+            {
+                "type": "mention",
+                "attrs": {
+                    "id": str(person_id),
+                    "label": naam,
+                    "mentionType": "person",
+                },
+            }
+        )
+        cursor = match.end()
+    # Restant.
+    if cursor < len(line):
+        children.append({"type": "text", "text": line[cursor:]})
+    elif not children:
+        # Volledig lege regel — TipTap accepteert een paragraph zonder content.
+        return {"type": "paragraph"}
+    return {"type": "paragraph", "content": children}
+
+
+async def render_mattermost_message_to_tiptap(
+    session: AsyncSession, message: str
+) -> tuple[str | None, list[UUID]]:
+    """Zet ``message`` om naar een TipTap-JSON-string als er gekoppelde
+    ``@username``-vermeldingen in zitten.
+
+    Returns ``(tiptap_json, mentioned_person_ids)``. Wanneer geen enkele
+    username gekoppeld is, geven we ``(None, [])`` terug zodat de caller op
+    de oorspronkelijke platte-tekst-flow kan terugvallen.
+    """
+    if not message:
+        return None, []
+
+    candidates = {m.group(1) for m in _MENTION_RE.finditer(message)}
+    resolved = await _resolve_usernames(session, candidates)
+    if not resolved:
+        return None, []
+
+    # Splits op newlines zodat regelopmaak intact blijft.
+    paragraphs = [_build_paragraph(line, resolved) for line in message.split("\n")]
+    doc = {"type": "doc", "content": paragraphs}
+    person_ids = [pid for pid, _ in resolved.values()]
+    return json.dumps(doc, ensure_ascii=False), person_ids

--- a/backend/scripts/backfill_mattermost_mentions.py
+++ b/backend/scripts/backfill_mattermost_mentions.py
@@ -1,0 +1,78 @@
+"""Backfill ``@username``-mentions in bestaande Mattermost-LeadActivities.
+
+Loop alle ``LeadActivity``-records langs waar ``metadata_->>'source' =
+'mattermost'`` én ``content`` géén TipTap-JSON is. Render opnieuw met de
+ingest-helper; als er nu wel een gekoppelde mention te vinden is, schrijf
+de TipTap-JSON terug en sync ``Mention``-records (geen notificaties — die
+zouden retroactief storen).
+
+Run:
+
+    uv run --project backend python -m scripts.backfill_mattermost_mentions
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from sqlalchemy import select
+
+from bouwmeester.core.database import async_session
+from bouwmeester.models.lead_activity import LeadActivity
+from bouwmeester.services.mattermost_mention_renderer import (
+    render_mattermost_message_to_tiptap,
+)
+from bouwmeester.services.mention_service import MentionService
+
+logger = logging.getLogger(__name__)
+
+
+def _looks_like_tiptap(content: str) -> bool:
+    s = content.lstrip()
+    return s.startswith('{"type"') or s.startswith("{'type'")
+
+
+async def backfill() -> tuple[int, int]:
+    """Returns ``(geïnspecteerd, herschreven)``."""
+    inspected = 0
+    rewritten = 0
+    async with async_session() as session:
+        stmt = select(LeadActivity).where(
+            LeadActivity.metadata_["source"].as_string() == "mattermost"
+        )
+        rows = (await session.execute(stmt)).scalars().all()
+        for activity in rows:
+            inspected += 1
+            if not activity.content or _looks_like_tiptap(activity.content):
+                continue
+            tiptap_json, mentioned_ids = await render_mattermost_message_to_tiptap(
+                session, activity.content
+            )
+            if not tiptap_json or not mentioned_ids:
+                continue
+            activity.content = tiptap_json
+            await MentionService(session).sync_mentions(
+                "lead_activity",
+                activity.id,
+                tiptap_json,
+                created_by=activity.author_id,
+            )
+            rewritten += 1
+            logger.info(
+                "Herschreven LeadActivity %s met %d mention(s)",
+                activity.id,
+                len(mentioned_ids),
+            )
+        await session.commit()
+    return inspected, rewritten
+
+
+async def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    inspected, rewritten = await backfill()
+    print(f"Geïnspecteerd: {inspected}, herschreven: {rewritten}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/tests/test_mattermost_ingest.py
+++ b/backend/tests/test_mattermost_ingest.py
@@ -323,6 +323,133 @@ async def test_lead_channel_unlinked_author_uses_via_prefix(db_session, sample_l
     assert f"via mm:@{mm_uid}" in activity.content
 
 
+async def test_lead_channel_renders_at_mentions_as_tiptap(
+    db_session, sample_lead, create_person
+):
+    """``@username`` van een gekoppeld persoon wordt een TipTap-mention
+    zodat de frontend een klikbare badge kan tonen."""
+    import json
+
+    from bouwmeester.models.mention import Mention
+    from bouwmeester.models.notification import Notification
+
+    anne = await create_person(naam="Anne Schuth", prefix="anne.schuth")
+    daan = await create_person(naam="Daan Wijnhorst", prefix="daan")
+    cid = _id()
+    daan_mm_uid = _id()
+    db_session.add_all(
+        [
+            MattermostChannelLink(
+                channel_id=cid,
+                channel_name="proj",
+                channel_display_name="Project",
+                scope_type=SCOPE_LEAD,
+                scope_id=sample_lead.id,
+                auto_note_enabled=True,
+            ),
+            MattermostUser(
+                person_id=anne.id,
+                mattermost_user_id=_id(),
+                mattermost_username="anne.schuth-rijksoverheid",
+            ),
+            MattermostUser(
+                person_id=daan.id,
+                mattermost_user_id=daan_mm_uid,
+                mattermost_username="daan",
+            ),
+        ]
+    )
+    await db_session.flush()
+
+    ingest = MattermostIngestService(db_session)
+    post = {
+        "id": _id(),
+        "channel_id": cid,
+        "user_id": daan_mm_uid,
+        "create_at": 1_700_000_000_000,
+        "message": ("@anne.schuth-rijksoverheid handig om ff over WOW te overleggen"),
+    }
+    await ingest.ingest_post(post)
+
+    activity = (
+        await db_session.execute(
+            select(LeadActivity).where(LeadActivity.lead_id == sample_lead.id)
+        )
+    ).scalar_one()
+
+    doc = json.loads(activity.content)
+    assert doc["type"] == "doc"
+    inline = doc["content"][0]["content"]
+    mention_nodes = [n for n in inline if n["type"] == "mention"]
+    assert len(mention_nodes) == 1
+    assert mention_nodes[0]["attrs"]["id"] == str(anne.id)
+    assert mention_nodes[0]["attrs"]["label"] == "Anne Schuth"
+    assert mention_nodes[0]["attrs"]["mentionType"] == "person"
+
+    # Mention-record voor back-references.
+    mentions = (
+        (
+            await db_session.execute(
+                select(Mention).where(
+                    Mention.source_type == "lead_activity",
+                    Mention.source_id == activity.id,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert [m.target_id for m in mentions] == [anne.id]
+
+    # Anne krijgt een notification, Daan (de auteur) niet.
+    notifs = (
+        (
+            await db_session.execute(
+                select(Notification).where(Notification.type == "mention")
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert [n.person_id for n in notifs] == [anne.id]
+    assert notifs[0].related_lead_id == sample_lead.id
+
+
+async def test_lead_channel_unknown_username_stays_plain_text(db_session, sample_lead):
+    """Een ``@username`` zonder MattermostUser-koppeling blijft platte tekst."""
+    cid = _id()
+    db_session.add(
+        MattermostChannelLink(
+            channel_id=cid,
+            channel_name="proj",
+            channel_display_name="Project",
+            scope_type=SCOPE_LEAD,
+            scope_id=sample_lead.id,
+            auto_note_enabled=True,
+        )
+    )
+    await db_session.flush()
+
+    ingest = MattermostIngestService(db_session)
+    post = {
+        "id": _id(),
+        "channel_id": cid,
+        "user_id": _id(),
+        "create_at": 1_700_000_000_000,
+        "message": "@onbekend hoi",
+    }
+    await ingest.ingest_post(post)
+
+    activity = (
+        await db_session.execute(
+            select(LeadActivity).where(LeadActivity.lead_id == sample_lead.id)
+        )
+    ).scalar_one()
+    # Geen TipTap, geen mention-node — gewoon de oorspronkelijke tekst.
+    assert "@onbekend hoi" in activity.content
+    assert not activity.content.startswith("{")
+
+
 async def test_lead_channel_with_auto_note_disabled_skips_activity(
     db_session, sample_lead
 ):

--- a/justfile
+++ b/justfile
@@ -56,6 +56,10 @@ migration NAME:
 seed:
     cd backend && uv run python scripts/seed.py
 
+# Backfill TipTap-mentions in bestaande Mattermost-LeadActivities
+backfill-mattermost-mentions:
+    cd backend && DATABASE_URL=postgresql+asyncpg://bouwmeester:bouwmeester@localhost:5433/bouwmeester uv run python -m scripts.backfill_mattermost_mentions
+
 # Force restart all services (always works, even after crashes)
 kick:
     -docker compose down backend


### PR DESCRIPTION
## Summary
- `@username` in Mattermost-berichten wordt bij ingest opgezocht in `MattermostUser`. Bij een match schrijven we de auto-note als TipTap-JSON met een mention-node, zodat de frontend de klikbare badge rendert (zelfde rendering als reguliere mentions in Bouwmeester).
- Mention-records worden gesynced via `sync_and_notify_mentions` zodat back-references werken; gementionde personen krijgen een notificatie, de auteur zelf wordt overgeslagen.
- Onbekende usernames blijven platte tekst — geen regressie op huidig gedrag.
- Backfill-script (`just backfill-mattermost-mentions`) herschrijft bestaande Mattermost-notes waarvan een username nu wél matcht; geen retro-notificaties.

## Test plan
- [x] `pytest backend/tests/test_mattermost_ingest.py` — 15/15 groen
- [ ] In productie: `just backfill-mattermost-mentions` om de bestaande "VIA MATTERMOST"-notitie van Daan te herschrijven
- [ ] UI-check: oude note toont `@Anne Schuth` als blauwe badge, nieuwe Mattermost-berichten met `@username` ook