### PR TITLE
Mattermost-websocket: geen reconnect-storm op rustige kanalen

### DIFF
--- a/backend/bouwmeester/services/mattermost_websocket_service.py
+++ b/backend/bouwmeester/services/mattermost_websocket_service.py
@@ -239,21 +239,18 @@ class MattermostWebsocketService:
                 await service.close()
 
     async def _read_loop(self, ws) -> None:
-        last_activity = time.monotonic()
         last_heartbeat = 0.0
         while not self._stop:
             try:
                 raw = await asyncio.wait_for(ws.recv(), timeout=_HEARTBEAT_INTERVAL)
-                last_activity = time.monotonic()
             except TimeoutError:
-                # Stuur een lichte ping via een no-op authentication_challenge?
-                # Mattermost gebruikt geen expliciet ping/pong voor clients;
-                # bij langdurige stilte (>2x interval) breken we de connectie.
-                if time.monotonic() - last_activity > _HEARTBEAT_INTERVAL * 2:
-                    raise RuntimeError("Mattermost websocket: idle timeout")
-                # Idle but still under threshold — refresh the heartbeat row
-                # so the admin UI can distinguish "connected, just quiet" from
-                # "connected then died". Once per minute is plenty.
+                # Geen events binnen het heartbeat-venster — gewoon
+                # admin-UI heartbeat ticken. De `websockets`-library doet
+                # zelf ping/pong elke 20s (zie ``ping_interval`` in run());
+                # die control-frames passeren ``recv()`` niet, dus stilte
+                # hier zegt niets over de connectie-gezondheid. Een dode
+                # connectie wordt door de library zelf opgemerkt en als
+                # ``ConnectionClosed`` op ``recv()`` opgegooid.
                 if time.monotonic() - last_heartbeat > 60.0:
                     last_heartbeat = time.monotonic()
                     await health_tick(

--- a/backend/tests/test_mattermost_websocket.py
+++ b/backend/tests/test_mattermost_websocket.py
@@ -887,11 +887,13 @@ async def test_read_loop_idle_does_not_raise_on_long_silence(monkeypatch):
         await asyncio.sleep(0.25)
         svc._stop = True
 
-    asyncio.create_task(stopper())
-
-    # Mag terugkeren zonder RuntimeError, ondanks dat er nooit een frame
-    # is binnengekomen.
-    await svc._read_loop(fake_ws)
+    stopper_task = asyncio.create_task(stopper())
+    try:
+        # Mag terugkeren zonder RuntimeError, ondanks dat er nooit een
+        # frame is binnengekomen.
+        await svc._read_loop(fake_ws)
+    finally:
+        await stopper_task
 
 
 async def test_read_loop_propagates_connection_closed(monkeypatch):

--- a/backend/tests/test_mattermost_websocket.py
+++ b/backend/tests/test_mattermost_websocket.py
@@ -849,3 +849,67 @@ async def test_recover_dm_posts_uses_last_recovery_ms_on_subsequent_runs():
 
     service.get_bot_dm_posts.assert_called_once()
     assert service.get_bot_dm_posts.call_args.kwargs["since"] == 1_700_000_000_000
+
+
+# ---------------------------------------------------------------------------
+# _read_loop idle-gedrag — lange stilte mag niet leiden tot reconnect-storm
+# ---------------------------------------------------------------------------
+
+
+async def test_read_loop_idle_does_not_raise_on_long_silence(monkeypatch):
+    """Bij een rustig kanaal (geen events binnen ``_HEARTBEAT_INTERVAL``)
+    mag ``_read_loop`` géén ``RuntimeError`` gooien. De ``websockets``-
+    library doet zelf ping/pong; een artificiële idle-counter veroorzaakt
+    alleen reconnect-stormen op stille verbindingen."""
+    import asyncio
+    from unittest.mock import AsyncMock
+
+    from bouwmeester.services import mattermost_websocket_service as ws_mod
+
+    svc = MattermostWebsocketService()
+
+    # Nooit een echte recv() — trigger altijd TimeoutError. Dit zou
+    # vóór de fix na 60s een RuntimeError("idle timeout") opgooien.
+    async def never_resolves():
+        await asyncio.sleep(3600)
+
+    fake_ws = AsyncMock()
+    fake_ws.recv = AsyncMock(side_effect=never_resolves)
+
+    # Maak het heartbeat-interval kort zodat de test niet 30s wacht.
+    monkeypatch.setattr(ws_mod, "_HEARTBEAT_INTERVAL", 0.05)
+
+    # Health-tick mocken zodat we niet daadwerkelijk de DB raken.
+    monkeypatch.setattr(ws_mod, "health_tick", AsyncMock(return_value=None))
+
+    # Stop het loopje na een tijdje van buitenaf.
+    async def stopper():
+        await asyncio.sleep(0.25)
+        svc._stop = True
+
+    asyncio.create_task(stopper())
+
+    # Mag terugkeren zonder RuntimeError, ondanks dat er nooit een frame
+    # is binnengekomen.
+    await svc._read_loop(fake_ws)
+
+
+async def test_read_loop_propagates_connection_closed(monkeypatch):
+    """Bij een echte connection-close (door library zelf opgemerkt via
+    ping-timeout) mag ``_read_loop`` de exception laten bubblen zodat
+    ``run()`` reconnect."""
+    from unittest.mock import AsyncMock
+
+    import websockets
+
+    from bouwmeester.services import mattermost_websocket_service as ws_mod
+
+    svc = MattermostWebsocketService()
+    fake_ws = AsyncMock()
+    fake_ws.recv = AsyncMock(side_effect=websockets.ConnectionClosedError(None, None))
+
+    monkeypatch.setattr(ws_mod, "_HEARTBEAT_INTERVAL", 0.05)
+    monkeypatch.setattr(ws_mod, "health_tick", AsyncMock(return_value=None))
+
+    with pytest.raises(websockets.ConnectionClosedError):
+        await svc._read_loop(fake_ws)


### PR DESCRIPTION
## Samenvatting

In productie zagen we elke ~minuut:

\`\`\`
RuntimeError: Mattermost websocket: idle timeout
\`\`\`

`_read_loop` raised die fout wanneer er 60s lang geen frame uit `ws.recv()` kwam. Maar de `websockets`-library doet zelf al ping/pong elke 20s (geconfigureerd in `run()` met `ping_interval=20, ping_timeout=20`). Pongs passeren `recv()` niet — dat zijn control-frames die de library transparant afhandelt. Op een rustig kanaal zonder messages tikte de idle-teller daarom sowieso af, ook al was de connectie gezond.

Effect: continue reconnects op stille kanalen → ruis in de logs en een korte gap waarin events kunnen missen tussen disconnect en `_recover_missed_posts`.

## Fix

Idle-timeout schrappen. De library detecteert dode connecties zelf via ping-timeout en raise't dan `ConnectionClosedError` op `recv()` — die exception bubbelt al door `run()` en triggert een reconnect met exponential backoff. We tikken nog wel de admin-UI heartbeat elke 60s zodat operators \"connected, just quiet\" kunnen onderscheiden van \"stuk\".

## Test plan

- [ ] CI groen
- [ ] Productie-logs tonen geen `idle timeout`-RuntimeErrors meer op rustige periodes
- [ ] Bij echte connection-loss (proxy down, server restart) zie je nog steeds reconnects met backoff via `ConnectionClosedError`
- [ ] Beheer > Systeem toont nog steeds `connected — idle (no events)` na 1 minuut stilte