### PR TITLE
Netwerkview: interne organisaties onderaan in eigen swim-lane

### DIFF
--- a/backend/bouwmeester/repositories/graph.py
+++ b/backend/bouwmeester/repositories/graph.py
@@ -232,6 +232,10 @@ class GraphRepository:
         """
         graph_nodes: dict[str, CommunityGraphNode] = {}
         graph_edges: list[CommunityGraphEdge] = []
+        # Org keys (graph_nodes IDs) where at least one internal person is
+        # actively placed. Used at the end to flag org_role="intern" so the
+        # frontend can put these in a separate swim-lane.
+        internal_org_keys: set[str] = set()
         edge_counter = 0
 
         def _next_edge_id() -> str:
@@ -510,11 +514,14 @@ class GraphRepository:
                     )
 
                 for pl in plaatsing_rows:
+                    oe_key = f"oe-{pl.organisatie_eenheid_id}"
+                    if pl.person_id in internal_person_ids:
+                        internal_org_keys.add(oe_key)
                     graph_edges.append(
                         CommunityGraphEdge(
                             id=_next_edge_id(),
                             source=f"person-{pl.person_id}",
-                            target=f"oe-{pl.organisatie_eenheid_id}",
+                            target=oe_key,
                             edge_type="lid_van",
                             label="lid van",
                         )
@@ -559,6 +566,10 @@ class GraphRepository:
                             label=lid.rol or "lid",
                         )
                     )
+
+        for node in graph_nodes.values():
+            if node.node_type == "organisation":
+                node.org_role = "intern" if node.id in internal_org_keys else "extern"
 
         return CommunityGraphResponse(
             nodes=list(graph_nodes.values()),

--- a/backend/bouwmeester/schema/community_graph.py
+++ b/backend/bouwmeester/schema/community_graph.py
@@ -20,6 +20,7 @@ class CommunityGraphNode(BaseModel):
     expertise: str | None = None  # for persons
     person_role: str | None = None  # "intern" | "extern" — for persons
     org_type: str | None = None  # for organisations
+    org_role: str | None = None  # "intern" | "extern" — for organisations
     samenwerkingsverband_type: str | None = None  # for samenwerkingsverbanden
     corpus_node_type: str | None = None  # for corpus nodes
 

--- a/backend/tests/test_graph.py
+++ b/backend/tests/test_graph.py
@@ -310,6 +310,121 @@ async def test_community_graph_intern_wins_over_extern(
     assert person_node["person_role"] == "intern"
 
 
+async def test_community_graph_org_with_internal_person_is_intern(
+    client, db_session, sample_person, sample_organisatie
+):
+    """Een OrganisatieEenheid waar een interne persoon (lead-assignee) actief
+    in geplaatst is, krijgt org_role='intern' — zodat de frontend deze in de
+    onderste swim-lane kan zetten."""
+    from bouwmeester.models.person_organisatie import PersonOrganisatieEenheid
+
+    lead = Lead(
+        id=uuid.uuid4(),
+        title="Lead met interne assignee",
+        stage="verkennen",
+        assignee_id=sample_person.id,
+    )
+    db_session.add(lead)
+    db_session.add(
+        PersonOrganisatieEenheid(
+            id=uuid.uuid4(),
+            person_id=sample_person.id,
+            organisatie_eenheid_id=sample_organisatie.id,
+            start_datum=date.today(),
+        )
+    )
+    await db_session.flush()
+
+    resp = await client.get("/api/graph/community")
+    assert resp.status_code == 200
+    org_node = next(
+        (n for n in resp.json()["nodes"] if n["id"] == f"oe-{sample_organisatie.id}"),
+        None,
+    )
+    assert org_node is not None
+    assert org_node["org_role"] == "intern"
+
+
+async def test_community_graph_externe_organisatie_is_extern(
+    client, db_session, sample_person
+):
+    """Een ExterneOrganisatie die via een lead in de graph terechtkomt krijgt
+    org_role='extern'."""
+    from bouwmeester.models.externe_organisatie import ExterneOrganisatie
+
+    ext_org = ExterneOrganisatie(
+        id=uuid.uuid4(),
+        naam="Externe Adviesbureau BV",
+        type="marktpartij",
+    )
+    db_session.add(ext_org)
+    await db_session.flush()
+
+    lead = Lead(
+        id=uuid.uuid4(),
+        title="Lead met externe organisatie",
+        stage="verkennen",
+        assignee_id=sample_person.id,
+        externe_organisatie_id=ext_org.id,
+    )
+    db_session.add(lead)
+    await db_session.flush()
+
+    resp = await client.get("/api/graph/community")
+    assert resp.status_code == 200
+    ext_node = next(
+        (n for n in resp.json()["nodes"] if n["id"] == f"org-{ext_org.id}"),
+        None,
+    )
+    assert ext_node is not None
+    assert ext_node["org_role"] == "extern"
+
+
+async def test_community_graph_org_with_only_external_person_is_extern(
+    client, db_session, sample_person, sample_organisatie
+):
+    """Een OrganisatieEenheid waar alleen een externe contact in geplaatst is,
+    krijgt org_role='extern'. Dit voorkomt dat een gemeente die toevallig als
+    OrganisatieEenheid bestaat onderaan terechtkomt zodra een externe contact
+    daar gekoppeld is."""
+    from bouwmeester.models.person_organisatie import PersonOrganisatieEenheid
+
+    lead = Lead(
+        id=uuid.uuid4(),
+        title="Lead met externe contact in OE",
+        stage="verkennen",
+    )
+    db_session.add(lead)
+    await db_session.flush()
+    db_session.add(
+        ResourcePermission(
+            id=uuid.uuid4(),
+            resource_type="lead",
+            resource_id=lead.id,
+            person_id=sample_person.id,
+            rol="contactpersoon",
+        )
+    )
+    db_session.add(
+        PersonOrganisatieEenheid(
+            id=uuid.uuid4(),
+            person_id=sample_person.id,
+            organisatie_eenheid_id=sample_organisatie.id,
+            start_datum=date.today(),
+        )
+    )
+    await db_session.flush()
+
+    resp = await client.get("/api/graph/community")
+    assert resp.status_code == 200
+    org_node = next(
+        (n for n in resp.json()["nodes"] if n["id"] == f"oe-{sample_organisatie.id}"),
+        None,
+    )
+    assert org_node is not None
+    assert org_node["org_role"] == "extern"
+
+
 async def test_community_graph_contact_edge_label_is_externe_contactpersoon(
     client, db_session, sample_person
 ):

--- a/backend/tests/test_graph.py
+++ b/backend/tests/test_graph.py
@@ -417,9 +417,15 @@ async def test_community_graph_org_with_only_external_person_is_extern(
 
     resp = await client.get("/api/graph/community")
     assert resp.status_code == 200
+    nodes = resp.json()["nodes"]
+    person_node = next(
+        (n for n in nodes if n["id"] == f"person-{sample_person.id}"), None
+    )
+    assert person_node is not None
+    # Bewijs de keten: persoon is extern → org waar die persoon in zit blijft extern.
+    assert person_node["person_role"] == "extern"
     org_node = next(
-        (n for n in resp.json()["nodes"] if n["id"] == f"oe-{sample_organisatie.id}"),
-        None,
+        (n for n in nodes if n["id"] == f"oe-{sample_organisatie.id}"), None
     )
     assert org_node is not None
     assert org_node["org_role"] == "extern"

--- a/frontend/src/components/leads/LeadGraphView.tsx
+++ b/frontend/src/components/leads/LeadGraphView.tsx
@@ -66,28 +66,34 @@ const CORPUS_NODE_FALLBACK = '#6B7280';
 // ---- Community node type to rank (swim-lane y) ----
 // Strikte horizontale swim-lanes per node-type, top-down. Y wordt opgelegd
 // via LANE_Y; dagre regelt alleen nog x-positie en cross-minimization.
-const RANK_ORGANISATION = 0;
+// Externe orgs bovenaan, interne thuis-organisaties helemaal onderaan
+// (onder de interne mensen die er werken).
+const RANK_ORG_EXTERN = 0;
 const RANK_CORPUS_NODE = 1;
 const RANK_LEAD = 2;
 const RANK_SAMENWERKINGSVERBAND = 3;
 const RANK_PERSON_EXTERN = 4;
 const RANK_PERSON_INTERN = 5;
+const RANK_ORG_INTERN = 6;
 const RANK_DEFAULT = RANK_LEAD;
 
 const LANE_Y: Record<number, number> = {
-  [RANK_ORGANISATION]: 40,
+  [RANK_ORG_EXTERN]: 40,
   [RANK_CORPUS_NODE]: 240,
   [RANK_LEAD]: 440,
   [RANK_SAMENWERKINGSVERBAND]: 640,
   [RANK_PERSON_EXTERN]: 840,
   [RANK_PERSON_INTERN]: 1040,
+  [RANK_ORG_INTERN]: 1240,
 };
 
 function getNodeRank(node: CommunityGraphNode): number {
   if (node.node_type === 'person') {
     return node.person_role === 'extern' ? RANK_PERSON_EXTERN : RANK_PERSON_INTERN;
   }
-  if (node.node_type === 'organisation') return RANK_ORGANISATION;
+  if (node.node_type === 'organisation') {
+    return node.org_role === 'intern' ? RANK_ORG_INTERN : RANK_ORG_EXTERN;
+  }
   if (node.node_type === 'samenwerkingsverband') return RANK_SAMENWERKINGSVERBAND;
   if (node.node_type === 'corpus_node') return RANK_CORPUS_NODE;
   if (node.node_type === 'lead') return RANK_LEAD;
@@ -148,6 +154,7 @@ interface CommunityGraphNodeData {
   expertise?: string | null;
   personRole?: 'intern' | 'extern' | null;
   orgType?: string | null;
+  orgRole?: 'intern' | 'extern' | null;
   swvType?: string | null;
   corpusNodeType?: string | null;
   dimmed?: boolean;
@@ -172,6 +179,10 @@ function getNodeColor(data: CommunityGraphNodeData): string {
 
 function CommunityGraphNodeComponent({ data }: NodeProps<CommunityGraphNodeData>) {
   const color = getNodeColor(data);
+  const borderColor =
+    data.nodeType === 'organisation' && data.orgRole === 'intern'
+      ? PERSON_INTERN_COLOR
+      : color;
 
   const badgeContent = (() => {
     if (data.nodeType === 'lead' && data.stage) {
@@ -212,11 +223,14 @@ function CommunityGraphNodeComponent({ data }: NodeProps<CommunityGraphNodeData>
       );
     }
     if (data.nodeType === 'organisation') {
+      const isIntern = data.orgRole === 'intern';
+      const badgeColor = isIntern ? PERSON_INTERN_COLOR : color;
       return (
         <div className="flex items-center gap-1 mb-1">
-          <Building2 className="h-3 w-3" style={{ color }} />
-          <span style={{ color, fontSize: '10px', fontWeight: 600, letterSpacing: '0.025em', textTransform: 'uppercase' }}>
-            {data.orgType ?? 'Organisatie'}
+          <Building2 className="h-3 w-3" style={{ color: badgeColor }} />
+          <span style={{ color: badgeColor, fontSize: '10px', fontWeight: 600, letterSpacing: '0.025em', textTransform: 'uppercase' }}>
+            {isIntern ? 'Intern' : data.orgType ?? 'Organisatie'}
+            {isIntern && data.orgType ? ` · ${data.orgType}` : ''}
           </span>
         </div>
       );
@@ -254,7 +268,7 @@ function CommunityGraphNodeComponent({ data }: NodeProps<CommunityGraphNodeData>
         background: '#ffffff',
         borderRadius: '10px',
         boxShadow: '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1)',
-        border: `1px solid ${color}33`,
+        border: `1px solid ${borderColor}55`,
         minWidth: '160px',
         maxWidth: '220px',
         cursor: data.onClick ? 'pointer' : 'default',
@@ -490,6 +504,7 @@ function CommunityGraphInner({
           expertise: node.expertise,
           personRole: node.person_role ?? null,
           orgType: node.org_type,
+          orgRole: node.org_role ?? null,
           swvType: node.samenwerkingsverband_type ?? null,
           corpusNodeType: node.corpus_node_type,
           onClick,

--- a/frontend/src/components/leads/LeadGraphView.tsx
+++ b/frontend/src/components/leads/LeadGraphView.tsx
@@ -225,12 +225,28 @@ function CommunityGraphNodeComponent({ data }: NodeProps<CommunityGraphNodeData>
     if (data.nodeType === 'organisation') {
       const isIntern = data.orgRole === 'intern';
       const badgeColor = isIntern ? PERSON_INTERN_COLOR : color;
+      const orgTypeLabel = data.orgType ?? 'Organisatie';
+      const label = isIntern
+        ? data.orgType
+          ? `Intern · ${data.orgType}`
+          : 'Intern'
+        : orgTypeLabel;
       return (
-        <div className="flex items-center gap-1 mb-1">
-          <Building2 className="h-3 w-3" style={{ color: badgeColor }} />
-          <span style={{ color: badgeColor, fontSize: '10px', fontWeight: 600, letterSpacing: '0.025em', textTransform: 'uppercase' }}>
-            {isIntern ? 'Intern' : data.orgType ?? 'Organisatie'}
-            {isIntern && data.orgType ? ` · ${data.orgType}` : ''}
+        <div className="flex items-center gap-1 mb-1 min-w-0">
+          <Building2 className="h-3 w-3 shrink-0" style={{ color: badgeColor }} />
+          <span
+            style={{
+              color: badgeColor,
+              fontSize: '10px',
+              fontWeight: 600,
+              letterSpacing: '0.025em',
+              textTransform: 'uppercase',
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            {label}
           </span>
         </div>
       );

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -2151,6 +2151,7 @@ export interface CommunityGraphNode {
   expertise?: string | null;
   person_role?: 'intern' | 'extern' | null;
   org_type?: string | null;
+  org_role?: 'intern' | 'extern' | null;
   samenwerkingsverband_type?: string | null;
   corpus_node_type?: string | null;
 }


### PR DESCRIPTION
## Summary

In de leads-netwerkview stonden alle organisaties op één lijn helemaal bovenaan, ongeacht of het externe gesprekspartners waren of de eigen organisatiestructuur (RegelRecht, kernteam, Moza, …). Visueel suggereerde dat dat 'team RegelRecht' gelijkwaardig was aan elke andere org, terwijl het juist de basis is waaraan elk kernteamlid hangt.

- Backend: nieuw afgeleid `org_role`-veld op `CommunityGraphNode`. Een organisatie is `intern` als minstens één interne persoon (lead-assignee of corpus-stakeholder) er actief in geplaatst is, anders `extern`. Externe orgs (`org-*`, `orgtext-*`) worden per definitie `extern`.
- Frontend: nieuwe swim-lane `RANK_ORG_INTERN` (y=1240) onder de interne-personen-lane. Externe orgs blijven bovenaan op y=40.
- Visueel: interne org-nodes krijgen een pink accent (badge-icon + label + border, in dezelfde tint als de interne-personen één lane erboven) — teal blijft de organisatie-identiteit via de top-bar en handles.

Ravi (intern, geplaatst bij Moza én RegelRecht) zakt nu via twee `lid_van`-edges naar onder; een kernteamlid zakt alleen via RegelRecht en kernteam. Die distinctie blijft leesbaar via de bestaande edges, geen extra modellering nodig.

## Test plan

- [x] `uv run --project backend pytest backend/tests/test_graph.py -v` (19/19 groen, incl. 3 nieuwe tests voor `org_role`)
- [x] `tsc --noEmit` clean
- [ ] Handmatig: open `/leads`, tab "Netwerk":
  - RegelRecht en kernteam staan onderaan, onder de interne-mensen-lane
  - Externe orgs (ministeries die alleen via lead/contact verbonden zijn) blijven bovenaan
  - Ravi heeft `lid_van`-edges naar zowel Moza als RegelRecht; Moza komt ook onderaan terecht (er hangt een interne aan vast)