### PR TITLE
Lead-suggesties: oude leads ook vinden via trigram-similarity

### DIFF
--- a/backend/bouwmeester/services/llm/prompts.py
+++ b/backend/bouwmeester/services/llm/prompts.py
@@ -545,7 +545,7 @@ def build_chat_context_message(context: dict | None) -> str:
 # ---------------------------------------------------------------------------
 
 
-MAX_RECENT_LEADS_IN_PROMPT = 20
+MAX_RECENT_LEADS_IN_PROMPT = 60
 
 
 def build_classify_mattermost_lead_prompt(
@@ -558,16 +558,21 @@ def build_classify_mattermost_lead_prompt(
     """Bouw een prompt voor het classificeren van een Mattermost-bericht
     als (potentiële) lead binnen een initiatief.
 
-    ``recent_leads`` is een lijst dicts ``{id, title, stage}`` van leads
-    binnen hetzelfde initiatief, zodat de LLM duplicaten kan voorstellen.
+    ``recent_leads`` is een lijst dicts ``{id, title, organization, stage}``
+    van leads binnen hetzelfde initiatief, zodat de LLM duplicaten kan
+    voorstellen. De caller bepaalt de selectie (recency + trigram-
+    similarity); deze functie cap't alleen op ``MAX_RECENT_LEADS_IN_PROMPT``.
     """
     leads_block = ""
     if recent_leads:
         items = []
         for lead in recent_leads[:MAX_RECENT_LEADS_IN_PROMPT]:
+            org = lead.get("organization")
+            org_part = f', organisatie: "{org}"' if org else ""
             items.append(
                 f"- id: {lead['id']}, "
-                f'titel: "{lead["title"]}", '
+                f'titel: "{lead["title"]}"'
+                f"{org_part}, "
                 f"stage: {lead.get('stage', '?')}"
             )
         leads_block = (

--- a/backend/bouwmeester/services/mattermost_ingest_service.py
+++ b/backend/bouwmeester/services/mattermost_ingest_service.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import logging
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -48,6 +48,19 @@ from bouwmeester.services.mattermost_mention_renderer import (
 from bouwmeester.services.mention_helper import sync_and_notify_mentions
 
 logger = logging.getLogger(__name__)
+
+
+# Selectie van bestaande leads die meegaan in de LLM-prompt voor
+# duplicate-detection. We nemen een unie van twee groepen, dedupliceren op
+# id en cappen op MAX_LEADS_FOR_LLM:
+#   1. de N nieuwste leads (vangt kwesties op die nog actief gespeeld worden)
+#   2. de M leads waarvan titel/organisatie het meest lijkt op het
+#      bericht via pg_trgm word_similarity (vangt oude leads waarvan de
+#      naam expliciet genoemd wordt)
+RECENT_LEADS_FOR_LLM = 25
+SIMILAR_LEADS_FOR_LLM = 50
+SIMILAR_LEAD_THRESHOLD = 0.3
+MAX_LEADS_FOR_LLM = 60
 
 
 async def handle_dm_post(post: dict, *, bot_user_id: str | None = None) -> bool:
@@ -400,15 +413,17 @@ class MattermostIngestService:
             )
             return None, "stale_initiatief"
 
-        recent_leads_stmt = (
-            select(Lead.id, Lead.title, Lead.stage)
-            .where(Lead.initiatief_id == channel_link_initiatief_id)
-            .order_by(Lead.created_at.desc())
-            .limit(20)
+        rows = await self._collect_lead_candidates_for_llm(
+            channel_link_initiatief_id, message
         )
-        rows = (await self.session.execute(recent_leads_stmt)).all()
         recent = [
-            {"id": str(row.id), "title": row.title, "stage": row.stage} for row in rows
+            {
+                "id": str(row.id),
+                "title": row.title,
+                "organization": row.organization,
+                "stage": row.stage,
+            }
+            for row in rows
         ]
 
         result = await llm.classify_mattermost_lead_candidate(
@@ -468,6 +483,63 @@ class MattermostIngestService:
             )
 
         return suggested.id, None
+
+    async def _collect_lead_candidates_for_llm(
+        self, initiatief_id: UUID, message: str
+    ) -> list:
+        """Selecteer bestaande leads die mogelijk relevant zijn voor de
+        LLM-duplicate-check.
+
+        Twee groepen, gededupliceerd op id en gecapped:
+
+        1. ``RECENT_LEADS_FOR_LLM`` nieuwste leads voor dit initiatief
+           (recency, vangt actieve kwesties zonder expliciete naam in
+           het bericht).
+        2. ``SIMILAR_LEADS_FOR_LLM`` leads die het meest lijken op het
+           bericht via ``pg_trgm.word_similarity`` op titel of
+           organisatie (vangt oude leads waarvan de naam expliciet
+           genoemd wordt; bv. "HHNK" matcht een lead "HHNK
+           (Hoogheemraadschap...)" ook al staat die niet in de top-25).
+
+        Recente leads krijgen voorrang in de dedup zodat hun ``stage``
+        consistent is. ``SIMILAR_LEAD_THRESHOLD`` is een ruime default;
+        ``word_similarity`` retourneert 0..1 en 0.3 vangt afkortingen +
+        kleine spelvariaties zonder te veel ruis.
+        """
+        recent_stmt = (
+            select(Lead.id, Lead.title, Lead.organization, Lead.stage)
+            .where(Lead.initiatief_id == initiatief_id)
+            .order_by(Lead.created_at.desc())
+            .limit(RECENT_LEADS_FOR_LLM)
+        )
+        recent_rows = (await self.session.execute(recent_stmt)).all()
+
+        # Pre-filter ruwweg op een ondergrens om geen full-table-scan op te
+        # eten in initiatieven met veel leads. word_similarity is symmetrisch:
+        # we zoeken leads waar TITEL of ORG voorkomt als "woord" in MESSAGE.
+        title_sim = func.word_similarity(Lead.title, message)
+        org_sim = func.word_similarity(Lead.organization, message)
+        max_sim = func.greatest(title_sim, func.coalesce(org_sim, 0.0))
+        similar_stmt = (
+            select(Lead.id, Lead.title, Lead.organization, Lead.stage)
+            .where(
+                Lead.initiatief_id == initiatief_id,
+                or_(
+                    title_sim > SIMILAR_LEAD_THRESHOLD,
+                    org_sim > SIMILAR_LEAD_THRESHOLD,
+                ),
+            )
+            .order_by(max_sim.desc())
+            .limit(SIMILAR_LEADS_FOR_LLM)
+        )
+        similar_rows = (await self.session.execute(similar_stmt)).all()
+
+        merged: dict = {}
+        for row in recent_rows:
+            merged[row.id] = row
+        for row in similar_rows:
+            merged.setdefault(row.id, row)
+        return list(merged.values())[:MAX_LEADS_FOR_LLM]
 
     async def _post_suggestion_reply(
         self,

--- a/backend/tests/test_mattermost_suggested_lead.py
+++ b/backend/tests/test_mattermost_suggested_lead.py
@@ -561,3 +561,75 @@ async def test_llm_says_no_marks_no_lead(db_session, sample_channel):
         )
     ).scalar_one()
     assert pl.skipped_reason == "no_lead"
+
+
+# ---------------------------------------------------------------------------
+# Lead-kandidaten-selectie voor LLM (recency + trigram-similarity)
+# ---------------------------------------------------------------------------
+
+
+async def test_collect_candidates_includes_old_lead_via_similarity(
+    db_session, sample_initiatief
+):
+    """Een oude lead (buiten de top-25 recency) moet via trigram-similarity
+    op organisatie/titel toch in de kandidaten-lijst belanden zodra de
+    naam in het bericht voorkomt. Reproductie van het HHNK-scenario."""
+    from datetime import UTC, datetime, timedelta
+
+    # 1 oude HHNK-lead, lang geleden aangemaakt.
+    old = Lead(
+        id=uuid.uuid4(),
+        title="HHNK",
+        organization="Hoogheemraadschap Hollands Noorderkwartier",
+        initiatief_id=sample_initiatief.id,
+        stage="in_the_pocket",
+    )
+    db_session.add(old)
+    await db_session.flush()
+    old.created_at = datetime.now(UTC) - timedelta(days=120)
+
+    # Ruim genoeg jongere leads om de oude HHNK uit de top-25 te duwen.
+    for i in range(40):
+        recent = Lead(
+            id=uuid.uuid4(),
+            title=f"Andere lead {i}",
+            organization=f"Organisatie {i}",
+            initiatief_id=sample_initiatief.id,
+            stage="lead",
+        )
+        db_session.add(recent)
+    await db_session.flush()
+
+    ingest = MattermostIngestService(db_session)
+    rows = await ingest._collect_lead_candidates_for_llm(
+        sample_initiatief.id,
+        "Ik denk dat ik een nieuwe lead heb! HHNK lijkt een goeie partner",
+    )
+
+    ids = [r.id for r in rows]
+    assert old.id in ids, (
+        "Oude HHNK-lead moet via trigram-similarity gevonden worden, "
+        "ook al staat hij niet in de top-25 nieuwste."
+    )
+
+
+async def test_collect_candidates_dedups_overlap(db_session, sample_initiatief):
+    """Een lead die zowel in de recency-top als in de similarity-top zit,
+    mag maar één keer voorkomen in de output."""
+    overlap = Lead(
+        id=uuid.uuid4(),
+        title="Gemeente Utrecht",
+        organization="Gemeente Utrecht",
+        initiatief_id=sample_initiatief.id,
+        stage="lead",
+    )
+    db_session.add(overlap)
+    await db_session.flush()
+
+    ingest = MattermostIngestService(db_session)
+    rows = await ingest._collect_lead_candidates_for_llm(
+        sample_initiatief.id,
+        "Gemeente Utrecht heeft interesse",
+    )
+
+    assert [r.id for r in rows].count(overlap.id) == 1


### PR DESCRIPTION
## Probleem

De LLM-prompt voor Mattermost-lead-suggesties kreeg alleen de 20 nieuwste leads van het initiatief mee. Bij een initiatief met veel leads (RegelRecht heeft er inmiddels >20) viel een oude lead buiten dat venster, waardoor de LLM 'm niet kon herkennen als duplicate, zelfs als zijn naam expliciet in het bericht stond.

Concreet voorbeeld dat dit triggerde: een oude HHNK-lead bestond al, maar het bericht "HHNK lijkt een goeie partner" werd toch als nieuwe suggestie gepost.

## Fix

Hybride selectie van kandidaten in `_collect_lead_candidates_for_llm`:

1. **Top 25 nieuwste** — recency, vangt actuele kwesties zonder expliciete naam in het bericht.
2. **Top 50 trigram-matches** — `pg_trgm.word_similarity(Lead.title, message) > 0.3` of hetzelfde voor `organization`. Vangt oude leads waarvan de naam expliciet genoemd wordt, inclusief afkortingen en kleine spelvariaties.
3. Dedup op id (recency wint), hard cap op 60.

Tokenkosten: ~30 tokens per lead × 60 = ~1.8k overhead, prima voor de VLAM-call.

`pg_trgm` was al actief via een eerdere migratie; geen schema-wijziging.

Daarnaast meegestuurd in de prompt: `organisatie`-veld naast `titel`, zodat de LLM ook op organisatienaam kan matchen.

## Tests

- `test_collect_candidates_includes_old_lead_via_similarity` reproduceert het HHNK-scenario: 1 oude HHNK-lead + 40 jongere onafhankelijke leads, bericht "HHNK lijkt een goeie partner", de oude HHNK moet in de kandidaten-output verschijnen.
- `test_collect_candidates_dedups_overlap` controleert dat een lead die in beide groepen valt maar één keer voorkomt.

## Test plan
- [ ] Post in een initiatief-kanaal een bericht met de naam van een bestaande oudere lead → bot suggereert `:link:` als optie
- [ ] Post een bericht zonder lead-naam → bot biedt alleen `:white_check_mark:` / `:x:` (geen valse `:link:`)