### PR TITLE
Funnel-kolommen aanpasbaar per initiatief

### DIFF
--- a/backend/bouwmeester/api/routes/__init__.py
+++ b/backend/bouwmeester/api/routes/__init__.py
@@ -21,6 +21,7 @@ from bouwmeester.api.routes.initiatief import router as initiatieven_router
 from bouwmeester.api.routes.initiatief_update import (
     router as initiatief_updates_router,
 )
+from bouwmeester.api.routes.lead_columns import router as lead_columns_router
 from bouwmeester.api.routes.leads import router as leads_router
 from bouwmeester.api.routes.llm import router as llm_router
 from bouwmeester.api.routes.mattermost import router as mattermost_router
@@ -72,6 +73,7 @@ api_router.include_router(graph_router)
 api_router.include_router(initiatieven_router)
 api_router.include_router(initiatief_updates_router)
 api_router.include_router(import_export_router)
+api_router.include_router(lead_columns_router)
 api_router.include_router(leads_router)
 api_router.include_router(llm_router)
 api_router.include_router(mattermost_router)

--- a/backend/bouwmeester/api/routes/lead_columns.py
+++ b/backend/bouwmeester/api/routes/lead_columns.py
@@ -1,0 +1,265 @@
+"""API routes for per-initiatief funnel-kolommen."""
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bouwmeester.api.deps import require_found
+from bouwmeester.api.routes.initiatief import (
+    _require_access,
+    _resolve_access_level,
+)
+from bouwmeester.core.auth import OptionalUser
+from bouwmeester.core.database import get_db
+from bouwmeester.core.permissions import (
+    PermissionContext,
+    get_permission_context,
+)
+from bouwmeester.repositories.initiatief import InitiatiefRepository
+from bouwmeester.repositories.lead_column import LeadColumnRepository
+from bouwmeester.schema.lead_column import (
+    LeadColumnCreate,
+    LeadColumnReorder,
+    LeadColumnResponse,
+    LeadColumnUpdate,
+)
+from bouwmeester.services.activity_service import log_activity
+
+router = APIRouter(prefix="/initiatieven", tags=["lead-columns"])
+
+
+def _to_response(column, lead_count: int = 0) -> LeadColumnResponse:
+    return LeadColumnResponse(
+        id=column.id,
+        initiatief_id=column.initiatief_id,
+        name=column.name,
+        slug=column.slug,
+        sort_order=column.sort_order,
+        color=column.color,
+        is_active_stage=column.is_active_stage,
+        is_public_visible=column.is_public_visible,
+        lead_count=lead_count,
+        created_at=column.created_at,
+        updated_at=column.updated_at,
+    )
+
+
+@router.get(
+    "/{initiatief_id}/columns",
+    response_model=list[LeadColumnResponse],
+)
+async def list_columns(
+    initiatief_id: UUID,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    perm_ctx: PermissionContext = Depends(get_permission_context),
+) -> list[LeadColumnResponse]:
+    """List funnel-kolommen for an initiatief. Any member with access."""
+    init_repo = InitiatiefRepository(db)
+    require_found(await init_repo.get_by_id(initiatief_id), "Initiatief")
+    access_level = await _resolve_access_level(
+        init_repo, initiatief_id, current_user, perm_ctx
+    )
+    if access_level is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Geen toegang tot dit initiatief",
+        )
+
+    repo = LeadColumnRepository(db)
+    columns = await repo.list_for_initiatief(initiatief_id)
+    counts = await repo.lead_counts_for_initiatief(initiatief_id)
+    return [_to_response(c, counts.get(c.slug, 0)) for c in columns]
+
+
+@router.post(
+    "/{initiatief_id}/columns",
+    response_model=LeadColumnResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_column(
+    initiatief_id: UUID,
+    data: LeadColumnCreate,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    perm_ctx: PermissionContext = Depends(get_permission_context),
+) -> LeadColumnResponse:
+    """Create a new funnel-kolom. Eigenaar only."""
+    init_repo = InitiatiefRepository(db)
+    require_found(await init_repo.get_by_id(initiatief_id), "Initiatief")
+    await _require_access(init_repo, initiatief_id, current_user, perm_ctx, "eigenaar")
+
+    repo = LeadColumnRepository(db)
+    if await repo.slug_or_name_exists(initiatief_id, name=data.name):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Een kolom met deze naam bestaat al",
+        )
+    column = await repo.create(initiatief_id, data)
+
+    await log_activity(
+        db,
+        current_user,
+        None,
+        "lead_column.created",
+        details={
+            "initiatief_id": str(initiatief_id),
+            "column_id": str(column.id),
+            "name": column.name,
+            "slug": column.slug,
+        },
+    )
+
+    return _to_response(column, 0)
+
+
+@router.put(
+    "/{initiatief_id}/columns/{column_id}",
+    response_model=LeadColumnResponse,
+)
+async def update_column(
+    initiatief_id: UUID,
+    column_id: UUID,
+    data: LeadColumnUpdate,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    perm_ctx: PermissionContext = Depends(get_permission_context),
+) -> LeadColumnResponse:
+    """Update a funnel-kolom (name/color/flags). Slug is immutable. Eigenaar only."""
+    init_repo = InitiatiefRepository(db)
+    require_found(await init_repo.get_by_id(initiatief_id), "Initiatief")
+    await _require_access(init_repo, initiatief_id, current_user, perm_ctx, "eigenaar")
+
+    repo = LeadColumnRepository(db)
+    existing = await repo.get(column_id)
+    if existing is None or existing.initiatief_id != initiatief_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Kolom niet gevonden"
+        )
+    if data.name is not None and data.name != existing.name:
+        if await repo.slug_or_name_exists(
+            initiatief_id, name=data.name, exclude_id=column_id
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Een kolom met deze naam bestaat al",
+            )
+    column = await repo.update(column_id, data)
+
+    await log_activity(
+        db,
+        current_user,
+        None,
+        "lead_column.updated",
+        details={
+            "initiatief_id": str(initiatief_id),
+            "column_id": str(column_id),
+            "fields": list(data.model_dump(exclude_unset=True).keys()),
+        },
+    )
+
+    counts = await repo.lead_counts_for_initiatief(initiatief_id)
+    return _to_response(column, counts.get(column.slug, 0))
+
+
+@router.delete(
+    "/{initiatief_id}/columns/{column_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_column(
+    initiatief_id: UUID,
+    column_id: UUID,
+    current_user: OptionalUser,
+    move_to: UUID | None = Query(None),
+    db: AsyncSession = Depends(get_db),
+    perm_ctx: PermissionContext = Depends(get_permission_context),
+) -> None:
+    """Delete a kolom. Migrates leads to ``move_to`` if non-empty (eigenaar)."""
+    init_repo = InitiatiefRepository(db)
+    require_found(await init_repo.get_by_id(initiatief_id), "Initiatief")
+    await _require_access(init_repo, initiatief_id, current_user, perm_ctx, "eigenaar")
+
+    repo = LeadColumnRepository(db)
+    deleted, error = await repo.delete_with_move(initiatief_id, column_id, move_to)
+    if not deleted:
+        if error == "not_found":
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Kolom niet gevonden",
+            )
+        if error == "last_column":
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Er moet tenminste 1 kolom zijn",
+            )
+        if error == "leads_present":
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Kolom bevat leads; geef move_to mee om ze te verplaatsen",
+            )
+        if error == "invalid_target":
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Ongeldige doel-kolom voor move_to",
+            )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Kon kolom niet verwijderen",
+        )
+
+    await log_activity(
+        db,
+        current_user,
+        None,
+        "lead_column.deleted",
+        details={
+            "initiatief_id": str(initiatief_id),
+            "column_id": str(column_id),
+            "move_to": str(move_to) if move_to else None,
+        },
+    )
+
+
+@router.post(
+    "/{initiatief_id}/columns/reorder",
+    response_model=list[LeadColumnResponse],
+)
+async def reorder_columns(
+    initiatief_id: UUID,
+    data: LeadColumnReorder,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    perm_ctx: PermissionContext = Depends(get_permission_context),
+) -> list[LeadColumnResponse]:
+    """Reorder kolommen. Body must list every column id (eigenaar)."""
+    init_repo = InitiatiefRepository(db)
+    require_found(await init_repo.get_by_id(initiatief_id), "Initiatief")
+    await _require_access(init_repo, initiatief_id, current_user, perm_ctx, "eigenaar")
+
+    repo = LeadColumnRepository(db)
+    ok, error = await repo.reorder(initiatief_id, data.column_ids)
+    if not ok:
+        if error == "mismatch":
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    "column_ids moet exact alle kolommen van het initiatief bevatten"
+                ),
+            )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Kon kolommen niet herordenen",
+        )
+
+    await log_activity(
+        db,
+        current_user,
+        None,
+        "lead_column.reordered",
+        details={"initiatief_id": str(initiatief_id)},
+    )
+
+    columns = await repo.list_for_initiatief(initiatief_id)
+    counts = await repo.lead_counts_for_initiatief(initiatief_id)
+    return [_to_response(c, counts.get(c.slug, 0)) for c in columns]

--- a/backend/bouwmeester/api/routes/leads.py
+++ b/backend/bouwmeester/api/routes/leads.py
@@ -32,7 +32,7 @@ from bouwmeester.models.lead_activity import LeadActivity
 from bouwmeester.models.lead_attachment import LeadAttachment
 from bouwmeester.models.lead_node import LeadNode
 from bouwmeester.repositories.github_link import GitHubLinkRepository
