### PR TITLE
Samenwerkingsverband-leden: inline persoon aanmaken + leden bewerken

### DIFF
--- a/backend/bouwmeester/schema/samenwerkingsverband.py
+++ b/backend/bouwmeester/schema/samenwerkingsverband.py
@@ -44,6 +44,7 @@ class SamenwerkingsverbandLidCreate(BaseModel):
 
 class SamenwerkingsverbandLidUpdate(BaseModel):
     rol: str | None = Field(None, max_length=50)
+    start_datum: date | None = None
     eind_datum: date | None = None
 
 

--- a/frontend/src/pages/SamenwerkingsverbandDetailPage.tsx
+++ b/frontend/src/pages/SamenwerkingsverbandDetailPage.tsx
@@ -6,6 +6,7 @@ import {
   useUpdateSamenwerkingsverband,
   useDeleteSamenwerkingsverband,
   useAddLid,
+  useUpdateLid,
   useRemoveLid,
 } from '@/hooks/useSamenwerkingsverbanden';
 import { usePeople } from '@/hooks/usePeople';
@@ -17,10 +18,13 @@ import { ConfirmDialog } from '@/components/common/ConfirmDialog';
 import { RichTextDisplay } from '@/components/common/RichTextDisplay';
 import { RichTextFormField } from '@/components/common/RichTextFormField';
 import { CreatableSelect, type SelectOption } from '@/components/common/CreatableSelect';
+import { PersonQuickCreateForm } from '@/components/people/PersonQuickCreateForm';
 import {
   SAMENWERKINGSVERBAND_TYPE_LABELS,
   SAMENWERKINGSVERBAND_TYPE_BADGE_COLORS,
   SAMENWERKINGSVERBAND_TYPE_OPTIONS,
+  type SamenwerkingsverbandLid,
+  type SamenwerkingsverbandLidUpdate,
   type SamenwerkingsverbandUpdate,
 } from '@/types';
 
