### PR TITLE
Mattermost lead-suggestie: aparte copy voor bestaande lead

### DIFF
--- a/backend/bouwmeester/services/mattermost_ingest_service.py
+++ b/backend/bouwmeester/services/mattermost_ingest_service.py
@@ -612,8 +612,8 @@ class MattermostIngestService:
                         if stage_label
                         else ""
                     )
-                    + "Het Mattermost-bericht wordt als notitie aan deze lead "
-                    "toegevoegd zodra je :link: plaatst.",
+                    + "Bij koppelen wordt dit Mattermost-bericht als notitie "
+                    "aan de lead toegevoegd.",
                     "footer": "Bouwmeester · bestaande lead herkend",
                 }
             else:

--- a/backend/bouwmeester/services/mattermost_ingest_service.py
+++ b/backend/bouwmeester/services/mattermost_ingest_service.py
@@ -63,6 +63,20 @@ SIMILAR_LEAD_THRESHOLD = 0.3
 MAX_LEADS_FOR_LLM = 60
 
 
+# Mirror van LEAD_STAGE_LABELS in frontend/src/types/index.ts. Backend heeft
+# verder geen plek waar lead-stages naar mensentaal worden vertaald, dus we
+# houden de map lokaal tot een tweede call-site dit nodig heeft.
+_LEAD_STAGE_LABELS = {
+    "inbox": "Inbox",
+    "verkennen": "Verkennen",
+    "eerste_gesprek": "Eerste gesprek",
+    "interne_check": "Interne check",
+    "follow_up": "Follow-up",
+    "in_the_pocket": "In the pocket",
+    "koelkast": "Koelkast",
+}
+
+
 async def handle_dm_post(post: dict, *, bot_user_id: str | None = None) -> bool:
     """Verwerk een DM naar de bot: zoek link-code, koppel account.
 
@@ -436,15 +450,18 @@ class MattermostIngestService:
             return None, "no_lead"
 
         match_lead_uuid: UUID | None = None
+        matched_lead: dict | None = None
         if result.match_existing_lead_id:
             try:
                 candidate = UUID(result.match_existing_lead_id)
             except ValueError:
                 candidate = None
-            if candidate is not None and any(
-                str(row.id) == str(candidate) for row in rows
-            ):
-                match_lead_uuid = candidate
+            if candidate is not None:
+                for row in rows:
+                    if str(row.id) == str(candidate):
+                        match_lead_uuid = candidate
+                        matched_lead = {"title": row.title, "stage": row.stage}
+                        break
 
         suggested = SuggestedLead(
             source_type="mattermost",
@@ -475,7 +492,7 @@ class MattermostIngestService:
                 root_post_id=post.get("root_id") or post["id"],
                 suggested=suggested,
                 initiatief=initiatief,
-                match_lead=match_lead_uuid is not None,
+                matched_lead=matched_lead,
             )
         except Exception:
             logger.exception(
@@ -548,7 +565,7 @@ class MattermostIngestService:
         root_post_id: str,
         suggested: SuggestedLead,
         initiatief: Initiatief,
-        match_lead: bool,
+        matched_lead: dict | None,
     ) -> None:
         """Plaats een bot-reply met emoji-reactions als trigger.
 
@@ -558,6 +575,10 @@ class MattermostIngestService:
         naar onze publieke endpoint. Reactions komen via dezelfde
         websocket binnen die we al gebruiken voor het meelezen, en zijn
         daarmee robuust tegen die platformbeperkingen.