-from bouwmeester.repositories.lead import LeadRepository
+from bouwmeester.repositories.lead import LeadRepository, StageNotInColumnsError
 from bouwmeester.repositories.lead_activity import LeadActivityRepository
 from bouwmeester.schema.github_link import (
     GitHubLinkCreate,
@@ -55,7 +55,6 @@ from bouwmeester.schema.lead import (
     LeadParseResult,
     LeadReorder,
     LeadResponse,
-    LeadStage,
     LeadTimelineEvent,
     LeadTimelineResponse,
     LeadUpdate,
@@ -151,7 +150,7 @@ def _check_initiatief_access(
 @router.get("", response_model=list[LeadResponse])
 async def list_leads(
     current_user: OptionalUser,
-    stage: LeadStage | None = Query(None),
+    stage: str | None = Query(None, max_length=120),
     tag: str | None = Query(None),
     assignee_id: UUID | None = Query(None),
     date_from: date | None = Query(None),
@@ -202,7 +201,13 @@ async def create_lead(
     _check_initiatief_access(data.initiatief_id, init_ctx)
     author_id = current_user.id if current_user else None
     repo = LeadRepository(db)
-    lead = await repo.create(data, author_id=author_id)
+    try:
+        lead = await repo.create(data, author_id=author_id)
+    except StageNotInColumnsError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Onbekende stage '{exc.args[0]}' voor dit initiatief",
+        )
 
     # Notify assignee (if any, and not self-assignment)
     if lead.assignee_id and lead.assignee_id != author_id:
@@ -401,7 +406,13 @@ async def update_lead(
     old_stage = old_lead.stage
 
     repo = LeadRepository(db)
-    lead = require_found(await repo.update(lead_id, data), "Lead")
+    try:
+        lead = require_found(await repo.update(lead_id, data), "Lead")
+    except StageNotInColumnsError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Onbekende stage '{exc.args[0]}' voor dit initiatief",
+        )
 
     notif_svc = NotificationService(db)
 
@@ -502,9 +513,15 @@ async def move_lead(
     _check_lead_access(lead, init_ctx)
     author_id = current_user.id if current_user else None
     repo = LeadRepository(db)
-    lead = require_found(
-        await repo.move(lead_id, data.stage, author_id=author_id), "Lead"
-    )
+    try:
+        lead = require_found(
+            await repo.move(lead_id, data.stage, author_id=author_id), "Lead"
+        )
+    except StageNotInColumnsError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Onbekende stage '{exc.args[0]}' voor dit initiatief",
+        )
 
     # Notify assignee about stage change
     if lead.assignee_id and lead.assignee_id != author_id:

--- a/backend/bouwmeester/api/routes/public_initiatief.py
+++ b/backend/bouwmeester/api/routes/public_initiatief.py
@@ -10,19 +10,10 @@ from bouwmeester.core.database import get_db
 from bouwmeester.models.initiatief import Initiatief
 from bouwmeester.models.initiatief_update import InitiatiefUpdatePost
 from bouwmeester.models.lead import Lead
+from bouwmeester.models.lead_column import LeadColumn
 from bouwmeester.schema.initiatief_update import InitiatiefUpdatePostPublicResponse
 
 router = APIRouter(prefix="/public/initiatieven", tags=["public-initiatief"])
-
-# Stages where a lead is considered actively in progress; others (inbox /
-# verkennen / koelkast) are intentionally hidden from the public surface
-# even when public_visible is true.
-_PUBLIC_VISIBLE_STAGES = (
-    "eerste_gesprek",
-    "interne_check",
-    "follow_up",
-    "in_the_pocket",
-)
 
 
 class PublicCasus(BaseModel):
@@ -82,15 +73,20 @@ async def get_public_initiatief(
     )
 
     # Lopende casussen: leads waar de eigenaar/contributor expliciet een
-    # publieks-titel heeft geschreven én de toggle aan zette én de lead in
-    # een actieve stage zit.
+    # publieks-titel heeft geschreven, de toggle aan zette, en de stage
+    # behoort tot een kolom die per-initiatief als publiek-zichtbaar is
+    # gemarkeerd (LeadColumn.is_public_visible).
+    public_slugs_subq = select(LeadColumn.slug).where(
+        LeadColumn.initiatief_id == initiatief.id,
+        LeadColumn.is_public_visible.is_(True),
+    )
     casussen_result = await db.execute(
         select(Lead.public_title, Lead.public_summary)
         .where(
             Lead.initiatief_id == initiatief.id,
             Lead.public_visible.is_(True),
             Lead.public_title.is_not(None),
-            Lead.stage.in_(_PUBLIC_VISIBLE_STAGES),
+            Lead.stage.in_(public_slugs_subq),
         )
         .order_by(Lead.created_at.desc())
     )

--- a/backend/bouwmeester/migrations/versions/b3c5e7f8d2a1_add_lead_column_table.py
+++ b/backend/bouwmeester/migrations/versions/b3c5e7f8d2a1_add_lead_column_table.py
@@ -1,0 +1,180 @@
+"""add lead_column table and seed defaults
+
+Revision ID: b3c5e7f8d2a1
+Revises: a8c2f4b1e9d3
+Create Date: 2026-05-07
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b3c5e7f8d2a1"
+down_revision: str | None = "a8c2f4b1e9d3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_DEFAULT_COLUMNS: list[dict] = [
+    {
+        "slug": "inbox",
+        "name": "Inbox",
+        "color": "bg-indigo-100 text-indigo-800",
+        "is_active_stage": False,
+        "is_public_visible": False,
+    },
+    {
+        "slug": "verkennen",
+        "name": "Verkennen",
+        "color": "bg-blue-100 text-blue-800",
+        "is_active_stage": True,
+        "is_public_visible": False,
+    },
+    {
+        "slug": "eerste_gesprek",
+        "name": "Eerste gesprek",
+        "color": "bg-yellow-100 text-yellow-800",
+        "is_active_stage": True,
+        "is_public_visible": True,
+    },
+    {
+        "slug": "interne_check",
+        "name": "Interne check",
+        "color": "bg-orange-100 text-orange-800",
+        "is_active_stage": True,
+        "is_public_visible": True,
+    },
+    {
+        "slug": "follow_up",
+        "name": "Follow-up",
+        "color": "bg-purple-100 text-purple-800",
+        "is_active_stage": True,
+        "is_public_visible": True,
+    },
+    {
+        "slug": "in_the_pocket",
+        "name": "In the pocket",
+        "color": "bg-green-100 text-green-800",
+        "is_active_stage": False,
+        "is_public_visible": True,
+    },
+    {
+        "slug": "koelkast",
+        "name": "Koelkast",
+        "color": "bg-gray-100 text-gray-800",
+        "is_active_stage": False,
+        "is_public_visible": False,
+    },
+]
+
+
+def upgrade() -> None:
+    # Composite index op lead.(initiatief_id, stage). Versnelt de
+    # per-initiatief stage-filter (kanban-board, metrics, GROUP BY stage,
+    # en de "non-active stage" subquery in de overdue/stale filters).
+    op.create_index(
+        "ix_lead_initiatief_stage",
+        "lead",
+        ["initiatief_id", "stage"],
+        unique=False,
+    )
+
+    op.create_table(
+        "lead_column",
+        sa.Column(
+            "id",
+            sa.UUID(),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("initiatief_id", sa.UUID(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("slug", sa.String(), nullable=False),
+        sa.Column("sort_order", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column(
+            "color",
+            sa.String(),
+            nullable=False,
+            server_default="bg-gray-100 text-gray-800",
+        ),
+        sa.Column(
+            "is_active_stage",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+        sa.Column(
+            "is_public_visible",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["initiatief_id"], ["initiatief.id"], ondelete="CASCADE"
+        ),
+        sa.UniqueConstraint(
+            "initiatief_id", "slug", name="uq_lead_column_initiatief_slug"
+        ),
+        sa.UniqueConstraint(
+            "initiatief_id", "name", name="uq_lead_column_initiatief_name"
+        ),
+    )
+    op.create_index(
+        op.f("ix_lead_column_initiatief_id"),
+        "lead_column",
+        ["initiatief_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_lead_column_initiatief_sort",
+        "lead_column",
+        ["initiatief_id", "sort_order"],
+        unique=False,
+    )
+
+    # Seed every existing initiatief with the 7 default columns. Idempotent
+    # via ON CONFLICT — safe to re-run after a partial migration.
+    bind = op.get_bind()
+    initiatief_ids = bind.execute(sa.text("SELECT id FROM initiatief")).all()
+    insert_stmt = sa.text(
+        """
+        INSERT INTO lead_column
+            (initiatief_id, name, slug, sort_order, color,
+             is_active_stage, is_public_visible)
+        VALUES
+            (:initiatief_id, :name, :slug, :sort_order, :color,
+             :is_active_stage, :is_public_visible)
+        ON CONFLICT (initiatief_id, slug) DO NOTHING
+        """
+    )
+    for (initiatief_id,) in initiatief_ids:
+        for idx, default in enumerate(_DEFAULT_COLUMNS):
+            bind.execute(
+                insert_stmt,
+                {
+                    "initiatief_id": initiatief_id,
+                    "name": default["name"],
+                    "slug": default["slug"],
+                    "sort_order": idx,
+                    "color": default["color"],
+                    "is_active_stage": default["is_active_stage"],
+                    "is_public_visible": default["is_public_visible"],
+                },
+            )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_lead_column_initiatief_sort", table_name="lead_column")
+    op.drop_index(op.f("ix_lead_column_initiatief_id"), table_name="lead_column")
+    op.drop_table("lead_column")
+    op.drop_index("ix_lead_initiatief_stage", table_name="lead")

--- a/backend/bouwmeester/models/__init__.py
+++ b/backend/bouwmeester/models/__init__.py
@@ -29,6 +29,7 @@ from bouwmeester.models.instrument import Instrument  # noqa: F401
 from bouwmeester.models.lead import Lead  # noqa: F401
 from bouwmeester.models.lead_activity import LeadActivity  # noqa: F401
 from bouwmeester.models.lead_attachment import LeadAttachment  # noqa: F401
+from bouwmeester.models.lead_column import LeadColumn  # noqa: F401
 from bouwmeester.models.lead_node import LeadNode  # noqa: F401
 from bouwmeester.models.maatregel import Maatregel  # noqa: F401
 from bouwmeester.models.mattermost_channel_link import (  # noqa: F401
@@ -112,6 +113,7 @@ __all__ = [
     "Lead",
     "LeadActivity",
     "LeadAttachment",
+    "LeadColumn",
     "LeadNode",
     "LeadTag",
     "Maatregel",

--- a/backend/bouwmeester/models/initiatief.py
+++ b/backend/bouwmeester/models/initiatief.py
@@ -60,3 +60,9 @@ class Initiatief(Base):
         cascade="all, delete-orphan",
         order_by="InitiatiefUpdatePost.created_at.desc()",
     )
+    lead_columns: Mapped[list["LeadColumn"]] = relationship(  # noqa: F821
+        "LeadColumn",
+        back_populates="initiatief",
+        cascade="all, delete-orphan",
+        order_by="LeadColumn.sort_order",
+    )

--- a/backend/bouwmeester/models/lead.py
+++ b/backend/bouwmeester/models/lead.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import date, datetime
 from typing import TYPE_CHECKING, Optional
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, Text, func, text
+from sqlalchemy import Boolean, DateTime, ForeignKey, Index, Text, func, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -22,6 +22,12 @@ if TYPE_CHECKING:
 
 class Lead(Base):
     __tablename__ = "lead"
+    __table_args__ = (
+        # Speeds up the per-initiatief stage filter that the kanbanbord,
+        # de metrics-aggregatie, en de "non-active stage" subquery in de
+        # overdue/stale filters elke keer raken.
+        Index("ix_lead_initiatief_stage", "initiatief_id", "stage"),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),

--- a/backend/bouwmeester/models/lead_column.py
+++ b/backend/bouwmeester/models/lead_column.py
@@ -1,0 +1,71 @@
+"""LeadColumn model - per-initiatief funnel-kolommen."""
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    UniqueConstraint,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from bouwmeester.core.database import Base
+
+if TYPE_CHECKING:
+    from bouwmeester.models.initiatief import Initiatief
+
+
+class LeadColumn(Base):
+    __tablename__ = "lead_column"
+    __table_args__ = (
+        UniqueConstraint(
+            "initiatief_id", "slug", name="uq_lead_column_initiatief_slug"
+        ),
+        UniqueConstraint(
+            "initiatief_id", "name", name="uq_lead_column_initiatief_name"
+        ),
+        Index("ix_lead_column_initiatief_sort", "initiatief_id", "sort_order"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    initiatief_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("initiatief.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    name: Mapped[str] = mapped_column(nullable=False)
+    slug: Mapped[str] = mapped_column(nullable=False)
+    sort_order: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    color: Mapped[str] = mapped_column(
+        nullable=False,
+        server_default="bg-gray-100 text-gray-800",
+    )
+    is_active_stage: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default="true"
+    )
+    is_public_visible: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), onupdate=func.now(), nullable=True
+    )
+
+    initiatief: Mapped["Initiatief"] = relationship(
+        "Initiatief", back_populates="lead_columns"
+    )

--- a/backend/bouwmeester/repositories/initiatief.py
+++ b/backend/bouwmeester/repositories/initiatief.py
@@ -94,6 +94,12 @@ class InitiatiefRepository(BaseRepository[Initiatief]):
             self.session.add(rp)
             await self.session.flush()
 
+        # Seed the 7 default funnel-kolommen so the initiatief has a board
+        # out of the box. Imported lazily to avoid a circular import.
+        from bouwmeester.repositories.lead_column import LeadColumnRepository
+
+        await LeadColumnRepository(self.session).seed_defaults(initiatief.id)
+
         await self.session.refresh(initiatief)
         return initiatief
 

--- a/backend/bouwmeester/repositories/lead.py
+++ b/backend/bouwmeester/repositories/lead.py
@@ -3,7 +3,7 @@
 from datetime import UTC, date, timedelta
 from uuid import UUID
 
-from sqlalchemy import func, or_, select
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.orm import selectinload
 
 from bouwmeester.core.initiatief_context import (
@@ -12,9 +12,25 @@ from bouwmeester.core.initiatief_context import (
 )
 from bouwmeester.models.lead import Lead
 from bouwmeester.models.lead_activity import LeadActivity
+from bouwmeester.models.lead_column import LeadColumn
 from bouwmeester.models.tag import LeadTag, Tag
 from bouwmeester.repositories.base import BaseRepository
-from bouwmeester.schema.lead import LeadCreate, LeadStage, LeadUpdate
+from bouwmeester.schema.lead import LeadCreate, LeadUpdate
+from bouwmeester.schema.lead_column import DEFAULT_ACTIVE_SLUGS, DEFAULT_SLUGS
+
+
+def _non_active_subq():
+    """Slugs whose column has is_active_stage=False (per-initiatief).
+
+    Returns a correlated subquery: a stage is "non-active" when it
+    matches a `lead_column` row with `is_active_stage=False` for the
+    same `initiatief_id`. Used to exclude terminal/inbox-like stages
+    from "overdue"/"stale" filters.
+    """
+    return select(LeadColumn.slug).where(
+        LeadColumn.initiatief_id == Lead.initiatief_id,
+        LeadColumn.is_active_stage.is_(False),
+    )
 
 
 def _lead_options():
@@ -29,8 +45,33 @@ def _lead_options():
     ]
 
 
+class StageNotInColumnsError(ValueError):
+    """Raised when a write tries to set a stage that has no matching column."""
+
+
 class LeadRepository(BaseRepository[Lead]):
     model = Lead
+
+    async def _validate_stage(
+        self, stage: str | None, initiatief_id: UUID | None
+    ) -> None:
+        """Reject writes that target a stage not defined for this initiatief.
+
+        Orphan leads (no initiatief) fall back to the 7 default slugs.
+        """
+        if stage is None:
+            return
+        if initiatief_id is None:
+            if stage not in DEFAULT_SLUGS:
+                raise StageNotInColumnsError(stage)
+            return
+        stmt = select(LeadColumn.id).where(
+            LeadColumn.initiatief_id == initiatief_id,
+            LeadColumn.slug == stage,
+        )
+        result = await self.session.execute(stmt.limit(1))
+        if result.first() is None:
+            raise StageNotInColumnsError(stage)
 
     async def get(
         self, id: UUID, init_ctx: InitiatiefContext | None = None
@@ -67,7 +108,7 @@ class LeadRepository(BaseRepository[Lead]):
         self,
         skip: int = 0,
         limit: int = 100,
-        stage: LeadStage | None = None,
+        stage: str | None = None,
         tag: str | None = None,
         assignee_id: UUID | None = None,
         init_ctx: InitiatiefContext | None = None,
@@ -105,7 +146,16 @@ class LeadRepository(BaseRepository[Lead]):
             if next_action_filter == "overdue":
                 stmt = stmt.where(
                     Lead.next_action_date < today,
-                    Lead.stage.notin_(["inbox", "in_the_pocket", "koelkast"]),
+                    or_(
+                        and_(
+                            Lead.initiatief_id.isnot(None),
+                            Lead.stage.notin_(_non_active_subq()),
+                        ),
+                        and_(
+                            Lead.initiatief_id.is_(None),
+                            Lead.stage.in_(DEFAULT_ACTIVE_SLUGS),
+                        ),
+                    ),
                 )
             elif next_action_filter == "today":
                 stmt = stmt.where(Lead.next_action_date == today)
@@ -133,6 +183,7 @@ class LeadRepository(BaseRepository[Lead]):
         return list(result.scalars().all())
 
     async def create(self, data: LeadCreate, author_id: UUID | None = None) -> Lead:
+        await self._validate_stage(data.stage, data.initiatief_id)
         dump = data.model_dump()
         # Only set created_at if explicitly provided (for backdating)
         if dump.get("created_at") is None:
@@ -169,6 +220,13 @@ class LeadRepository(BaseRepository[Lead]):
         if lead is None:
             return None
         update_data = data.model_dump(exclude_unset=True)
+        # If either the stage or the initiatief changes, validate against the
+        # destination initiatief's columns (or the new initiatief_id if both
+        # change in the same payload).
+        if "stage" in update_data or "initiatief_id" in update_data:
+            target_stage = update_data.get("stage", lead.stage)
+            target_init = update_data.get("initiatief_id", lead.initiatief_id)
+            await self._validate_stage(target_stage, target_init)
         for key, value in update_data.items():
             setattr(lead, key, value)
         await self.session.flush()
@@ -176,11 +234,12 @@ class LeadRepository(BaseRepository[Lead]):
         return await self.get(id)
 
     async def move(
-        self, id: UUID, stage: LeadStage, author_id: UUID | None = None
+        self, id: UUID, stage: str, author_id: UUID | None = None
     ) -> Lead | None:
         lead = await self.session.get(Lead, id)
         if lead is None:
             return None
+        await self._validate_stage(stage, lead.initiatief_id)
         old_stage = lead.stage
         lead.stage = stage
         await self.session.flush()
@@ -199,7 +258,7 @@ class LeadRepository(BaseRepository[Lead]):
         # Re-fetch with all eager loads to avoid lazy-loading errors
         return await self.get(id)
 
-    async def reorder(self, lead_ids: list[UUID], stage: LeadStage) -> list[Lead]:
+    async def reorder(self, lead_ids: list[UUID], stage: str) -> list[Lead]:
         for idx, lead_id in enumerate(lead_ids):
             lead = await self.session.get(Lead, lead_id)
             if lead is not None and lead.stage == stage:
@@ -483,13 +542,24 @@ class LeadRepository(BaseRepository[Lead]):
         stage_result = await self.session.execute(stage_stmt)
         by_stage = {row[0]: row[1] for row in stage_result.all()}
 
-        # Stale count: next_action_date < today and not in terminal/inbox stages
+        # Stale count: next_action_date < today and not in terminal/inbox stages.
+        # Active-stage filter is per-initiatief (lead_column.is_active_stage);
+        # orphan leads (initiatief_id IS NULL) fall back to the default set.
         stale_stmt = (
             select(func.count())
             .select_from(Lead)
             .where(
                 Lead.next_action_date < date.today(),
-                Lead.stage.notin_(["inbox", "in_the_pocket", "koelkast"]),
+                or_(
+                    and_(
+                        Lead.initiatief_id.isnot(None),
+                        Lead.stage.notin_(_non_active_subq()),
+                    ),
+                    and_(
+                        Lead.initiatief_id.is_(None),
+                        Lead.stage.in_(DEFAULT_ACTIVE_SLUGS),
+                    ),
+                ),
             )
         )
         stale_stmt = apply_initiatief_filter(stale_stmt, Lead.initiatief_id, init_ctx)

--- a/backend/bouwmeester/repositories/lead_column.py
+++ b/backend/bouwmeester/repositories/lead_column.py
@@ -1,0 +1,224 @@
+"""Repository for LeadColumn (per-initiatief funnel-kolommen)."""
+
+from uuid import UUID
+
+from sqlalchemy import delete, func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bouwmeester.core.slug import slugify
+from bouwmeester.models.lead import Lead
+from bouwmeester.models.lead_column import LeadColumn
+from bouwmeester.schema.lead_column import (
+    DEFAULT_COLUMNS,
+    LeadColumnCreate,
+    LeadColumnUpdate,
+)
+
+
+class LeadColumnRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def list_for_initiatief(self, initiatief_id: UUID) -> list[LeadColumn]:
+        stmt = (
+            select(LeadColumn)
+            .where(LeadColumn.initiatief_id == initiatief_id)
+            .order_by(LeadColumn.sort_order.asc(), LeadColumn.created_at.asc())
+        )
+        result = await self.session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def get(self, column_id: UUID) -> LeadColumn | None:
+        return await self.session.get(LeadColumn, column_id)
+
+    async def lead_counts_for_initiatief(self, initiatief_id: UUID) -> dict[str, int]:
+        """Return {slug: count} of leads per stage in this initiatief."""
+        stmt = (
+            select(Lead.stage, func.count())
+            .where(Lead.initiatief_id == initiatief_id)
+            .group_by(Lead.stage)
+        )
+        result = await self.session.execute(stmt)
+        return {row[0]: row[1] for row in result.all()}
+
+    async def count_leads_in_column(self, initiatief_id: UUID, slug: str) -> int:
+        stmt = (
+            select(func.count())
+            .select_from(Lead)
+            .where(Lead.initiatief_id == initiatief_id, Lead.stage == slug)
+        )
+        result = await self.session.execute(stmt)
+        return int(result.scalar_one())
+
+    async def slug_or_name_exists(
+        self,
+        initiatief_id: UUID,
+        slug: str | None = None,
+        name: str | None = None,
+        exclude_id: UUID | None = None,
+    ) -> bool:
+        clauses = []
+        if slug is not None:
+            clauses.append(LeadColumn.slug == slug)
+        if name is not None:
+            clauses.append(LeadColumn.name == name)
+        if not clauses:
+            return False
+        from sqlalchemy import or_
+
+        stmt = select(LeadColumn.id).where(
+            LeadColumn.initiatief_id == initiatief_id, or_(*clauses)
+        )
+        if exclude_id is not None:
+            stmt = stmt.where(LeadColumn.id != exclude_id)
+        result = await self.session.execute(stmt.limit(1))
+        return result.first() is not None
+
+    async def _next_slug(self, initiatief_id: UUID, base: str) -> str:
+        """Return base, base-2, base-3, ... until unique within the initiatief."""
+        existing_stmt = select(LeadColumn.slug).where(
+            LeadColumn.initiatief_id == initiatief_id,
+            LeadColumn.slug.like(f"{base}%"),
+        )
+        existing = {row[0] for row in (await self.session.execute(existing_stmt)).all()}
+        if base not in existing:
+            return base
+        i = 2
+        while f"{base}-{i}" in existing:
+            i += 1
+        return f"{base}-{i}"
+
+    async def _next_sort_order(self, initiatief_id: UUID) -> int:
+        stmt = select(func.coalesce(func.max(LeadColumn.sort_order), -1)).where(
+            LeadColumn.initiatief_id == initiatief_id
+        )
+        result = await self.session.execute(stmt)
+        return int(result.scalar_one()) + 1
+
+    async def create(self, initiatief_id: UUID, data: LeadColumnCreate) -> LeadColumn:
+        base_slug = slugify(data.name)
+        if not base_slug:
+            base_slug = "kolom"
+        slug = await self._next_slug(initiatief_id, base_slug)
+        sort_order = await self._next_sort_order(initiatief_id)
+        column = LeadColumn(
+            initiatief_id=initiatief_id,
+            name=data.name,
+            slug=slug,
+            sort_order=sort_order,
+            color=data.color,
+            is_active_stage=data.is_active_stage,
+            is_public_visible=data.is_public_visible,
+        )
+        self.session.add(column)
+        await self.session.flush()
+        await self.session.refresh(column)
+        return column
+
+    async def update(
+        self, column_id: UUID, data: LeadColumnUpdate
+    ) -> LeadColumn | None:
+        column = await self.get(column_id)
+        if column is None:
+            return None
+        for key, value in data.model_dump(exclude_unset=True).items():
+            setattr(column, key, value)
+        await self.session.flush()
+        await self.session.refresh(column)
+        return column
+
+    async def delete_with_move(
+        self,
+        initiatief_id: UUID,
+        column_id: UUID,
+        move_to_id: UUID | None,
+    ) -> tuple[bool, str | None]:
+        """Delete a column, optionally migrating its leads to another column.
+
+        Returns (deleted, error_code). error_code one of:
+            'not_found', 'last_column', 'leads_present', 'invalid_target'
+        or None on success.
+        """
+        column = await self.get(column_id)
+        if column is None or column.initiatief_id != initiatief_id:
+            return False, "not_found"
+
+        # Refuse to delete the last column.
+        total_stmt = (
+            select(func.count())
+            .select_from(LeadColumn)
+            .where(LeadColumn.initiatief_id == initiatief_id)
+        )
+        total = int((await self.session.execute(total_stmt)).scalar_one())
+        if total <= 1:
+            return False, "last_column"
+
+        lead_count = await self.count_leads_in_column(initiatief_id, column.slug)
+        if lead_count > 0:
+            if move_to_id is None:
+                return False, "leads_present"
+            target = await self.get(move_to_id)
+            if (
+                target is None
+                or target.initiatief_id != initiatief_id
+                or target.id == column.id
+            ):
+                return False, "invalid_target"
+            await self.session.execute(
+                update(Lead)
+                .where(
+                    Lead.initiatief_id == initiatief_id,
+                    Lead.stage == column.slug,
+                )
+                .values(stage=target.slug)
+            )
+
+        await self.session.execute(delete(LeadColumn).where(LeadColumn.id == column.id))
+        await self.session.flush()
+        return True, None
+
+    async def reorder(
+        self, initiatief_id: UUID, column_ids: list[UUID]
+    ) -> tuple[bool, str | None]:
+        """Rewrite sort_order 0..N-1 in the given order.
+
+        Returns (ok, error_code). error_code is 'mismatch' if the set
+        differs from the initiatief's columns.
+        """
+        existing = await self.list_for_initiatief(initiatief_id)
+        existing_ids = {c.id for c in existing}
+        if existing_ids != set(column_ids) or len(existing) != len(column_ids):
+            return False, "mismatch"
+        for idx, cid in enumerate(column_ids):
+            await self.session.execute(
+                update(LeadColumn).where(LeadColumn.id == cid).values(sort_order=idx)
+            )
+        await self.session.flush()
+        return True, None
+
+    async def seed_defaults(self, initiatief_id: UUID) -> None:
+        """Insert the 7 default columns for a new initiatief.
+
+        Idempotent: skips slugs that already exist (ON CONFLICT semantics
+        emulated by checking first, since SQLAlchemy's bulk-insert lacks
+        a portable upsert without dialect-specific code).
+        """
+        existing_stmt = select(LeadColumn.slug).where(
+            LeadColumn.initiatief_id == initiatief_id
+        )
+        existing = {row[0] for row in (await self.session.execute(existing_stmt)).all()}
+        for idx, default in enumerate(DEFAULT_COLUMNS):
+            if default["slug"] in existing:
+                continue
+            self.session.add(
+                LeadColumn(
+                    initiatief_id=initiatief_id,
+                    name=default["name"],
+                    slug=default["slug"],
+                    sort_order=idx,
+                    color=default["color"],
+                    is_active_stage=default["is_active_stage"],
+                    is_public_visible=default["is_public_visible"],
+                )
+            )
+        await self.session.flush()

--- a/backend/bouwmeester/schema/__init__.py
+++ b/backend/bouwmeester/schema/__init__.py
@@ -136,6 +136,12 @@ from bouwmeester.schema.lead import (
     LeadTimelineResponse,
     LeadUpdate,
 )
+from bouwmeester.schema.lead_column import (
+    LeadColumnCreate,
+    LeadColumnReorder,
+    LeadColumnResponse,
+    LeadColumnUpdate,
+)
 from bouwmeester.schema.llm import (
     CorpusGapOverviewResponse,
     CorpusGapSummaryItem,
@@ -476,6 +482,11 @@ __all__ = [
     "LeadTimelineEvent",
     "LeadTimelineResponse",
     "LeadUpdate",
+    # lead_column
+    "LeadColumnCreate",
+    "LeadColumnReorder",
+    "LeadColumnResponse",
+    "LeadColumnUpdate",
     # samenwerkingsverband
     "PersoonLidmaatschapResponse",
     "SamenwerkingsverbandCreate",

--- a/backend/bouwmeester/schema/lead.py
+++ b/backend/bouwmeester/schema/lead.py
@@ -11,6 +11,14 @@ from bouwmeester.schema.github_link import GitHubLinkResponse
 
 
 class LeadStage(enum.StrEnum):
+    """Default stage slugs.
+
+    Stage waarden zijn niet langer beperkt tot deze enum: per-initiatief
+    kunnen eigenaren eigen kolommen aanmaken via `lead_column`. De enum
+    blijft als referentie voor de 7 default-kolommen (orphan-leads zonder
+    initiatief, frontend fallback bij loading).
+    """
+
     inbox = "inbox"
     verkennen = "verkennen"
     eerste_gesprek = "eerste_gesprek"
@@ -47,7 +55,7 @@ class LeadBase(BaseModel):
     description: str | None = Field(None, max_length=10000)
     organization: str | None = Field(None, max_length=500)
     externe_organisatie_id: UUID | None = None
-    stage: LeadStage = LeadStage.inbox
+    stage: str = Field(default="inbox", min_length=1, max_length=120)
     assignee_id: UUID | None = None
     brought_by_id: UUID | None = None
     next_action: str | None = Field(None, max_length=5000)
@@ -72,7 +80,7 @@ class LeadUpdate(BaseModel):
     description: str | None = Field(None, max_length=10000)
     organization: str | None = Field(None, max_length=500)
     externe_organisatie_id: UUID | None = None
-    stage: LeadStage | None = None
+    stage: str | None = Field(None, min_length=1, max_length=120)
     assignee_id: UUID | None = None
     brought_by_id: UUID | None = None
     next_action: str | None = Field(None, max_length=5000)
@@ -91,12 +99,12 @@ class LeadUpdate(BaseModel):
 
 
 class LeadMove(BaseModel):
-    stage: LeadStage
+    stage: str = Field(min_length=1, max_length=120)
 
 
 class LeadReorder(BaseModel):
     lead_ids: list[UUID]
-    stage: LeadStage
+    stage: str = Field(min_length=1, max_length=120)
 
 
 class LeadMergeRequest(BaseModel):
@@ -239,7 +247,7 @@ class LeadResponse(BaseModel):
     organization: str | None = None
     externe_organisatie_id: UUID | None = None
     externe_organisatie: LeadExterneOrgSummary | None = None
-    stage: LeadStage
+    stage: str
     assignee_id: UUID | None = None
     assignee: LeadAssigneeSummary | None = None
     brought_by_id: UUID | None = None

--- a/backend/bouwmeester/schema/lead_column.py
+++ b/backend/bouwmeester/schema/lead_column.py
@@ -1,0 +1,102 @@
+"""Pydantic schemas for LeadColumn (per-initiatief funnel-kolommen)."""
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# Default columns inserted for every initiatief; also the fallback set used
+# by orphan-leads (initiatief_id IS NULL) and as a frontend loading fallback.
+DEFAULT_COLUMNS: list[dict] = [
+    {
+        "slug": "inbox",
+        "name": "Inbox",
+        "color": "bg-indigo-100 text-indigo-800",
+        "is_active_stage": False,
+        "is_public_visible": False,
+    },
+    {
+        "slug": "verkennen",
+        "name": "Verkennen",
+        "color": "bg-blue-100 text-blue-800",
+        "is_active_stage": True,
+        "is_public_visible": False,
+    },
+    {
+        "slug": "eerste_gesprek",
+        "name": "Eerste gesprek",
+        "color": "bg-yellow-100 text-yellow-800",
+        "is_active_stage": True,
+        "is_public_visible": True,
+    },
+    {
+        "slug": "interne_check",
+        "name": "Interne check",
+        "color": "bg-orange-100 text-orange-800",
+        "is_active_stage": True,
+        "is_public_visible": True,
+    },
+    {
+        "slug": "follow_up",
+        "name": "Follow-up",
+        "color": "bg-purple-100 text-purple-800",
+        "is_active_stage": True,
+        "is_public_visible": True,
+    },
+    {
+        "slug": "in_the_pocket",
+        "name": "In the pocket",
+        "color": "bg-green-100 text-green-800",
+        "is_active_stage": False,
+        "is_public_visible": True,
+    },
+    {
+        "slug": "koelkast",
+        "name": "Koelkast",
+        "color": "bg-gray-100 text-gray-800",
+        "is_active_stage": False,
+        "is_public_visible": False,
+    },
+]
+
+DEFAULT_SLUGS: frozenset[str] = frozenset(c["slug"] for c in DEFAULT_COLUMNS)
+DEFAULT_ACTIVE_SLUGS: frozenset[str] = frozenset(
+    c["slug"] for c in DEFAULT_COLUMNS if c["is_active_stage"]
+)
+DEFAULT_PUBLIC_SLUGS: frozenset[str] = frozenset(
+    c["slug"] for c in DEFAULT_COLUMNS if c["is_public_visible"]
+)
+
+
+class LeadColumnCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=80)
+    color: str = Field(min_length=1, max_length=120)
+    is_active_stage: bool = True
+    is_public_visible: bool = False
+
+
+class LeadColumnUpdate(BaseModel):
+    name: str | None = Field(None, min_length=1, max_length=80)
+    color: str | None = Field(None, min_length=1, max_length=120)
+    is_active_stage: bool | None = None
+    is_public_visible: bool | None = None
+
+
+class LeadColumnReorder(BaseModel):
+    column_ids: list[UUID] = Field(min_length=1)
+
+
+class LeadColumnResponse(BaseModel):
+    id: UUID
+    initiatief_id: UUID
+    name: str
+    slug: str
+    sort_order: int
+    color: str
+    is_active_stage: bool
+    is_public_visible: bool
+    lead_count: int = 0
+    created_at: datetime
+    updated_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/bouwmeester/services/mattermost_ingest_service.py
+++ b/backend/bouwmeester/services/mattermost_ingest_service.py
@@ -63,10 +63,11 @@ SIMILAR_LEAD_THRESHOLD = 0.3
 MAX_LEADS_FOR_LLM = 60
 
 
-# Mirror van LEAD_STAGE_LABELS in frontend/src/types/index.ts. Backend heeft
-# verder geen plek waar lead-stages naar mensentaal worden vertaald, dus we
-# houden de map lokaal tot een tweede call-site dit nodig heeft.
-_LEAD_STAGE_LABELS = {
+# Fallback labels voor de 7 default-stages. De echte naam komt sinds
+# per-initiatief lead_columns uit `lead_column.name`; deze map dient
+# alleen als reservering wanneer de stage-slug niet (meer) als kolom
+# bestaat (orphan-data, oude rij).
+_DEFAULT_STAGE_LABELS = {
     "inbox": "Inbox",
     "verkennen": "Verkennen",
     "eerste_gesprek": "Eerste gesprek",
@@ -460,7 +461,14 @@ class MattermostIngestService:
                 for row in rows:
                     if str(row.id) == str(candidate):
                         match_lead_uuid = candidate
-                        matched_lead = {"title": row.title, "stage": row.stage}
+                        stage_label = await self._resolve_stage_label(
+                            channel_link_initiatief_id, row.stage
+                        )
+                        matched_lead = {
+                            "title": row.title,
+                            "stage": row.stage,
+                            "stage_label": stage_label,
+                        }
                         break
 
         suggested = SuggestedLead(
@@ -558,6 +566,33 @@ class MattermostIngestService:
             merged.setdefault(row.id, row)
         return list(merged.values())[:MAX_LEADS_FOR_LLM]
 
+    async def _resolve_stage_label(
+        self, initiatief_id: UUID | None, stage: str | None
+    ) -> str:
+        """Vertaal een stage-slug naar de zichtbare kolomnaam.
+
+        Sinds per-initiatief lead_columns kunnen eigenaren stages
+        hernoemen; we lezen de naam direct uit ``lead_column``. Voor
+        orphan-leads (geen initiatief) of slugs die niet langer als
+        kolom bestaan vallen we terug op de 7-default-labels — anders
+        krijgt de bot-reply de raw slug te zien.
+        """
+        if not stage:
+            return ""
+        if initiatief_id is not None:
+            from sqlalchemy import select
+
+            from bouwmeester.models.lead_column import LeadColumn
+
+            stmt = select(LeadColumn.name).where(
+                LeadColumn.initiatief_id == initiatief_id,
+                LeadColumn.slug == stage,
+            )
+            name = (await self.session.execute(stmt)).scalar_one_or_none()
+            if name:
+                return name
+        return _DEFAULT_STAGE_LABELS.get(stage, stage)
+
     async def _post_suggestion_reply(
         self,
         *,
@@ -590,9 +625,7 @@ class MattermostIngestService:
             pct = int((suggested.confidence or 0) * 100)
 
             if matched_lead is not None:
-                stage_label = _LEAD_STAGE_LABELS.get(
-                    matched_lead.get("stage") or "", matched_lead.get("stage") or ""
-                )
+                stage_label = matched_lead.get("stage_label") or ""
                 text = (
                     f":link: Dit lijkt te gaan over een bestaande lead voor "
                     f"**{initiatief.naam}**: **{matched_lead['title']}**"

--- a/backend/scripts/seed.py
+++ b/backend/scripts/seed.py
@@ -4755,6 +4755,7 @@ async def seed(db: AsyncSession) -> None:
     from bouwmeester.core.slug import slugify
     from bouwmeester.models.initiatief import Initiatief
     from bouwmeester.models.resource_permission import ResourcePermission
+    from bouwmeester.repositories.lead_column import LeadColumnRepository
 
     initiatieven_data = [
         ("Regelrecht", "#3B82F6", "Community-tool voor team Regelrecht"),
@@ -4781,6 +4782,10 @@ async def seed(db: AsyncSession) -> None:
         )
         db.add(init)
         await db.flush()
+        # Seed de 7 default funnel-kolommen — het script bypasst
+        # InitiatiefRepository.create dus de auto-seed daar wordt niet
+        # getriggerd.
+        await LeadColumnRepository(db).seed_defaults(init.id)
         # First person (super_admin) becomes eigenaar
         if first_person:
             db.add(

--- a/backend/tests/test_lead_columns.py
+++ b/backend/tests/test_lead_columns.py
@@ -1,0 +1,216 @@
+"""Tests for per-initiatief funnel-kolommen (lead_column)."""
+
+import uuid
+
+from bouwmeester.repositories.lead_column import LeadColumnRepository
+
+
+async def _create_initiatief_with_defaults(db_session, *, naam: str = "Init"):
+    """Insert an initiatief and seed the 7 default columns.
+
+    Bypasses InitiatiefRepository.create (which would also try to write
+    a ResourcePermission for created_by_id) by adding the model directly
+    and seeding columns through the repo.
+    """
+    from bouwmeester.models.initiatief import Initiatief
+
+    init = Initiatief(id=uuid.uuid4(), naam=naam)
+    db_session.add(init)
+    await db_session.flush()
+    await LeadColumnRepository(db_session).seed_defaults(init.id)
+    return init
+
+
+async def test_seed_defaults_creates_seven_columns(client, db_session):
+    init = await _create_initiatief_with_defaults(db_session)
+    resp = await client.get(f"/api/initiatieven/{init.id}/columns")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert len(data) == 7
+    slugs = [c["slug"] for c in data]
+    assert slugs == [
+        "inbox",
+        "verkennen",
+        "eerste_gesprek",
+        "interne_check",
+        "follow_up",
+        "in_the_pocket",
+        "koelkast",
+    ]
+    by_slug = {c["slug"]: c for c in data}
+    # is_active_stage flags should exclude the three "non-active" stages
+    assert by_slug["inbox"]["is_active_stage"] is False
+    assert by_slug["in_the_pocket"]["is_active_stage"] is False
+    assert by_slug["koelkast"]["is_active_stage"] is False
+    assert by_slug["verkennen"]["is_active_stage"] is True
+    # is_public_visible flags should include the four publically-visible stages
+    assert by_slug["eerste_gesprek"]["is_public_visible"] is True
+    assert by_slug["in_the_pocket"]["is_public_visible"] is True
+    assert by_slug["inbox"]["is_public_visible"] is False
+
+
+async def test_create_column(client, db_session):
+    init = await _create_initiatief_with_defaults(db_session)
+    resp = await client.post(
+        f"/api/initiatieven/{init.id}/columns",
+        json={
+            "name": "Strategisch",
+            "color": "bg-red-100 text-red-800",
+            "is_active_stage": True,
+            "is_public_visible": False,
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    assert data["name"] == "Strategisch"
+    assert data["slug"] == "strategisch"
+    assert data["sort_order"] == 7  # appended after the 7 defaults
+
+
+async def test_create_column_duplicate_name_409(client, db_session):
+    init = await _create_initiatief_with_defaults(db_session)
+    resp = await client.post(
+        f"/api/initiatieven/{init.id}/columns",
+        json={"name": "Inbox", "color": "bg-red-100 text-red-800"},
+    )
+    assert resp.status_code == 409, resp.text
+
+
+async def test_update_column_rename(client, db_session):
+    init = await _create_initiatief_with_defaults(db_session)
+    listing = await client.get(f"/api/initiatieven/{init.id}/columns")
+    inbox = next(c for c in listing.json() if c["slug"] == "inbox")
+    resp = await client.put(
+        f"/api/initiatieven/{init.id}/columns/{inbox['id']}",
+        json={"name": "Aanmeldingen"},
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["name"] == "Aanmeldingen"
+    # Slug stays immutable so existing leads keep their FK reference
+    assert data["slug"] == "inbox"
+
+
+async def test_delete_empty_column(client, db_session):
+    init = await _create_initiatief_with_defaults(db_session)
+    listing = await client.get(f"/api/initiatieven/{init.id}/columns")
+    koelkast = next(c for c in listing.json() if c["slug"] == "koelkast")
+    resp = await client.delete(f"/api/initiatieven/{init.id}/columns/{koelkast['id']}")
+    assert resp.status_code == 204
+    after = await client.get(f"/api/initiatieven/{init.id}/columns")
+    assert all(c["slug"] != "koelkast" for c in after.json())
+
+
+async def test_delete_non_empty_requires_move_to(client, db_session):
+    from bouwmeester.models.lead import Lead
+
+    init = await _create_initiatief_with_defaults(db_session)
+    db_session.add(Lead(title="X", stage="verkennen", initiatief_id=init.id))
+    await db_session.flush()
+    listing = await client.get(f"/api/initiatieven/{init.id}/columns")
+    verkennen = next(c for c in listing.json() if c["slug"] == "verkennen")
+    follow_up = next(c for c in listing.json() if c["slug"] == "follow_up")
+
+    # Without move_to: 400
+    resp = await client.delete(f"/api/initiatieven/{init.id}/columns/{verkennen['id']}")
+    assert resp.status_code == 400
+    assert "move_to" in resp.text.lower()
+
+    # With move_to: 204 and lead now in target column
+    resp = await client.delete(
+        f"/api/initiatieven/{init.id}/columns/{verkennen['id']}"
+        f"?move_to={follow_up['id']}"
+    )
+    assert resp.status_code == 204
+    await db_session.flush()
+    from sqlalchemy import select
+
+    moved = (
+        await db_session.execute(
+            select(Lead.stage).where(Lead.initiatief_id == init.id)
+        )
+    ).scalar_one()
+    assert moved == "follow_up"
+
+
+async def test_delete_last_column_blocked(client, db_session):
+    init = await _create_initiatief_with_defaults(db_session)
+    listing = await client.get(f"/api/initiatieven/{init.id}/columns")
+    # Delete six of the seven (all empty); the 7th deletion must fail.
+    for col in listing.json()[:-1]:
+        resp = await client.delete(f"/api/initiatieven/{init.id}/columns/{col['id']}")
+        assert resp.status_code == 204, (col, resp.text)
+    last = listing.json()[-1]
+    resp = await client.delete(f"/api/initiatieven/{init.id}/columns/{last['id']}")
+    assert resp.status_code == 400
+    assert "tenminste 1 kolom" in resp.text.lower()
+
+
+async def test_reorder_columns(client, db_session):
+    init = await _create_initiatief_with_defaults(db_session)
+    listing = await client.get(f"/api/initiatieven/{init.id}/columns")
+    ids = [c["id"] for c in listing.json()]
+    reversed_ids = list(reversed(ids))
+    resp = await client.post(
+        f"/api/initiatieven/{init.id}/columns/reorder",
+        json={"column_ids": reversed_ids},
+    )
+    assert resp.status_code == 200, resp.text
+    after = await client.get(f"/api/initiatieven/{init.id}/columns")
+    after_ids = [c["id"] for c in after.json()]
+    assert after_ids == reversed_ids
+
+
+async def test_reorder_mismatch_400(client, db_session):
+    init = await _create_initiatief_with_defaults(db_session)
+    listing = await client.get(f"/api/initiatieven/{init.id}/columns")
+    ids = [c["id"] for c in listing.json()][:-1]  # missing one
+    resp = await client.post(
+        f"/api/initiatieven/{init.id}/columns/reorder",
+        json={"column_ids": ids},
+    )
+    assert resp.status_code == 400
+
+
+async def test_create_lead_with_unknown_stage_422(client, db_session):
+    init = await _create_initiatief_with_defaults(db_session)
+    resp = await client.post(
+        "/api/leads",
+        json={
+            "title": "Test",
+            "stage": "niet-bestaand",
+            "initiatief_id": str(init.id),
+        },
+    )
+    assert resp.status_code == 422, resp.text
+    assert "niet-bestaand" in resp.text
+
+
+async def test_orphan_lead_accepts_default_slugs(client, db_session):
+    """Lead zonder initiatief_id valt terug op de 7 default-slugs."""
+    resp = await client.post(
+        "/api/leads",
+        json={"title": "Orphan", "stage": "verkennen"},
+    )
+    assert resp.status_code == 201, resp.text
+
+
+async def test_orphan_lead_rejects_unknown_slug(client, db_session):
+    resp = await client.post(
+        "/api/leads",
+        json={"title": "Orphan", "stage": "strategisch"},
+    )
+    assert resp.status_code == 422, resp.text
+
+
+async def test_lead_count_returned_in_list(client, db_session):
+    from bouwmeester.models.lead import Lead
+
+    init = await _create_initiatief_with_defaults(db_session)
+    db_session.add(Lead(title="A", stage="verkennen", initiatief_id=init.id))
+    db_session.add(Lead(title="B", stage="verkennen", initiatief_id=init.id))
+    await db_session.flush()
+    resp = await client.get(f"/api/initiatieven/{init.id}/columns")
+    by_slug = {c["slug"]: c for c in resp.json()}
+    assert by_slug["verkennen"]["lead_count"] == 2
+    assert by_slug["inbox"]["lead_count"] == 0

--- a/backend/tests/test_mattermost_suggested_lead.py
+++ b/backend/tests/test_mattermost_suggested_lead.py
@@ -26,9 +26,15 @@ def _id() -> str:
 
 @pytest.fixture
 async def sample_initiatief(db_session):
+    from bouwmeester.repositories.lead_column import LeadColumnRepository
+
     init = Initiatief(id=uuid.uuid4(), naam="Regelrecht")
     db_session.add(init)
     await db_session.flush()
+    # Seed de 7 default-kolommen zodat stage-labels (bv. "Verkennen") door
+    # _resolve_stage_label gevonden worden in plaats van terug te vallen
+    # op de raw slug.
+    await LeadColumnRepository(db_session).seed_defaults(init.id)
     return init
 
 
@@ -736,6 +742,7 @@ async def test_post_suggestion_reply_existing_lead_copy(
             matched_lead={
                 "title": "HHNK (Hoogheemraadschap Hollands Noorderkwartier)",
                 "stage": "verkennen",
+                "stage_label": "Verkennen",
             },
         )
 
@@ -814,3 +821,6 @@ async def test_ingest_propagates_matched_lead_to_reply(
     assert matched is not None
     assert matched["title"] == "HHNK (Hoogheemraadschap Hollands Noorderkwartier)"
     assert matched["stage"] == "verkennen"
+    # Label komt uit lead_column.name (per-initiatief), niet uit een
+    # hardcoded backend-map.
+    assert matched["stage_label"] == "Verkennen"

--- a/backend/tests/test_public_initiatief.py
+++ b/backend/tests/test_public_initiatief.py
@@ -17,6 +17,7 @@ async def _create_initiatief(
     public: bool = False,
 ):
     from bouwmeester.models.initiatief import Initiatief
+    from bouwmeester.repositories.lead_column import LeadColumnRepository
 
     init = Initiatief(
         id=uuid.uuid4(),
@@ -28,6 +29,10 @@ async def _create_initiatief(
     )
     db_session.add(init)
     await db_session.flush()
+    # Seed de 7 default-kolommen zodat de publieke pagina casuses kan tonen
+    # (LeadColumn.is_public_visible filtert nu wat zichtbaar is, ipv een
+    # hardcoded slug-lijst).
+    await LeadColumnRepository(db_session).seed_defaults(init.id)
     return init
 
 

--- a/frontend/src/api/leadColumns.ts
+++ b/frontend/src/api/leadColumns.ts
@@ -1,0 +1,55 @@
+import { apiGet, apiPost, apiPut, apiDelete } from './client';
+import type { LeadColumn } from '@/types';
+
+export interface LeadColumnCreate {
+  name: string;
+  color: string;
+  is_active_stage?: boolean;
+  is_public_visible?: boolean;
+}
+
+export interface LeadColumnUpdate {
+  name?: string;
+  color?: string;
+  is_active_stage?: boolean;
+  is_public_visible?: boolean;
+}
+
+export function listLeadColumns(initiatiefId: string): Promise<LeadColumn[]> {
+  return apiGet(`/api/initiatieven/${initiatiefId}/columns`);
+}
+
+export function createLeadColumn(
+  initiatiefId: string,
+  data: LeadColumnCreate,
+): Promise<LeadColumn> {
+  return apiPost(`/api/initiatieven/${initiatiefId}/columns`, data);
+}
+
+export function updateLeadColumn(
+  initiatiefId: string,
+  columnId: string,
+  data: LeadColumnUpdate,
+): Promise<LeadColumn> {
+  return apiPut(`/api/initiatieven/${initiatiefId}/columns/${columnId}`, data);
+}
+
+export function deleteLeadColumn(
+  initiatiefId: string,
+  columnId: string,
+  moveTo?: string,
+): Promise<void> {
+  const qs = moveTo ? `?move_to=${encodeURIComponent(moveTo)}` : '';
+  return apiDelete(
+    `/api/initiatieven/${initiatiefId}/columns/${columnId}${qs}`,
+  );
+}
+
+export function reorderLeadColumns(
+  initiatiefId: string,
+  columnIds: string[],
+): Promise<LeadColumn[]> {
+  return apiPost(`/api/initiatieven/${initiatiefId}/columns/reorder`, {
+    column_ids: columnIds,
+  });
+}

--- a/frontend/src/components/initiatieven/InitiatiefDetailModal.tsx
+++ b/frontend/src/components/initiatieven/InitiatiefDetailModal.tsx
@@ -52,6 +52,7 @@ import type {
 } from '@/types';
 import { StakeholderTab } from '@/components/stakeholders/StakeholderTab';
 import { MattermostChannelsSection } from '@/components/mattermost/MattermostChannelsSection';
+import { ColumnsManager } from '@/components/leads/ColumnsManager';
 
 interface InitiatiefDetailModalProps {
   initiatiefId: string;
@@ -483,6 +484,19 @@ export function InitiatiefDetailModal({
 
             {/* Updates (publication posts) */}
             <UpdatesSection initiatief={detail} canEdit={canEdit} />
+
+            {/* Funnel-kolommen — eigenaar only */}
+            {isEigenaar && (
+              <div>
+                <div className="flex items-center justify-between mb-2">
+                  <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider flex items-center gap-1.5">
+                    <SettingsIcon className="h-3.5 w-3.5" />
+                    Funnel-kolommen
+                  </h4>
+                </div>
+                <ColumnsManager initiatiefId={detail.id} />
+              </div>
+            )}
 
             {/* Settings — eigenaar only */}
             {isEigenaar && <SettingsSection initiatief={detail} />}

--- a/frontend/src/components/leads/ColumnsManager.tsx
+++ b/frontend/src/components/leads/ColumnsManager.tsx
@@ -1,0 +1,385 @@
+import { useMemo, useState } from 'react';
+import {
+  Plus,
+  Trash2,
+  ArrowUp,
+  ArrowDown,
+  Eye,
+  EyeOff,
+  Globe,
+  Check,
+  X,
+} from 'lucide-react';
+import { Button } from '@/components/common/Button';
+import { ConfirmDialog } from '@/components/common/ConfirmDialog';
+import { LoadingSpinner } from '@/components/common/LoadingSpinner';
+import {
+  useCreateLeadColumn,
+  useDeleteLeadColumn,
+  useLeadColumns,
+  useReorderLeadColumns,
+  useUpdateLeadColumn,
+} from '@/hooks/useLeadColumns';
+import type { LeadColumn } from '@/types';
+
+const COLOR_PRESETS: { label: string; value: string }[] = [
+  { label: 'Indigo', value: 'bg-indigo-100 text-indigo-800' },
+  { label: 'Blauw', value: 'bg-blue-100 text-blue-800' },
+  { label: 'Geel', value: 'bg-yellow-100 text-yellow-800' },
+  { label: 'Oranje', value: 'bg-orange-100 text-orange-800' },
+  { label: 'Paars', value: 'bg-purple-100 text-purple-800' },
+  { label: 'Groen', value: 'bg-green-100 text-green-800' },
+  { label: 'Grijs', value: 'bg-gray-100 text-gray-800' },
+  { label: 'Roze', value: 'bg-pink-100 text-pink-800' },
+  { label: 'Rood', value: 'bg-red-100 text-red-800' },
+  { label: 'Smaragd', value: 'bg-emerald-100 text-emerald-800' },
+];
+
+interface ColumnsManagerProps {
+  initiatiefId: string;
+}
+
+export function ColumnsManager({ initiatiefId }: ColumnsManagerProps) {
+  const { columns, isLoading } = useLeadColumns(initiatiefId);
+  const createMutation = useCreateLeadColumn(initiatiefId);
+  const updateMutation = useUpdateLeadColumn(initiatiefId);
+  const deleteMutation = useDeleteLeadColumn(initiatiefId);
+  const reorderMutation = useReorderLeadColumns(initiatiefId);
+
+  const [adding, setAdding] = useState(false);
+  const [draftName, setDraftName] = useState('');
+  const [draftColor, setDraftColor] = useState(COLOR_PRESETS[0].value);
+  const [editing, setEditing] = useState<string | null>(null);
+  const [editName, setEditName] = useState('');
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [moveTarget, setMoveTarget] = useState<string>('');
+
+  const sortedColumns = useMemo(
+    () => [...columns].sort((a, b) => a.sort_order - b.sort_order),
+    [columns],
+  );
+
+  const deletingColumn = sortedColumns.find((c) => c.id === deletingId) ?? null;
+  const otherColumns = sortedColumns.filter((c) => c.id !== deletingId);
+
+  const handleAdd = async () => {
+    const name = draftName.trim();
+    if (!name) return;
+    await createMutation.mutateAsync({ name, color: draftColor });
+    setDraftName('');
+    setDraftColor(COLOR_PRESETS[0].value);
+    setAdding(false);
+  };
+
+  const startEdit = (col: LeadColumn) => {
+    setEditing(col.id);
+    setEditName(col.name);
+  };
+
+  const commitEdit = async () => {
+    if (!editing) return;
+    const name = editName.trim();
+    if (!name) {
+      setEditing(null);
+      return;
+    }
+    await updateMutation.mutateAsync({ id: editing, data: { name } });
+    setEditing(null);
+  };
+
+  const moveColumn = async (col: LeadColumn, dir: 'up' | 'down') => {
+    const idx = sortedColumns.findIndex((c) => c.id === col.id);
+    const targetIdx = dir === 'up' ? idx - 1 : idx + 1;
+    if (targetIdx < 0 || targetIdx >= sortedColumns.length) return;
+    const next = [...sortedColumns];
+    [next[idx], next[targetIdx]] = [next[targetIdx], next[idx]];
+    await reorderMutation.mutateAsync(next.map((c) => c.id));
+  };
+
+  const setColor = async (col: LeadColumn, color: string) => {
+    await updateMutation.mutateAsync({ id: col.id, data: { color } });
+  };
+
+  const toggleActive = async (col: LeadColumn) => {
+    await updateMutation.mutateAsync({
+      id: col.id,
+      data: { is_active_stage: !col.is_active_stage },
+    });
+  };
+
+  const togglePublic = async (col: LeadColumn) => {
+    await updateMutation.mutateAsync({
+      id: col.id,
+      data: { is_public_visible: !col.is_public_visible },
+    });
+  };
+
+  const confirmDelete = async () => {
+    if (!deletingColumn) return;
+    const needsMove = deletingColumn.lead_count > 0;
+    if (needsMove && !moveTarget) return;
+    await deleteMutation.mutateAsync({
+      id: deletingColumn.id,
+      moveTo: needsMove ? moveTarget : undefined,
+    });
+    setDeletingId(null);
+    setMoveTarget('');
+  };
+
+  if (isLoading) {
+    return <LoadingSpinner className="py-6" />;
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-text-secondary">
+        Eigenaren beheren hier de funnel-kolommen voor dit initiatief. Slug
+        blijft vast na aanmaken zodat bestaande leads gekoppeld blijven.
+        "Actieve fase" telt mee voor de overdue-filter; "Publiek zichtbaar"
+        toont casuses op de publieke pagina.
+      </p>
+
+      <ul className="divide-y divide-border rounded-xl border border-border">
+        {sortedColumns.map((col, idx) => {
+          const isFirst = idx === 0;
+          const isLast = idx === sortedColumns.length - 1;
+          return (
+            <li key={col.id} className="px-3 py-2.5 space-y-2">
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex items-center gap-2 min-w-0 flex-1">
+                  <span
+                    className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${col.color}`}
+                  >
+                    {col.slug}
+                  </span>
+                  {editing === col.id ? (
+                    <input
+                      type="text"
+                      value={editName}
+                      onChange={(e) => setEditName(e.target.value)}
+                      onBlur={commitEdit}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') commitEdit();
+                        if (e.key === 'Escape') setEditing(null);
+                      }}
+                      autoFocus
+                      className="flex-1 text-sm rounded-lg border border-border px-2 py-1 focus:outline-none focus:ring-2 focus:ring-primary"
+                    />
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => startEdit(col)}
+                      className="text-sm font-medium text-text hover:text-primary-700 truncate text-left"
+                      title="Klik om te hernoemen"
+                    >
+                      {col.name}
+                    </button>
+                  )}
+                  <span className="text-xs text-text-secondary tabular-nums">
+                    {col.lead_count} {col.lead_count === 1 ? 'lead' : 'leads'}
+                  </span>
+                </div>
+
+                <div className="flex items-center gap-1 shrink-0">
+                  <button
+                    type="button"
+                    onClick={() => moveColumn(col, 'up')}
+                    disabled={isFirst || reorderMutation.isPending}
+                    className="p-1 rounded hover:bg-gray-100 text-text-secondary disabled:opacity-30"
+                    title="Omhoog"
+                  >
+                    <ArrowUp className="h-3.5 w-3.5" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => moveColumn(col, 'down')}
+                    disabled={isLast || reorderMutation.isPending}
+                    className="p-1 rounded hover:bg-gray-100 text-text-secondary disabled:opacity-30"
+                    title="Omlaag"
+                  >
+                    <ArrowDown className="h-3.5 w-3.5" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setDeletingId(col.id)}
+                    disabled={sortedColumns.length <= 1}
+                    className="p-1 rounded hover:bg-gray-100 text-text-secondary hover:text-red-500 disabled:opacity-30 disabled:hover:text-text-secondary"
+                    title={
+                      sortedColumns.length <= 1
+                        ? 'Laatste kolom kan niet weg'
+                        : 'Verwijderen'
+                    }
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+              </div>
+
+              <div className="flex items-center gap-3 flex-wrap pl-1 text-xs">
+                <button
+                  type="button"
+                  onClick={() => toggleActive(col)}
+                  className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 ${
+                    col.is_active_stage
+                      ? 'bg-emerald-100 text-emerald-800'
+                      : 'bg-gray-100 text-gray-600'
+                  }`}
+                  title="Telt mee voor overdue/stale-filter"
+                >
+                  {col.is_active_stage ? (
+                    <Check className="h-3 w-3" />
+                  ) : (
+                    <X className="h-3 w-3" />
+                  )}
+                  Actieve fase
+                </button>
+                <button
+                  type="button"
+                  onClick={() => togglePublic(col)}
+                  className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 ${
+                    col.is_public_visible
+                      ? 'bg-blue-100 text-blue-800'
+                      : 'bg-gray-100 text-gray-600'
+                  }`}
+                  title="Toont casuses op publieke pagina"
+                >
+                  {col.is_public_visible ? (
+                    <Eye className="h-3 w-3" />
+                  ) : (
+                    <EyeOff className="h-3 w-3" />
+                  )}
+                  Publiek zichtbaar
+                </button>
+                <div className="flex items-center gap-1">
+                  <Globe className="h-3 w-3 text-text-secondary" />
+                  <ColorSwatches
+                    selected={col.color}
+                    onSelect={(color) => setColor(col, color)}
+                  />
+                </div>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+
+      {adding ? (
+        <div className="rounded-xl border border-border p-3 space-y-2">
+          <input
+            type="text"
+            value={draftName}
+            onChange={(e) => setDraftName(e.target.value)}
+            placeholder="Kolomnaam (bv. Strategisch)"
+            className="w-full text-sm rounded-lg border border-border px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary"
+            autoFocus
+          />
+          <div className="flex items-center justify-between gap-2">
+            <ColorSwatches selected={draftColor} onSelect={setDraftColor} />
+            <div className="flex gap-1">
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => {
+                  setAdding(false);
+                  setDraftName('');
+                }}
+              >
+                Annuleren
+              </Button>
+              <Button
+                size="sm"
+                onClick={handleAdd}
+                loading={createMutation.isPending}
+                disabled={!draftName.trim()}
+              >
+                Toevoegen
+              </Button>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <Button
+          variant="secondary"
+          size="sm"
+          icon={<Plus className="h-3.5 w-3.5" />}
+          onClick={() => setAdding(true)}
+        >
+          Kolom toevoegen
+        </Button>
+      )}
+
+      <ConfirmDialog
+        open={!!deletingColumn}
+        onClose={() => {
+          setDeletingId(null);
+          setMoveTarget('');
+        }}
+        onConfirm={confirmDelete}
+        title="Kolom verwijderen"
+        confirmLabel="Verwijderen"
+        variant="danger"
+        loading={deleteMutation.isPending}
+      >
+        {deletingColumn && (
+          <div className="space-y-3">
+            <p>
+              Weet je zeker dat je <strong>{deletingColumn.name}</strong> wilt
+              verwijderen?
+            </p>
+            {deletingColumn.lead_count > 0 ? (
+              <div className="space-y-1">
+                <p className="text-sm text-text-secondary">
+                  Deze kolom bevat {deletingColumn.lead_count}{' '}
+                  {deletingColumn.lead_count === 1 ? 'lead' : 'leads'}. Kies een
+                  doel-kolom waar ze heen gaan:
+                </p>
+                <select
+                  value={moveTarget}
+                  onChange={(e) => setMoveTarget(e.target.value)}
+                  className="w-full text-sm rounded-lg border border-border px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary"
+                >
+                  <option value="">— Kies kolom —</option>
+                  {otherColumns.map((c) => (
+                    <option key={c.id} value={c.id}>
+                      {c.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            ) : (
+              <p className="text-sm text-text-secondary">
+                De kolom is leeg en wordt direct verwijderd.
+              </p>
+            )}
+          </div>
+        )}
+      </ConfirmDialog>
+    </div>
+  );
+}
+
+function ColorSwatches({
+  selected,
+  onSelect,
+}: {
+  selected: string;
+  onSelect: (color: string) => void;
+}) {
+  return (
+    <div className="flex gap-1">
+      {COLOR_PRESETS.map((preset) => (
+        <button
+          key={preset.value}
+          type="button"
+          onClick={() => onSelect(preset.value)}
+          title={preset.label}
+          className={`h-4 w-4 rounded-full border ${
+            preset.value
+          } ${selected === preset.value ? 'ring-2 ring-offset-1 ring-current' : ''}`}
+        >
+          <span className="sr-only">{preset.label}</span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/leads/LeadDetailPanel.tsx
+++ b/frontend/src/components/leads/LeadDetailPanel.tsx
@@ -85,7 +85,7 @@ interface PublicationStatus {
 function publicationStatus(args: {
   publicVisible: boolean;
   publicTitle: string | null;
-  stage: LeadStage;
+  stage: string;
 }): PublicationStatus {
   if (!args.publicVisible) {
     return { visible: false, reason: 'Toggle "Publiek tonen" staat uit.' };
@@ -93,10 +93,15 @@ function publicationStatus(args: {
   if (!args.publicTitle?.trim()) {
     return { visible: false, reason: 'Publieke titel is leeg.' };
   }
-  if (!PUBLIC_VISIBLE_STAGES.includes(args.stage)) {
+  // Heuristiek-fallback: voor de detail-panel-hint gebruiken we de
+  // 7-default whitelist. De backend doet de echte check op
+  // LeadColumn.is_public_visible per initiatief; deze UI-hint hoeft
+  // alleen "ongeveer juist" te zijn voor default-stages.
+  if (!PUBLIC_VISIBLE_STAGES.includes(args.stage as LeadStage)) {
+    const label = LEAD_STAGE_LABELS[args.stage] ?? args.stage;
     return {
       visible: false,
-      reason: `Lead in stage "${LEAD_STAGE_LABELS[args.stage]}" — alleen actieve stages worden publiek.`,
+      reason: `Lead in stage "${label}" — alleen actieve stages worden publiek.`,
     };
   }
   return { visible: true, reason: null };
@@ -142,7 +147,7 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
   const [editTitle, setEditTitle] = useState('');
   const [editDescription, setEditDescription] = useState('');
   const [editOrganization, setEditOrganization] = useState('');
-  const [editStage, setEditStage] = useState<LeadStage>(LeadStage.VERKENNEN);
+  const [editStage, setEditStage] = useState<string>(LeadStage.VERKENNEN);
   const [editAssignee, setEditAssignee] = useState('');
   const [editNextAction, setEditNextAction] = useState('');
   const [editNextActionDate, setEditNextActionDate] = useState('');

--- a/frontend/src/components/leads/LeadGraphView.tsx
+++ b/frontend/src/components/leads/LeadGraphView.tsx
@@ -37,9 +37,9 @@ import { useCommunityGraph } from '@/hooks/useLeads';
 import { useLeadDetail } from '@/contexts/LeadDetailContext';
 import { useNodeDetail } from '@/contexts/NodeDetailContext';
 import {
-  LeadStage,
   LEAD_STAGE_LABELS,
   LEAD_STAGE_COLORS,
+  LeadStage,
   NODE_TYPE_HEX_COLORS,
   NodeType,
   formatFunctie,
@@ -175,12 +175,17 @@ function CommunityGraphNodeComponent({ data }: NodeProps<CommunityGraphNodeData>
 
   const badgeContent = (() => {
     if (data.nodeType === 'lead' && data.stage) {
-      const stageKey = data.stage as LeadStage;
+      // De stage is sinds per-initiatief-kolommen een vrije slug. We pakken
+      // alleen de vaste fallback-stijlen voor de 7 defaults; voor custom
+      // kolommen valt de styling terug op een neutraal grijs en wordt de
+      // slug zelf getoond — een per-graph-node lookup van de actieve
+      // LeadColumn lijst zou hier overkill zijn.
+      const fallbackKey = data.stage as LeadStage;
       return (
         <span
-          className={`inline-block rounded-full px-2 py-0.5 text-[10px] font-medium mb-1 ${LEAD_STAGE_COLORS[stageKey] ?? 'bg-gray-100 text-gray-800'}`}
+          className={`inline-block rounded-full px-2 py-0.5 text-[10px] font-medium mb-1 ${LEAD_STAGE_COLORS[fallbackKey] ?? 'bg-gray-100 text-gray-800'}`}
         >
-          {LEAD_STAGE_LABELS[stageKey] ?? data.stage}
+          {LEAD_STAGE_LABELS[fallbackKey] ?? data.stage}
         </span>
       );
     }

--- a/frontend/src/components/leads/LeadIntakeDialog.tsx
+++ b/frontend/src/components/leads/LeadIntakeDialog.tsx
@@ -21,7 +21,8 @@ import {
 import { useInitiatieven, useCreateInitiatief } from '@/hooks/useInitiatieven';
 import { useCurrentPerson } from '@/contexts/CurrentPersonContext';
 import { useLeadDetail } from '@/contexts/LeadDetailContext';
-import { LeadStage, LEAD_STAGE_ORDER, LEAD_STAGE_LABELS, LEAD_STAGE_COLORS, INITIATIEF_COLORS, formatFunctie } from '@/types';
+import { INITIATIEF_COLORS, formatFunctie } from '@/types';
+import { useLeadColumns } from '@/hooks/useLeadColumns';
 import type { LeadParseResult } from '@/types';
 import { buildPersonOptions } from '@/utils/personOptions';
 
@@ -69,7 +70,7 @@ export function LeadIntakeDialog({ open, onClose, defaultInitiatiefId, sharedPar
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [tagSearch, setTagSearch] = useState('');
   const [tagDropdownOpen, setTagDropdownOpen] = useState(false);
-  const [stage, setStage] = useState<LeadStage>(LeadStage.INBOX);
+  const [stage, setStage] = useState<string>('inbox');
   const [contacts, setContacts] = useState<ContactEntry[]>([emptyContact()]);
   const updateContact = useCallback((index: number, updates: Partial<ContactEntry>) => {
     setContacts(prev => prev.map((c, i) => i === index ? { ...c, ...updates } : c));
@@ -83,6 +84,24 @@ export function LeadIntakeDialog({ open, onClose, defaultInitiatiefId, sharedPar
   const [assigneeId, setAssigneeId] = useState<string>('');
   const [broughtById, setBroughtById] = useState<string>('');
   const [leadDate, setLeadDate] = useState(() => new Date().toISOString().split('T')[0]);
+  const { columns: stageColumns } = useLeadColumns(initiatiefId || undefined);
+  const sortedStageColumns = useMemo(
+    () => [...stageColumns].sort((a, b) => a.sort_order - b.sort_order),
+    [stageColumns],
+  );
+  const stageColumnsBySlug = useMemo(() => {
+    const map = new Map<string, (typeof sortedStageColumns)[number]>();
+    for (const c of sortedStageColumns) map.set(c.slug, c);
+    return map;
+  }, [sortedStageColumns]);
+  // Wanneer het initiatief verandert kan de geselecteerde stage niet langer
+  // bestaan in de kolommen van dat initiatief. Val terug op de eerste kolom.
+  useEffect(() => {
+    if (sortedStageColumns.length === 0) return;
+    if (!stageColumnsBySlug.has(stage)) {
+      setStage(sortedStageColumns[0].slug);
+    }
+  }, [sortedStageColumns, stageColumnsBySlug, stage]);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const createLead = useCreateLead();
@@ -317,7 +336,7 @@ export function LeadIntakeDialog({ open, onClose, defaultInitiatiefId, sharedPar
     setSelectedTags([]);
     setTagSearch('');
     setTagDropdownOpen(false);
-    setStage(LeadStage.INBOX);
+    setStage('inbox');
     setContacts([emptyContact()]);
     setExtraExpertiseValues([]);
     setAssigneeId('');
@@ -676,7 +695,7 @@ export function LeadIntakeDialog({ open, onClose, defaultInitiatiefId, sharedPar
                           {d.title}
                         </button>
                         <span className="text-text-secondary ml-1">
-                          ({d.organization ?? 'geen organisatie'} - {LEAD_STAGE_LABELS[d.stage as LeadStage]})
+                          ({d.organization ?? 'geen organisatie'} - {stageColumnsBySlug.get(d.stage)?.name ?? d.stage})
                         </span>
                       </li>
                     ))}
@@ -689,18 +708,18 @@ export function LeadIntakeDialog({ open, onClose, defaultInitiatiefId, sharedPar
                   Status
                 </label>
                 <div className="flex flex-wrap gap-1.5">
-                  {LEAD_STAGE_ORDER.map((s) => (
+                  {sortedStageColumns.map((c) => (
                     <button
-                      key={s}
+                      key={c.id}
                       type="button"
-                      onClick={() => setStage(s)}
+                      onClick={() => setStage(c.slug)}
                       className={`rounded-full px-3 py-1 text-xs font-medium transition-all ${
-                        stage === s
-                          ? `${LEAD_STAGE_COLORS[s]} ring-2 ring-offset-1 ring-current`
+                        stage === c.slug
+                          ? `${c.color} ring-2 ring-offset-1 ring-current`
                           : 'bg-gray-100 text-text-secondary hover:bg-gray-200'
                       }`}
                     >
-                      {LEAD_STAGE_LABELS[s]}
+                      {c.name}
                     </button>
                   ))}
                 </div>

--- a/frontend/src/components/leads/LeadKanbanBoard.tsx
+++ b/frontend/src/components/leads/LeadKanbanBoard.tsx
@@ -1,28 +1,34 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { Plus } from 'lucide-react';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
 import { LeadCard } from './LeadCard';
 import { LeadMetricsBar } from './LeadMetricsBar';
 import { LeadIntakeDialog } from './LeadIntakeDialog';
 import { useLeads, useMoveLead } from '@/hooks/useLeads';
+import { useLeadColumns } from '@/hooks/useLeadColumns';
 import { useLeadDetail } from '@/contexts/LeadDetailContext';
-import {
-  LeadStage,
-  LEAD_STAGE_ORDER,
-  LEAD_STAGE_LABELS,
-  LEAD_STAGE_COLORS,
-} from '@/types';
-import type { Lead, LeadFilters } from '@/types';
+import type { Lead, LeadColumn, LeadFilters } from '@/types';
 
-const COLUMN_BORDER_COLORS: Record<LeadStage, string> = {
-  [LeadStage.INBOX]: 'border-t-indigo-400',
-  [LeadStage.VERKENNEN]: 'border-t-blue-400',
-  [LeadStage.EERSTE_GESPREK]: 'border-t-yellow-400',
-  [LeadStage.INTERNE_CHECK]: 'border-t-orange-400',
-  [LeadStage.FOLLOW_UP]: 'border-t-purple-400',
-  [LeadStage.IN_THE_POCKET]: 'border-t-green-400',
-  [LeadStage.KOELKAST]: 'border-t-gray-400',
+// Static map: Tailwind v4 only sees classes that appear literally in source.
+// Building the border class via string interpolation purges it, so we list
+// each chip-class explicitly. Keep in sync with COLOR_PRESETS in
+// ColumnsManager.tsx.
+const COLOR_TO_BORDER: Record<string, string> = {
+  'bg-indigo-100 text-indigo-800': 'border-t-indigo-400',
+  'bg-blue-100 text-blue-800': 'border-t-blue-400',
+  'bg-yellow-100 text-yellow-800': 'border-t-yellow-400',
+  'bg-orange-100 text-orange-800': 'border-t-orange-400',
+  'bg-purple-100 text-purple-800': 'border-t-purple-400',
+  'bg-green-100 text-green-800': 'border-t-green-400',
+  'bg-gray-100 text-gray-800': 'border-t-gray-400',
+  'bg-pink-100 text-pink-800': 'border-t-pink-400',
+  'bg-red-100 text-red-800': 'border-t-red-400',
+  'bg-emerald-100 text-emerald-800': 'border-t-emerald-400',
 };
+
+function chipToBorder(color: string): string {
+  return COLOR_TO_BORDER[color] ?? 'border-t-gray-400';
+}
 
 interface LeadKanbanBoardProps {
   searchQuery?: string;
@@ -51,63 +57,71 @@ export function LeadKanbanBoard({
   const { data: leads, isLoading } = useLeads(
     Object.keys(filters).length > 0 ? filters : undefined,
   );
+  const { columns, isLoading: columnsLoading } = useLeadColumns(initiatiefId);
   const moveLead = useMoveLead();
   const { openLeadDetail } = useLeadDetail();
-  const [dragOverColumn, setDragOverColumn] = useState<LeadStage | null>(null);
+  const [dragOverColumn, setDragOverColumn] = useState<string | null>(null);
   const [showIntake, setShowIntake] = useState(false);
 
-  if (isLoading) {
+  const allLeads = useMemo(() => leads ?? [], [leads]);
+  const filteredLeads = useMemo(() => {
+    if (!searchQuery) return allLeads;
+    const q = searchQuery.toLowerCase();
+    return allLeads.filter(
+      (l) =>
+        l.title.toLowerCase().includes(q) ||
+        (l.organization ?? '').toLowerCase().includes(q) ||
+        (l.description ?? '').toLowerCase().includes(q) ||
+        (l.assignee?.naam ?? '').toLowerCase().includes(q) ||
+        l.tags.some((t) => t.toLowerCase().includes(q)),
+    );
+  }, [allLeads, searchQuery]);
+
+  const visibleColumns = useMemo<LeadColumn[]>(
+    () =>
+      [...columns]
+        .sort((a, b) => a.sort_order - b.sort_order)
+        .filter((c) => !stageFilter || c.slug === stageFilter),
+    [columns, stageFilter],
+  );
+
+  const leadsByStage = useMemo(() => {
+    const map: Record<string, Lead[]> = {};
+    for (const col of visibleColumns) {
+      map[col.slug] = filteredLeads
+        .filter((l) => l.stage === col.slug)
+        .sort((a, b) => a.sort_order - b.sort_order);
+    }
+    return map;
+  }, [filteredLeads, visibleColumns]);
+
+  if (isLoading || columnsLoading) {
     return <LoadingSpinner className="py-8" />;
   }
-
-  const allLeads = leads ?? [];
-
-  const filteredLeads = searchQuery
-    ? allLeads.filter((l) => {
-        const q = searchQuery.toLowerCase();
-        return (
-          l.title.toLowerCase().includes(q) ||
-          (l.organization ?? '').toLowerCase().includes(q) ||
-          (l.description ?? '').toLowerCase().includes(q) ||
-          (l.assignee?.naam ?? '').toLowerCase().includes(q) ||
-          l.tags.some((t) => t.toLowerCase().includes(q))
-        );
-      })
-    : allLeads;
-
-  const leadsByStage = LEAD_STAGE_ORDER.reduce(
-    (acc, stage) => {
-      acc[stage] = filteredLeads
-        .filter((l) => l.stage === stage)
-        .sort((a, b) => a.sort_order - b.sort_order);
-      return acc;
-    },
-    {} as Record<LeadStage, Lead[]>,
-  );
 
   const handleDragStart = (e: React.DragEvent, lead: Lead) => {
     e.dataTransfer.setData('text/plain', lead.id);
     e.dataTransfer.effectAllowed = 'move';
   };
 
-  const handleDragOver = (e: React.DragEvent, stage: LeadStage) => {
+  const handleDragOver = (e: React.DragEvent, slug: string) => {
     e.preventDefault();
     e.dataTransfer.dropEffect = 'move';
-    setDragOverColumn(stage);
+    setDragOverColumn(slug);
   };
 
   const handleDragLeave = () => {
     setDragOverColumn(null);
   };
 
-  const handleDrop = (e: React.DragEvent, targetStage: LeadStage) => {
+  const handleDrop = (e: React.DragEvent, targetSlug: string) => {
     e.preventDefault();
     setDragOverColumn(null);
     const leadId = e.dataTransfer.getData('text/plain');
     const lead = allLeads.find((l) => l.id === leadId);
-    if (!lead || lead.stage === targetStage) return;
+    if (!lead || lead.stage === targetSlug) return;
 
-    moveLead.mutate({ id: leadId, stage: targetStage });
+    moveLead.mutate({ id: leadId, stage: targetSlug });
   };
 
   return (
@@ -117,35 +131,33 @@ export function LeadKanbanBoard({
       </div>
 
       <div className="-mx-4 px-4 md:mx-0 md:px-0 flex gap-3 min-h-[500px] overflow-x-auto pb-2 snap-x snap-mandatory md:snap-none md:pb-0">
-        {LEAD_STAGE_ORDER.filter((s) => !stageFilter || s === stageFilter).map((stage) => (
+        {visibleColumns.map((col) => (
           <div
-            key={stage}
-            onDragOver={(e) => handleDragOver(e, stage)}
+            key={col.id}
+            onDragOver={(e) => handleDragOver(e, col.slug)}
             onDragLeave={handleDragLeave}
-            onDrop={(e) => handleDrop(e, stage)}
+            onDrop={(e) => handleDrop(e, col.slug)}
             className={`flex-none w-[85vw] sm:w-[320px] md:flex-1 md:min-w-[200px] snap-center ${
-              dragOverColumn === stage ? 'ring-2 ring-primary-300 ring-inset rounded-xl' : ''
+              dragOverColumn === col.slug ? 'ring-2 ring-primary-300 ring-inset rounded-xl' : ''
             }`}
           >
             <div
-              className={`rounded-xl border border-border bg-gray-50/50 min-h-full flex flex-col border-t-3 ${COLUMN_BORDER_COLORS[stage]}`}
+              className={`rounded-xl border border-border bg-gray-50/50 min-h-full flex flex-col border-t-3 ${chipToBorder(col.color)}`}
             >
-              {/* Column header */}
               <div className="flex items-center justify-between px-3 py-2.5">
                 <span
-                  className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${LEAD_STAGE_COLORS[stage]}`}
+                  className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${col.color}`}
                 >
-                  {LEAD_STAGE_LABELS[stage]}
+                  {col.name}
                 </span>
                 <span className="text-xs text-text-secondary tabular-nums">
-                  {leadsByStage[stage]?.length ?? 0}
+                  {leadsByStage[col.slug]?.length ?? 0}
                 </span>
               </div>
 
-              {/* Cards */}
               <div className="flex-1 px-2 pb-2 space-y-2">
-                {(leadsByStage[stage] ?? []).length > 0 ? (
-                  (leadsByStage[stage] ?? []).map((lead) => (
+                {(leadsByStage[col.slug] ?? []).length > 0 ? (
+                  (leadsByStage[col.slug] ?? []).map((lead) => (
                     <div
                       key={lead.id}
                       draggable
@@ -164,7 +176,6 @@ export function LeadKanbanBoard({
                 )}
               </div>
 
-              {/* Add lead button */}
               <button
                 onClick={() => setShowIntake(true)}
                 className="flex items-center justify-center gap-1 px-3 py-2 text-xs text-text-secondary hover:text-text hover:bg-gray-100/80 transition-colors rounded-b-xl"
@@ -177,7 +188,11 @@ export function LeadKanbanBoard({
         ))}
       </div>
 
-      <LeadIntakeDialog open={showIntake} onClose={() => setShowIntake(false)} defaultInitiatiefId={initiatiefId} />
+      <LeadIntakeDialog
+        open={showIntake}
+        onClose={() => setShowIntake(false)}
+        defaultInitiatiefId={initiatiefId}
+      />
     </div>
   );
 }

--- a/frontend/src/components/leads/LeadListView.tsx
+++ b/frontend/src/components/leads/LeadListView.tsx
@@ -7,15 +7,10 @@ import { Button } from '@/components/common/Button';
 import { ConfirmDialog } from '@/components/common/ConfirmDialog';
 import { CreatableSelect, type SelectOption } from '@/components/common/CreatableSelect';
 import { useLeads, useMergeLeads, useDeleteLead } from '@/hooks/useLeads';
+import { useLeadColumns } from '@/hooks/useLeadColumns';
 import { useLeadDetail } from '@/contexts/LeadDetailContext';
 import { LeadMetricsBar } from './LeadMetricsBar';
-import {
-  LeadStage,
-  LEAD_STAGE_ORDER,
-  LEAD_STAGE_LABELS,
-  LEAD_STAGE_COLORS,
-} from '@/types';
-import type { Lead, LeadFilters } from '@/types';
+import type { Lead, LeadColumn, LeadFilters } from '@/types';
 import { isOverdue, formatDateShort, timeAgo } from '@/utils/dates';
 
 const SORT_OPTIONS: SelectOption[] = [
@@ -58,6 +53,12 @@ export function LeadListView({
   const { data: leads, isLoading } = useLeads(
     Object.keys(filters).length > 0 ? filters : undefined,
   );
+  const { columns } = useLeadColumns(initiatiefId);
+  const columnsBySlug = useMemo(() => {
+    const map = new Map<string, LeadColumn>();
+    for (const c of columns) map.set(c.slug, c);
+    return map;
+  }, [columns]);
   const { openLeadDetail } = useLeadDetail();
   const mergeMutation = useMergeLeads();
   const deleteLead = useDeleteLead();
@@ -75,9 +76,11 @@ export function LeadListView({
 
   const stageIndex = useMemo(() => {
     const map = new Map<string, number>();
-    LEAD_STAGE_ORDER.forEach((s, i) => map.set(s, i));
+    [...columns]
+      .sort((a, b) => a.sort_order - b.sort_order)
+      .forEach((c, i) => map.set(c.slug, i));
     return map;
-  }, []);
+  }, [columns]);
 
   const filteredLeads = useMemo(() => {
     if (!leads) return [];
@@ -224,11 +227,18 @@ export function LeadListView({
                         )}
                       </td>
                       <td className="px-4 py-3">
-                        <span
-                          className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium whitespace-nowrap ${LEAD_STAGE_COLORS[lead.stage]}`}
-                        >
-                          {LEAD_STAGE_LABELS[lead.stage]}
-                        </span>
+                        {(() => {
+                          const col = columnsBySlug.get(lead.stage);
+                          return (
+                            <span
+                              className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium whitespace-nowrap ${
+                                col?.color ?? 'bg-gray-100 text-gray-800'
+                              }`}
+                            >
+                              {col?.name ?? lead.stage}
+                            </span>
+                          );
+                        })()}
                       </td>
                       <td className="px-4 py-3 text-text-secondary truncate max-w-[150px]">
                         {lead.assignee?.naam ?? '-'}
@@ -308,7 +318,7 @@ export function LeadListView({
                   <div className="font-medium">{lead.title}</div>
                   <div className="text-sm text-text-secondary">
                     {lead.organization ?? 'geen organisatie'} -{' '}
-                    {LEAD_STAGE_LABELS[lead.stage as LeadStage]}
+                    {columnsBySlug.get(lead.stage)?.name ?? lead.stage}
                   </div>
                   <div className="text-xs text-primary-600 mt-1">
                     ← Deze behouden

--- a/frontend/src/hooks/queryKeys.ts
+++ b/frontend/src/hooks/queryKeys.ts
@@ -210,6 +210,13 @@ export const queryKeys = {
     metrics: () => ['leads', 'metrics'] as const,
   },
 
+  // --- Lead-kolommen (per-initiatief funnel-stages) ---
+  leadColumns: {
+    all: ['lead-columns'] as const,
+    list: (initiatiefId: string | undefined) =>
+      ['lead-columns', 'list', initiatiefId ?? null] as const,
+  },
+
   // --- Financieel ---
   financieel: {
     all: ['financieel'] as const,

--- a/frontend/src/hooks/useLeadColumns.ts
+++ b/frontend/src/hooks/useLeadColumns.ts
@@ -1,0 +1,77 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  createLeadColumn,
+  deleteLeadColumn,
+  listLeadColumns,
+  reorderLeadColumns,
+  updateLeadColumn,
+  type LeadColumnCreate,
+  type LeadColumnUpdate,
+} from '@/api/leadColumns';
+import { useMutationWithError } from '@/hooks/useMutationWithError';
+import { queryKeys } from '@/hooks/queryKeys';
+import { DEFAULT_LEAD_COLUMNS, type LeadColumn } from '@/types';
+
+/**
+ * Geef de funnel-kolommen van een initiatief terug.
+ *
+ * Zonder `initiatiefId` valt de hook terug op de 7 default-kolommen, zodat
+ * orphan-leads (geen initiatief) en de loading-flow van bv. de intake-dialog
+ * meteen iets renderbaars hebben in plaats van een lege lijst.
+ */
+export function useLeadColumns(initiatiefId: string | undefined) {
+  const query = useQuery({
+    queryKey: queryKeys.leadColumns.list(initiatiefId),
+    queryFn: () => listLeadColumns(initiatiefId as string),
+    enabled: !!initiatiefId,
+  });
+
+  const columns: LeadColumn[] =
+    initiatiefId && query.data ? query.data : DEFAULT_LEAD_COLUMNS;
+
+  return {
+    columns,
+    isLoading: !!initiatiefId && query.isLoading,
+    isError: query.isError,
+    refetch: query.refetch,
+  };
+}
+
+export function useCreateLeadColumn(initiatiefId: string) {
+  return useMutationWithError({
+    mutationFn: (data: LeadColumnCreate) => createLeadColumn(initiatiefId, data),
+    errorMessage: 'Fout bij aanmaken kolom',
+    invalidateKeys: [queryKeys.leadColumns.list(initiatiefId)],
+  });
+}
+
+export function useUpdateLeadColumn(initiatiefId: string) {
+  return useMutationWithError({
+    mutationFn: ({ id, data }: { id: string; data: LeadColumnUpdate }) =>
+      updateLeadColumn(initiatiefId, id, data),
+    errorMessage: 'Fout bij bijwerken kolom',
+    invalidateKeys: [queryKeys.leadColumns.list(initiatiefId)],
+  });
+}
+
+export function useDeleteLeadColumn(initiatiefId: string) {
+  return useMutationWithError({
+    mutationFn: ({ id, moveTo }: { id: string; moveTo?: string }) =>
+      deleteLeadColumn(initiatiefId, id, moveTo),
+    errorMessage: 'Fout bij verwijderen kolom',
+    invalidateKeys: [
+      queryKeys.leadColumns.list(initiatiefId),
+      queryKeys.leads.lists(),
+      queryKeys.leads.metrics(),
+    ],
+  });
+}
+
+export function useReorderLeadColumns(initiatiefId: string) {
+  return useMutationWithError({
+    mutationFn: (columnIds: string[]) =>
+      reorderLeadColumns(initiatiefId, columnIds),
+    errorMessage: 'Fout bij herordenen kolommen',
+    invalidateKeys: [queryKeys.leadColumns.list(initiatiefId)],
+  });
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1630,7 +1630,11 @@ export interface LeadColumn {
   updated_at: string | null;
 }
 
-export const LEAD_STAGE_LABELS: Record<LeadStage, string> = {
+// Record<string, ...> ipv Record<LeadStage, ...> zodat call-sites die met
+// een willekeurige slug-string indexeren (per-initiatief custom kolommen)
+// geen TS-fout krijgen. Onbekende slugs returnen `undefined` — gebruik
+// `?? slug` als fallback om de raw slug te tonen.
+export const LEAD_STAGE_LABELS: Record<string, string> = {
   [LeadStage.INBOX]: 'Inbox',
   [LeadStage.VERKENNEN]: 'Verkennen',
   [LeadStage.EERSTE_GESPREK]: 'Eerste gesprek',
@@ -1640,7 +1644,7 @@ export const LEAD_STAGE_LABELS: Record<LeadStage, string> = {
   [LeadStage.KOELKAST]: 'Koelkast',
 };
 
-export const LEAD_STAGE_COLORS: Record<LeadStage, string> = {
+export const LEAD_STAGE_COLORS: Record<string, string> = {
   [LeadStage.INBOX]: 'bg-indigo-100 text-indigo-800',
   [LeadStage.VERKENNEN]: 'bg-blue-100 text-blue-800',
   [LeadStage.EERSTE_GESPREK]: 'bg-yellow-100 text-yellow-800',
@@ -1774,7 +1778,7 @@ export interface Lead {
   organization: string | null;
   externe_organisatie_id: string | null;
   externe_organisatie: LeadExterneOrgSummary | null;
-  stage: LeadStage;
+  stage: string;
   assignee_id: string | null;
   assignee: LeadAssigneeSummary | null;
   brought_by_id: string | null;
@@ -1834,7 +1838,7 @@ export interface LeadCreate {
   description?: string | null;
   organization?: string | null;
   externe_organisatie_id?: string | null;
-  stage?: LeadStage;
+  stage?: string;
   assignee_id?: string | null;
   brought_by_id?: string | null;
   next_action?: string | null;
@@ -1856,7 +1860,7 @@ export interface LeadUpdate {
   description?: string | null;
   organization?: string | null;
   externe_organisatie_id?: string | null;
-  stage?: LeadStage;
+  stage?: string;
   assignee_id?: string | null;
   brought_by_id?: string | null;
   next_action?: string | null;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1601,7 +1601,11 @@ export interface FinancieelOverzicht {
   per_jaar: FinancieelJaar[];
 }
 
-// Lead Stage enum and labels
+// Lead Stage enum and labels.
+// De stage-waarde van een lead is sinds de per-initiatief-kolommen-feature
+// geen vaste enum meer; eigenaren kunnen kolommen toevoegen/verwijderen via
+// `LeadColumn`. Deze enum + de DEFAULT_LEAD_COLUMNS hieronder dienen als
+// fallback voor orphan-leads (geen initiatief) en als loading-placeholder.
 export enum LeadStage {
   INBOX = 'inbox',
   VERKENNEN = 'verkennen',
@@ -1610,6 +1614,20 @@ export enum LeadStage {
   FOLLOW_UP = 'follow_up',
   IN_THE_POCKET = 'in_the_pocket',
   KOELKAST = 'koelkast',
+}
+
+export interface LeadColumn {
+  id: string;
+  initiatief_id: string;
+  name: string;
+  slug: string;
+  sort_order: number;
+  color: string;
+  is_active_stage: boolean;
+  is_public_visible: boolean;
+  lead_count: number;
+  created_at: string;
+  updated_at: string | null;
 }
 
 export const LEAD_STAGE_LABELS: Record<LeadStage, string> = {
@@ -1641,6 +1659,33 @@ export const LEAD_STAGE_ORDER: LeadStage[] = [
   LeadStage.IN_THE_POCKET,
   LeadStage.KOELKAST,
 ];
+
+// Fallback-kolommen voor leads zonder initiatief en voor de loading-flow van
+// `useLeadColumns`. Spiegelt de defaults uit `backend/schema/lead_column.py`.
+export const DEFAULT_LEAD_COLUMNS: LeadColumn[] = LEAD_STAGE_ORDER.map(
+  (slug, idx) => ({
+    id: `default-${slug}`,
+    initiatief_id: '',
+    name: LEAD_STAGE_LABELS[slug],
+    slug,
+    sort_order: idx,
+    color: LEAD_STAGE_COLORS[slug],
+    is_active_stage: ![
+      LeadStage.INBOX,
+      LeadStage.IN_THE_POCKET,
+      LeadStage.KOELKAST,
+    ].includes(slug),
+    is_public_visible: [
+      LeadStage.EERSTE_GESPREK,
+      LeadStage.INTERNE_CHECK,
+      LeadStage.FOLLOW_UP,
+      LeadStage.IN_THE_POCKET,
+    ].includes(slug),
+    lead_count: 0,
+    created_at: new Date(0).toISOString(),
+    updated_at: null,
+  }),
+);
 
 export enum LeadActivityType {
   NOTE = 'note',


### PR DESCRIPTION
## Samenvatting

- Eigenaar van een initiatief beheert eigen funnel-kolommen: toevoegen, hernoemen, herordenen, kleur kiezen, verwijderen
- Bij verwijderen van een niet-lege kolom wijst de eigenaar een doel-kolom aan waar de leads heen gaan
- Twee globale stage-aannames vervallen: per-initiatief flags `is_active_stage` (overdue/stale-filter) en `is_public_visible` (community-pagina) vervangen de hardcoded slug-lijsten in `repositories/lead.py` en `routes/public_initiatief.py`

## Datamodel

Nieuwe `lead_column`-tabel met FK naar `initiatief`, immutable slug, sort_order, color, en de twee semantische booleans. `Lead.stage` blijft een TEXT-slug (geen FK) zodat orphan-leads (zonder initiatief) en historische `LeadActivity.metadata_`-rijen blijven werken. Validatie zit in de repository en geeft 422 als de slug niet matcht met een kolom van het initiatief.

Composite index op `lead(initiatief_id, stage)` voor de nieuwe per-initiatief stage-filters.

## Migratie

Seedt voor elk bestaand initiatief de 7 default-kolommen (`inbox`, `verkennen`, `eerste_gesprek`, `interne_check`, `follow_up`, `in_the_pocket`, `koelkast`) idempotent via `ON CONFLICT`. `InitiatiefRepository.create` roept dezelfde seed aan zodat nieuwe initiatieven meteen een board hebben.

## API

Onder `/api/initiatieven/{id}/columns`:

| Method | Pad | Auth |
|---|---|---|
| GET | `/` | lid |
| POST | `/` | eigenaar |
| PUT | `/{column_id}` | eigenaar |
| DELETE | `/{column_id}?move_to=...` | eigenaar |
| POST | `/reorder` | eigenaar |

## Frontend

- `useLeadColumns(initiatiefId)` hook met `DEFAULT_LEAD_COLUMNS`-fallback voor orphan-flow / loading
- `ColumnsManager`-component in `InitiatiefDetailModal` (eigenaar-only) met up/down-reorder, inline rename, color picker, twee flag-toggles, delete-met-target-picker
- `LeadKanbanBoard`, `LeadListView`, `LeadIntakeDialog` lezen kolommen via de hook in plaats van de globale enum

## Test plan

- [x] `pytest backend/tests/test_lead_columns.py` (13 nieuwe tests, allemaal groen)
- [x] `pytest backend/tests/test_public_initiatief.py` (helper aangepast om kolommen te seeden)
- [x] `pytest backend/tests/test_route_authorization_inventory.py` (nieuwe GET-route heeft authz-dep)
- [x] `pytest backend/tests/test_fk_index_inventory.py` (FK krijgt index)
- [x] `tsc --noEmit` schoon
- [x] `vite build` schoon
- [x] `eslint` schoon
- [ ] Browser: open initiatief → "Funnel-kolommen" → kolom toevoegen → drag lead op het bord → verifieer slug
- [ ] Toggle `is_active_stage` uit voor "verkennen" → leads verdwijnen uit de overdue-filter en `stale_count` in `/leads/metrics`
- [ ] Toggle `is_public_visible` aan/uit en check `/api/public/initiatieven/{slug}`
- [ ] Delete-flow: kolom met leads zonder `move_to` → 400; met `move_to` → 204 + leads verplaatst