@@ -31,6 +35,7 @@ export function SamenwerkingsverbandDetailPage() {
   const updateMutation = useUpdateSamenwerkingsverband();
   const deleteMutation = useDeleteSamenwerkingsverband();
   const addLidMutation = useAddLid();
+  const updateLidMutation = useUpdateLid();
   const removeLidMutation = useRemoveLid();
   const { data: people = [] } = usePeople();
 
@@ -43,6 +48,18 @@ export function SamenwerkingsverbandDetailPage() {
   const [showAddLid, setShowAddLid] = useState(false);
   const [newLidPersonId, setNewLidPersonId] = useState('');
   const [newLidRol, setNewLidRol] = useState('');
+
+  // Inline persoon-aanmaken vanuit lid-toevoeg-flow
+  const [showPersonCreate, setShowPersonCreate] = useState(false);
+  const [personCreateName, setPersonCreateName] = useState('');
+
+  // Lid-bewerken-form (één lid tegelijk)
+  const [editingLidId, setEditingLidId] = useState<string | null>(null);
+  const [lidEditForm, setLidEditForm] = useState<{
+    rol: string;
+    start_datum: string;
+    eind_datum: string;
+  }>({ rol: '', start_datum: '', eind_datum: '' });
 
   if (isLoading) {
     return <div className="flex items-center justify-center py-12"><LoadingSpinner /></div>;
@@ -112,6 +129,48 @@ export function SamenwerkingsverbandDetailPage() {
       setConfirmRemoveLidId(null);
     } catch {
       setConfirmRemoveLidId(null);
+    }
+  };
+
+  const handleCreatePerson = async (text: string): Promise<string | null> => {
+    setPersonCreateName(text);
+    setShowPersonCreate(true);
+    return null;
+  };
+
+  const handlePersonCreated = (personId: string) => {
+    setNewLidPersonId(personId);
+  };
+
+  const startEditLid = (lid: SamenwerkingsverbandLid) => {
+    setEditingLidId(lid.id);
+    setLidEditForm({
+      rol: lid.rol ?? '',
+      start_datum: lid.start_datum ?? '',
+      eind_datum: lid.eind_datum ?? '',
+    });
+  };
+
+  const cancelEditLid = () => {
+    setEditingLidId(null);
+  };
+
+  const handleSaveLid = async () => {
+    if (!id || !editingLidId) return;
+    const data: SamenwerkingsverbandLidUpdate = {
+      rol: lidEditForm.rol.trim() || null,
+      eind_datum: lidEditForm.eind_datum || null,
+    };
+    // Lege start_datum niet meesturen: kolom is NOT NULL en er is geen
+    // semantische "lid sinds onbekend"-state. Veld blijft dan onveranderd.
+    if (lidEditForm.start_datum) {
+      data.start_datum = lidEditForm.start_datum;
+    }
+    try {
+      await updateLidMutation.mutateAsync({ swvId: id, lidId: editingLidId, data });
+      setEditingLidId(null);
+    } catch {
+      // toast
     }
   };
 
@@ -257,6 +316,8 @@ export function SamenwerkingsverbandDetailPage() {
                 onChange={setNewLidPersonId}
                 options={personOptions}
                 placeholder="Zoek persoon..."
+                onCreate={handleCreatePerson}
+                createLabel="Nieuwe persoon aanmaken"
               />
               <Input
                 label="Rol (optioneel)"
@@ -289,32 +350,93 @@ export function SamenwerkingsverbandDetailPage() {
           <p className="text-sm text-text-secondary italic">Nog geen leden.</p>
         ) : (
           <ul className="space-y-1">
-            {swv.leden.map((lid) => (
-              <li
-                key={lid.id}
-                className="group flex items-center gap-2 rounded-lg px-2 py-1.5 hover:bg-gray-50 transition-colors"
-              >
-                <div className="flex-1 flex items-center gap-2 text-sm">
-                  <span className="font-medium text-text">{lid.person_naam}</span>
-                  {lid.person_expertise && (
-                    <Badge variant="indigo">{lid.person_expertise}</Badge>
-                  )}
-                  {lid.rol && (
-                    <span className="text-xs text-text-secondary">— {lid.rol}</span>
-                  )}
-                </div>
-                <span className="text-xs text-text-secondary">
-                  sinds {new Date(lid.start_datum).toLocaleDateString('nl-NL')}
-                </span>
-                <button
-                  onClick={() => setConfirmRemoveLidId(lid.id)}
-                  className="opacity-0 group-hover:opacity-100 p-1 rounded text-text-secondary hover:text-red-600 hover:bg-red-50 transition-all"
-                  title="Verwijderen"
+            {swv.leden.map((lid) => {
+              const isEditing = editingLidId === lid.id;
+              if (isEditing) {
+                return (
+                  <li
+                    key={lid.id}
+                    className="rounded-lg border border-border bg-gray-50 p-3 space-y-3"
+                  >
+                    <div className="text-sm font-medium text-text">{lid.person_naam}</div>
+                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                      <Input
+                        label="Rol"
+                        value={lidEditForm.rol}
+                        onChange={(e) =>
+                          setLidEditForm((f) => ({ ...f, rol: e.target.value }))
+                        }
+                        placeholder="bv. trekker, voorzitter"
+                      />
+                      <Input
+                        label="Startdatum"
+                        type="date"
+                        value={lidEditForm.start_datum}
+                        onChange={(e) =>
+                          setLidEditForm((f) => ({ ...f, start_datum: e.target.value }))
+                        }
+                      />
+                      <Input
+                        label="Einddatum"
+                        type="date"
+                        value={lidEditForm.eind_datum}
+                        onChange={(e) =>
+                          setLidEditForm((f) => ({ ...f, eind_datum: e.target.value }))
+                        }
+                      />
+                    </div>
+                    <div className="flex items-center gap-2 justify-end">
+                      <Button variant="secondary" size="sm" onClick={cancelEditLid}>
+                        Annuleren
+                      </Button>
+                      <Button
+                        size="sm"
+                        onClick={handleSaveLid}
+                        loading={updateLidMutation.isPending}
+                      >
+                        Opslaan
+                      </Button>
+                    </div>
+                  </li>
+                );
+              }
+              return (
+                <li
+                  key={lid.id}
+                  className="group flex items-center gap-2 rounded-lg px-2 py-1.5 hover:bg-gray-50 transition-colors"
                 >
-                  <X className="h-3.5 w-3.5" />
-                </button>
-              </li>
-            ))}
+                  <div className="flex-1 flex items-center gap-2 text-sm">
+                    <span className="font-medium text-text">{lid.person_naam}</span>
+                    {lid.person_expertise && (
+                      <Badge variant="indigo">{lid.person_expertise}</Badge>
+                    )}
+                    {lid.rol && (
+                      <span className="text-xs text-text-secondary">— {lid.rol}</span>
+                    )}
+                  </div>
+                  <span className="text-xs text-text-secondary">
+                    sinds {new Date(lid.start_datum).toLocaleDateString('nl-NL')}
+                    {lid.eind_datum && (
+                      <> · tot {new Date(lid.eind_datum).toLocaleDateString('nl-NL')}</>
+                    )}
+                  </span>
+                  <button
+                    onClick={() => startEditLid(lid)}
+                    className="opacity-0 group-hover:opacity-100 p-1 rounded text-text-secondary hover:text-text hover:bg-gray-100 transition-all"
+                    title="Bewerken"
+                  >
+                    <Pencil className="h-3.5 w-3.5" />
+                  </button>
+                  <button
+                    onClick={() => setConfirmRemoveLidId(lid.id)}
+                    className="opacity-0 group-hover:opacity-100 p-1 rounded text-text-secondary hover:text-red-600 hover:bg-red-50 transition-all"
+                    title="Verwijderen"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                </li>
+              );
+            })}
           </ul>
         )}
       </div>
@@ -345,6 +467,13 @@ export function SamenwerkingsverbandDetailPage() {
       >
         <p>Weet je zeker dat je dit lid wilt verwijderen?</p>
       </ConfirmDialog>
+
+      <PersonQuickCreateForm
+        open={showPersonCreate}
+        onClose={() => setShowPersonCreate(false)}
+        initialName={personCreateName}
+        onCreated={handlePersonCreated}
+      />
     </div>
   );
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -2273,6 +2273,7 @@ export interface SamenwerkingsverbandLidCreate {
 
 export interface SamenwerkingsverbandLidUpdate {
   rol?: string | null;
+  start_datum?: string | null;
   eind_datum?: string | null;
 }
 


### PR DESCRIPTION
## Summary

Twee gaten in `SamenwerkingsverbandDetailPage` opgelost:

- **Inline persoon aanmaken** in de "+ Toevoegen"-flow. De Persoon-`CreatableSelect` krijgt nu een `onCreate`-handler die de bestaande `PersonQuickCreateForm` opent (naam + e-mail + duplicate-check), net zoals bij Taken. Na aanmaken staat de nieuwe persoon direct geselecteerd.
- **Leden bewerken** in plaats van alleen verwijderen. Hover op een lid-rij toont een potlood-icoon; klikken opent inline drie velden (rol, startdatum, einddatum) met Opslaan/Annuleren. Eind_datum wordt nu ook in de leesweergave getoond (`sinds X · tot Y`).

Backend: één veld toegevoegd aan `SamenwerkingsverbandLidUpdate` (`start_datum: date | None`). De update-route gebruikt al `model_dump(exclude_unset=True)`, dus geen route-aanpassing en geen migratie (kolom bestaat al `NOT NULL`).

UI-policy: lege `start_datum` in het edit-formulier wordt niet meegestuurd (kolom is NOT NULL, geen "lid sinds onbekend"-state). `rol` en `eind_datum` mogen wel naar `null`.

## Test plan

- [ ] `+ Toevoegen` → typ niet-bestaande naam → "Nieuwe persoon aanmaken" verschijnt → modal opent met naam voorgevuld → na "Aanmaken" staat persoon geselecteerd → lid wordt toegevoegd
- [ ] Bestaand lid: hover → potlood → wijzig rol/start/eind → Opslaan → waarden persistent na refresh
- [ ] Eind_datum verwijderen (leeg) → lid wordt weer "actief" zonder eind
- [ ] Bestaande regressies: lid verwijderen, samenwerkingsverband bewerken/verwijderen blijven werken
- [ ] Tests: `uv run --project backend pytest backend/tests/test_samenwerkingsverband.py` (8/8 groen lokaal)