+
+        Bij ``matched_lead`` (titel + stage van een door de LLM herkende
+        bestaande lead) gebruiken we andere copy en zetten we :link: als
+        eerste/aanbevolen actie boven :white_check_mark:.
         """
         from bouwmeester.services.mattermost_service import MattermostService
 
@@ -565,27 +586,52 @@ class MattermostIngestService:
         try:
             if not await service.is_enabled():
                 return
-            instructie_lines = [
-                "_Reageer met:_",
-                ":white_check_mark: om de lead aan te maken",
-            ]
-            if match_lead:
-                instructie_lines.append(":link: om aan een bestaande lead te koppelen")
-            instructie_lines.append(":x: om de suggestie te negeren")
-            instructie = "\n".join(instructie_lines)
-            text = (
-                f":dart: Ik denk dat dit een lead is voor "
-                f"**{initiatief.naam}**.\n"
-                f"_Voorstel:_ {suggested.proposed_title}\n"
-                f"_Vertrouwen:_ {int((suggested.confidence or 0) * 100)}%\n\n"
-                f"{instructie}"
-            )
-            attachment = {
-                "color": "#3B82F6",
-                "title": suggested.proposed_title,
-                "text": suggested.proposed_description or "",
-                "footer": "Bouwmeester · suggestie vanuit Mattermost",
-            }
+
+            pct = int((suggested.confidence or 0) * 100)
+
+            if matched_lead is not None:
+                stage_label = _LEAD_STAGE_LABELS.get(
+                    matched_lead.get("stage") or "", matched_lead.get("stage") or ""
+                )
+                text = (
+                    f":link: Dit lijkt te gaan over een bestaande lead voor "
+                    f"**{initiatief.naam}**: **{matched_lead['title']}**"
+                    f"{f' ({stage_label})' if stage_label else ''}.\n"
+                    f"_Vertrouwen:_ {pct}%\n\n"
+                    "_Reageer met:_\n"
+                    ":link: om dit bericht aan die lead te koppelen "
+                    "_(aanbevolen)_\n"
+                    ":white_check_mark: om tóch een nieuwe lead aan te maken\n"
+                    ":x: om de suggestie te negeren"
+                )
+                attachment = {
+                    "color": "#3B82F6",
+                    "title": matched_lead["title"],
+                    "text": (
+                        f"Bestaande lead in stage _{stage_label}_. "
+                        if stage_label
+                        else ""
+                    )
+                    + "Het Mattermost-bericht wordt als notitie aan deze lead "
+                    "toegevoegd zodra je :link: plaatst.",
+                    "footer": "Bouwmeester · bestaande lead herkend",
+                }
+            else:
+                text = (
+                    f":dart: Nieuwe lead voor **{initiatief.naam}**?\n"
+                    f"_Voorstel:_ {suggested.proposed_title}\n"
+                    f"_Vertrouwen:_ {pct}%\n\n"
+                    "_Reageer met:_\n"
+                    ":white_check_mark: om de lead aan te maken\n"
+                    ":x: om de suggestie te negeren"
+                )
+                attachment = {
+                    "color": "#3B82F6",
+                    "title": suggested.proposed_title,
+                    "text": suggested.proposed_description or "",
+                    "footer": "Bouwmeester · suggestie vanuit Mattermost",
+                }
+
             data = await service.reply_to_post(
                 channel_id,
                 root_post_id,
@@ -598,12 +644,14 @@ class MattermostIngestService:
             suggested.mm_thread_post_id = mm_thread_post_id
             await self.session.flush()
 
-            # Plaats bot-reactions als clickable affordance. Volgorde:
-            # check, link (alleen bij match), x. Failures zijn niet
-            # fataal; de gebruiker kan zelf nog reacties plaatsen.
-            await service.add_reaction(mm_thread_post_id, "white_check_mark")
-            if match_lead:
+            # Plaats bot-reactions als clickable affordance. Bij een match
+            # komt :link: eerst (aanbevolen actie), anders alleen :check: + :x:.
+            # Failures zijn niet fataal; de gebruiker kan zelf reacties plaatsen.
+            if matched_lead is not None:
                 await service.add_reaction(mm_thread_post_id, "link")
+                await service.add_reaction(mm_thread_post_id, "white_check_mark")
+            else:
+                await service.add_reaction(mm_thread_post_id, "white_check_mark")
             await service.add_reaction(mm_thread_post_id, "x")
         finally:
             await service.close()

--- a/backend/tests/test_mattermost_suggested_lead.py
+++ b/backend/tests/test_mattermost_suggested_lead.py
@@ -633,3 +633,128 @@ async def test_collect_candidates_dedups_overlap(db_session, sample_initiatief):
     )
 
     assert [r.id for r in rows].count(overlap.id) == 1
+
+
+# ---------------------------------------------------------------------------
+# Bot-reply copy
+# ---------------------------------------------------------------------------
+
+
+def _stub_mm_service():
+    """Maak een stub die zich gedraagt als MattermostService voor de
+    suggestion-reply: enabled, reply_to_post returnt een post-id, reactions
+    no-op, close no-op. We capturen de calls voor assertions."""
+    stub = AsyncMock()
+    stub.is_enabled = AsyncMock(return_value=True)
+    stub.reply_to_post = AsyncMock(return_value={"id": "thread-post-id"})
+    stub.add_reaction = AsyncMock(return_value=True)
+    stub.close = AsyncMock(return_value=None)
+    return stub
+
+
+async def test_post_suggestion_reply_new_lead_copy(
+    db_session, sample_initiatief, sample_channel
+):
+    """Zonder match: copy zegt 'Nieuwe lead', geen :link:-emoji en geen
+    referentie naar 'bestaande lead'."""
+    suggested = SuggestedLead(
+        source_post_id=_id(),
+        source_channel_id=sample_channel.channel_id,
+        initiatief_id=sample_initiatief.id,
+        proposed_title="Gemeente X",
+        proposed_description="Wil iets met regelhulp",
+        raw_text="origineel bericht",
+        confidence=0.82,
+        status="pending",
+    )
+    db_session.add(suggested)
+    await db_session.flush()
+    await db_session.refresh(suggested)
+
+    stub = _stub_mm_service()
+    with patch(
+        "bouwmeester.services.mattermost_service.MattermostService",
+        return_value=stub,
+    ):
+        ingest = MattermostIngestService(db_session)
+        await ingest._post_suggestion_reply(
+            channel_id=sample_channel.channel_id,
+            root_post_id="root-post-id",
+            suggested=suggested,
+            initiatief=sample_initiatief,
+            matched_lead=None,
+        )
+
+    stub.reply_to_post.assert_awaited_once()
+    call = stub.reply_to_post.await_args
+    posted_text = call.args[2]
+    attachment = call.kwargs["props"]["attachments"][0]
+
+    assert "Nieuwe lead voor" in posted_text
+    assert "Regelrecht" in posted_text
+    assert "Gemeente X" in posted_text
+    assert "82%" in posted_text
+    assert ":link:" not in posted_text
+    assert "bestaande lead" not in posted_text.lower()
+    assert attachment["title"] == "Gemeente X"
+    assert attachment["footer"] == "Bouwmeester · suggestie vanuit Mattermost"
+
+    emojis = [c.args[1] for c in stub.add_reaction.await_args_list]
+    assert emojis == ["white_check_mark", "x"]
+
+
+async def test_post_suggestion_reply_existing_lead_copy(
+    db_session, sample_initiatief, sample_channel
+):
+    """Met match: copy noemt bestaande lead + stage-label, :link: staat
+    boven :white_check_mark: en is aanbevolen."""
+    suggested = SuggestedLead(
+        source_post_id=_id(),
+        source_channel_id=sample_channel.channel_id,
+        initiatief_id=sample_initiatief.id,
+        proposed_title="HHNK",
+        proposed_description=None,
+        raw_text="origineel bericht",
+        confidence=0.95,
+        status="pending",
+    )
+    db_session.add(suggested)
+    await db_session.flush()
+    await db_session.refresh(suggested)
+
+    stub = _stub_mm_service()
+    with patch(
+        "bouwmeester.services.mattermost_service.MattermostService",
+        return_value=stub,
+    ):
+        ingest = MattermostIngestService(db_session)
+        await ingest._post_suggestion_reply(
+            channel_id=sample_channel.channel_id,
+            root_post_id="root-post-id",
+            suggested=suggested,
+            initiatief=sample_initiatief,
+            matched_lead={
+                "title": "HHNK (Hoogheemraadschap Hollands Noorderkwartier)",
+                "stage": "verkennen",
+            },
+        )
+
+    stub.reply_to_post.assert_awaited_once()
+    call = stub.reply_to_post.await_args
+    posted_text = call.args[2]
+    attachment = call.kwargs["props"]["attachments"][0]
+
+    assert "bestaande lead" in posted_text.lower()
+    assert "HHNK (Hoogheemraadschap Hollands Noorderkwartier)" in posted_text
+    assert "Verkennen" in posted_text  # stage-label, niet de raw key
+    assert "verkennen" not in posted_text.replace("Verkennen", "")  # geen raw key
+    assert "95%" in posted_text
+    assert "_(aanbevolen)_" in posted_text
+    # :link: moet vóór :white_check_mark: staan in de instructie
+    assert posted_text.index(":link:") < posted_text.index(":white_check_mark:")
+    assert attachment["title"] == "HHNK (Hoogheemraadschap Hollands Noorderkwartier)"
+    assert attachment["footer"] == "Bouwmeester · bestaande lead herkend"
+    assert "gemeld als nieuwe lead" not in attachment["text"].lower()
+
+    emojis = [c.args[1] for c in stub.add_reaction.await_args_list]
+    assert emojis == ["link", "white_check_mark", "x"]

--- a/backend/tests/test_mattermost_suggested_lead.py
+++ b/backend/tests/test_mattermost_suggested_lead.py
@@ -758,3 +758,59 @@ async def test_post_suggestion_reply_existing_lead_copy(
 
     emojis = [c.args[1] for c in stub.add_reaction.await_args_list]
     assert emojis == ["link", "white_check_mark", "x"]
+
+
+async def test_ingest_propagates_matched_lead_to_reply(
+    db_session, sample_initiatief, sample_channel
+):
+    """End-to-end: als de LLM een bestaande lead-id teruggeeft die in de
+    candidate-rows staat, ontvangt _post_suggestion_reply een matched_lead
+    dict met titel + stage. Vangt regressies in de extractie-loop in
+    _create_suggested_lead."""
+    existing = Lead(
+        id=uuid.uuid4(),
+        title="HHNK (Hoogheemraadschap Hollands Noorderkwartier)",
+        organization="HHNK",
+        initiatief_id=sample_initiatief.id,
+        stage="verkennen",
+    )
+    db_session.add(existing)
+    await db_session.flush()
+
+    llm_match = AsyncMock(
+        return_value=LeadCandidateClassification(
+            is_lead=True,
+            confidence=0.95,
+            proposed_title="HHNK",
+            proposed_description="Vraag van HHNK",
+            match_existing_lead_id=str(existing.id),
+            reasoning="naam matcht expliciet",
+        )
+    )
+    fake_llm = AsyncMock()
+    fake_llm.classify_mattermost_lead_candidate = llm_match
+
+    reply_mock = AsyncMock(return_value=None)
+    with (
+        patch(
+            "bouwmeester.services.llm.factory.get_llm_service_for",
+            new=AsyncMock(return_value=fake_llm),
+        ),
+        patch.object(MattermostIngestService, "_post_suggestion_reply", new=reply_mock),
+    ):
+        ingest = MattermostIngestService(db_session)
+        await ingest.ingest_post(
+            {
+                "id": _id(),
+                "channel_id": sample_channel.channel_id,
+                "user_id": _id(),
+                "create_at": 1_700_000_000_000,
+                "message": "HHNK heeft een vervolgvraag.",
+            }
+        )
+
+    reply_mock.assert_awaited_once()
+    matched = reply_mock.await_args.kwargs["matched_lead"]
+    assert matched is not None
+    assert matched["title"] == "HHNK (Hoogheemraadschap Hollands Noorderkwartier)"
+    assert matched["stage"] == "verkennen"


### PR DESCRIPTION
## Samenvatting

De LLM detecteert al wanneer een Mattermost-bericht gaat over een **bestaande** lead binnen het initiatief (`match_existing_lead_id`), maar de bot-reply zei desondanks _\"Ik denk dat dit een lead is voor X\"_ en _\"gemeld als nieuwe lead\"_. In die situatie is dat misleidend — er is niets nieuws, je wil het bericht koppelen aan de lead die er al staat.

## Wat verandert

Twee tekst-paden in `_post_suggestion_reply` (`backend/bouwmeester/services/mattermost_ingest_service.py`):

**Geen match (nieuwe lead):**

> :dart: Nieuwe lead voor **Regelrecht**?
> _Voorstel:_ Gemeente X
> _Vertrouwen:_ 82%
>
> _Reageer met:_
> :white_check_mark: om de lead aan te maken
> :x: om de suggestie te negeren

**Wel een match (bestaande lead):**

> :link: Dit lijkt te gaan over een bestaande lead voor **Regelrecht**: **HHNK (Hoogheemraadschap Hollands Noorderkwartier)** (Verkennen).
> _Vertrouwen:_ 95%
>
> _Reageer met:_
> :link: om dit bericht aan die lead te koppelen _(aanbevolen)_
> :white_check_mark: om tóch een nieuwe lead aan te maken
> :x: om de suggestie te negeren

Bij een match komt :link: zowel in de instructie-tekst als bij de bot-reactions vóór :white_check_mark:, zodat de aanbevolen actie ook als eerste emoji onder de post staat. De attachment-titel toont de bestaande lead-naam in plaats van de proposed-title, en de footer is _\"Bouwmeester · bestaande lead herkend\"_.

Stage-keys (`verkennen`, `eerste_gesprek`, ...) krijgen een nette label-vertaling via een lokale `_LEAD_STAGE_LABELS`-dict (mirror van `LEAD_STAGE_LABELS` in `frontend/src/types/index.ts`). De map staat lokaal in het ingest-service-bestand — zodra een tweede call-site dit nodig heeft verhuist 'ie naar een gedeelde plek.

## Test plan

- [x] `pytest backend/tests/test_mattermost_suggested_lead.py` — 14/14 passed (2 nieuwe tests voor de copy-paden, bestaande tests onveranderd)
- [x] `ruff format` + `ruff check` schoon
- [ ] End-to-end check in een gekoppeld kanaal: bericht over een bestaande lead → bot zegt _\"bestaande lead\"_ + 🔗 voor ✅; bericht over een nieuwe naam → bot zegt _\"Nieuwe lead\"_ + alleen ✅/❌