### PR TITLE
Lead-updates: AI-gegenereerde mail + publieke versie per lead

### DIFF
--- a/backend/bouwmeester/api/routes/__init__.py
+++ b/backend/bouwmeester/api/routes/__init__.py
@@ -22,6 +22,7 @@ from bouwmeester.api.routes.initiatief_update import (
     router as initiatief_updates_router,
 )
 from bouwmeester.api.routes.lead_columns import router as lead_columns_router
+from bouwmeester.api.routes.lead_update import router as lead_updates_router
 from bouwmeester.api.routes.leads import router as leads_router
 from bouwmeester.api.routes.llm import router as llm_router
 from bouwmeester.api.routes.mattermost import router as mattermost_router
@@ -75,6 +76,7 @@ api_router.include_router(initiatief_updates_router)
 api_router.include_router(import_export_router)
 api_router.include_router(lead_columns_router)
 api_router.include_router(leads_router)
+api_router.include_router(lead_updates_router)
 api_router.include_router(llm_router)
 api_router.include_router(mattermost_router)
 api_router.include_router(mattermost_channels_router)

--- a/backend/bouwmeester/api/routes/lead_update.py
+++ b/backend/bouwmeester/api/routes/lead_update.py
@@ -19,8 +19,14 @@ from bouwmeester.core.initiatief_context import (
     InitiatiefContext,
     get_initiatief_context,
 )
+from bouwmeester.core.storage import (
+    ensure_bijlagen_dir,
+    file_exists_on_disk,
+    safe_resolve_or_400,
+)
 from bouwmeester.models.lead import Lead
 from bouwmeester.models.lead_activity import LeadActivity
+from bouwmeester.models.lead_attachment import LeadAttachment
 from bouwmeester.models.lead_update import LeadUpdatePost
 from bouwmeester.models.resource_permission import ResourcePermission
 from bouwmeester.repositories.lead import LeadRepository
@@ -38,6 +44,14 @@ from bouwmeester.services.markdown_min import markdown_to_html
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/leads", tags=["lead-updates"])
+
+LEADS_BIJLAGEN_ROOT = ensure_bijlagen_dir()
+
+# Cap how many existing attachments we drop into a single LLM call. The /parse
+# endpoint already accepts ad-hoc uploads; bulk-feeding 30 historical files
+# would blow past the model's vision-image budget and balloon token cost.
+_MAX_ATTACHMENTS_FOR_PARSE = 6
+_MAX_ATTACHMENT_BYTES = 4 * 1024 * 1024  # per file
 
 
 def _to_response(post: LeadUpdatePost) -> LeadUpdatePostResponse:
@@ -162,6 +176,70 @@ async def _suggested_recipients(db: AsyncSession, lead_id: UUID) -> list[str]:
     return sorted({c["email"] for c in contacts if c["email"]})
 
 
+def _load_lead_attachments_for_llm(
+    attachments: list[LeadAttachment],
+) -> tuple[list[str], list[dict]]:
+    """Read existing lead-attachments from disk for LLM consumption.
+
+    Returns (text_parts, image_parts) — same shapes the parse endpoint uses
+    for ad-hoc UploadFile inputs. Images become vision content; text-bearing
+    documents (pdf/docx/odt/txt) get extracted via the existing
+    ``document_extract`` helper. Anything else is silently skipped.
+
+    Caps at ``_MAX_ATTACHMENTS_FOR_PARSE`` newest-first to keep token cost
+    bounded; per-file size is gated by ``_MAX_ATTACHMENT_BYTES``.
+    """
+    text_parts: list[str] = []
+    image_parts: list[dict] = []
+
+    sorted_attachments = sorted(
+        (a for a in attachments if a.pad),
+        key=lambda a: a.created_at,
+        reverse=True,
+    )[:_MAX_ATTACHMENTS_FOR_PARSE]
+
+    for att in sorted_attachments:
+        if not file_exists_on_disk(LEADS_BIJLAGEN_ROOT, att.pad):
+            continue
+        try:
+            file_path = safe_resolve_or_400(LEADS_BIJLAGEN_ROOT, att.pad)
+        except HTTPException:
+            continue
+        try:
+            size = file_path.stat().st_size
+        except OSError:
+            continue
+        if size > _MAX_ATTACHMENT_BYTES:
+            logger.info(
+                "Skipping lead-attachment %s in parse: %d bytes > limit",
+                att.bestandsnaam,
+                size,
+            )
+            continue
+
+        ct = att.content_type or ""
+        if ct.startswith("image/"):
+            try:
+                content_bytes = file_path.read_bytes()
+            except OSError:
+                continue
+            b64 = base64.b64encode(content_bytes).decode("ascii")
+            image_parts.append(
+                {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:{ct};base64,{b64}"},
+                }
+            )
+            continue
+
+        extracted = extract_text(file_path, ct)
+        if extracted:
+            label = att.bestandsnaam or "bijlage"
+            text_parts.append(f"[bijlage: {label}]\n{extracted}")
+
+    return text_parts, image_parts
+
+
 # ---------------------------------------------------------------------------
 # AI parse — produce a draft from raw input + lead context
 # ---------------------------------------------------------------------------
@@ -176,6 +254,7 @@ async def parse_lead_update(
     current_user: OptionalUser,
     raw_text: str | None = Form(None),
     use_lead_history: bool = Form(False),
+    include_attachments: bool = Form(False),
     files: list[UploadFile] | None = None,
     db: AsyncSession = Depends(get_db),
     init_ctx: InitiatiefContext = Depends(get_initiatief_context),
@@ -190,6 +269,19 @@ async def parse_lead_update(
 
     text_parts: list[str] = []
     image_parts: list[dict] = []
+
+    # When generating from lead history we always pull in attachments too —
+    # screenshots and uploaded documents (incl. the ones Mattermost-ingest
+    # auto-attaches) are usually the most concrete evidence the LLM has to
+    # work with. For the raw-input mode it's opt-in to keep token cost in
+    # check when the user just wants to clean up a quick paste.
+    pull_attachments = include_attachments or use_lead_history
+    if pull_attachments and lead.attachments:
+        attachment_text, attachment_images = _load_lead_attachments_for_llm(
+            lead.attachments
+        )
+        text_parts.extend(attachment_text)
+        image_parts.extend(attachment_images)
 
     if raw_text:
         text_parts.append(raw_text)
@@ -229,7 +321,8 @@ async def parse_lead_update(
             status_code=400,
             detail=(
                 "Geen invoer: geef ruwe tekst, een bestand, of zet"
-                " use_lead_history=true om uit lead-historie te genereren."
+                " use_lead_history=true / include_attachments=true om uit"
+                " lead-context te genereren."
             ),
         )
 

--- a/backend/bouwmeester/api/routes/lead_update.py
+++ b/backend/bouwmeester/api/routes/lead_update.py
@@ -1,0 +1,509 @@
+"""API routes for LeadUpdatePost — per-lead update posts (mail + community)."""
+
+import base64
+import logging
+from datetime import UTC, datetime
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Form, HTTPException, UploadFile, status
+from fastapi.responses import Response
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from bouwmeester.api.deps import require_found
+from bouwmeester.api.routes.leads import _check_lead_access, _robust_parse_json
+from bouwmeester.core.auth import OptionalUser
+from bouwmeester.core.database import get_db
+from bouwmeester.core.initiatief_context import (
+    InitiatiefContext,
+    get_initiatief_context,
+)
+from bouwmeester.models.lead import Lead
+from bouwmeester.models.lead_activity import LeadActivity
+from bouwmeester.models.lead_update import LeadUpdatePost
+from bouwmeester.models.resource_permission import ResourcePermission
+from bouwmeester.repositories.lead import LeadRepository
+from bouwmeester.schema.lead_update import (
+    LeadUpdateExtractResult,
+    LeadUpdatePostCreate,
+    LeadUpdatePostEdit,
+    LeadUpdatePostResponse,
+)
+from bouwmeester.services.activity_service import log_activity
+from bouwmeester.services.document_extract import extract_text
+from bouwmeester.services.eml_builder import build_outlook_draft_eml
+from bouwmeester.services.markdown_min import markdown_to_html
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/leads", tags=["lead-updates"])
+
+
+def _to_response(post: LeadUpdatePost) -> LeadUpdatePostResponse:
+    return LeadUpdatePostResponse(
+        id=post.id,
+        lead_id=post.lead_id,
+        titel=post.titel,
+        body_internal=post.body_internal,
+        body_public=post.body_public,
+        mail_subject=post.mail_subject,
+        mail_to=post.mail_to,
+        mail_cc=post.mail_cc,
+        published_at=post.published_at,
+        published_by_id=post.published_by_id,
+        published_by_naam=(post.published_by.naam if post.published_by else None),
+        created_at=post.created_at,
+        updated_at=post.updated_at,
+    )
+
+
+async def _load_post(
+    db: AsyncSession, lead_id: UUID, post_id: UUID
+) -> LeadUpdatePost | None:
+    stmt = (
+        select(LeadUpdatePost)
+        .where(
+            LeadUpdatePost.id == post_id,
+            LeadUpdatePost.lead_id == lead_id,
+        )
+        .options(selectinload(LeadUpdatePost.published_by))
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def _build_lead_context(db: AsyncSession, lead: Lead) -> str:
+    """Compose a short paragraph the LLM uses to ground the update.
+
+    Pulls in initiatief metadata, lead title/organisatie/description, recent
+    activity bodies and the contact name list so the model has enough to
+    write a coherent update even when the user pastes only a one-liner.
+    """
+    parts: list[str] = []
+    if lead.initiatief is not None:
+        init = lead.initiatief
+        parts.append(f"Initiatief: {init.naam}")
+        if init.beschrijving:
+            parts.append(f"Initiatief-beschrijving: {init.beschrijving[:800]}")
+    parts.append(f"Lead: {lead.title}")
+    if lead.organization:
+        parts.append(f"Organisatie: {lead.organization}")
+    if lead.description:
+        parts.append(f"Beschrijving: {lead.description[:600]}")
+    parts.append(f"Stage: {lead.stage}")
+
+    activities_stmt = (
+        select(LeadActivity)
+        .where(LeadActivity.lead_id == lead.id)
+        .order_by(LeadActivity.created_at.desc())
+        .limit(8)
+    )
+    activities = (await db.execute(activities_stmt)).scalars().all()
+    if activities:
+        parts.append("\nRecente activity (nieuwste eerst):")
+        for a in activities:
+            stamp = a.created_at.strftime("%Y-%m-%d") if a.created_at else "?"
+            content = (a.content or "").strip()
+            if not content:
+                continue
+            parts.append(f"- [{stamp} · {a.activity_type}] {content[:600]}")
+            if a.uitkomst:
+                parts.append(f"  uitkomst: {a.uitkomst[:300]}")
+            if a.vervolgacties:
+                parts.append(f"  vervolg: {a.vervolgacties[:300]}")
+
+    contacts = await _list_contacts_with_email(db, lead.id)
+    if contacts:
+        names = ", ".join(
+            f"{c['naam']}" + (f" <{c['email']}>" if c["email"] else "")
+            for c in contacts
+        )
+        parts.append(f"\nContacten: {names}")
+
+    return "\n".join(parts)
+
+
+async def _list_contacts_with_email(
+    db: AsyncSession, lead_id: UUID
+) -> list[dict[str, str | None]]:
+    """Return contact persons attached to the lead with their default email."""
+    from bouwmeester.models.person import Person
+
+    stmt = (
+        select(ResourcePermission)
+        .where(
+            ResourcePermission.resource_type == "lead",
+            ResourcePermission.resource_id == lead_id,
+            ResourcePermission.person_id.isnot(None),
+        )
+        .options(selectinload(ResourcePermission.person).selectinload(Person.emails))
+    )
+    rows = (await db.execute(stmt)).scalars().all()
+    out: list[dict[str, str | None]] = []
+    for rp in rows:
+        person = rp.person
+        if person is None:
+            continue
+        email: str | None = None
+        emails = getattr(person, "emails", None) or []
+        if emails:
+            default = next((e for e in emails if e.is_default), None)
+            email = (default or emails[0]).email
+        if email is None:
+            email = getattr(person, "email", None)
+        out.append({"naam": person.naam, "email": email})
+    return out
+
+
+async def _suggested_recipients(db: AsyncSession, lead_id: UUID) -> list[str]:
+    """Default To: list — emails of every contact linked to the lead."""
+    contacts = await _list_contacts_with_email(db, lead_id)
+    return sorted({c["email"] for c in contacts if c["email"]})
+
+
+# ---------------------------------------------------------------------------
+# AI parse — produce a draft from raw input + lead context
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/{lead_id}/updates/parse",
+    response_model=LeadUpdateExtractResult,
+)
+async def parse_lead_update(
+    lead_id: UUID,
+    current_user: OptionalUser,
+    raw_text: str | None = Form(None),
+    use_lead_history: bool = Form(False),
+    files: list[UploadFile] | None = None,
+    db: AsyncSession = Depends(get_db),
+    init_ctx: InitiatiefContext = Depends(get_initiatief_context),
+) -> LeadUpdateExtractResult:
+    """Parse raw text/uploaded docs (or just the lead history) into an update draft."""
+    from bouwmeester.services.llm.factory import get_llm_service
+    from bouwmeester.services.llm.prompts import build_lead_update_prompt
+
+    repo = LeadRepository(db)
+    lead = require_found(await repo.get_detail(lead_id, init_ctx=init_ctx), "Lead")
+    _check_lead_access(lead, init_ctx)
+
+    text_parts: list[str] = []
+    image_parts: list[dict] = []
+
+    if raw_text:
+        text_parts.append(raw_text)
+
+    if files:
+        for f in files:
+            content_bytes = await f.read()
+            ct = f.content_type or ""
+            if ct.startswith("image/"):
+                b64 = base64.b64encode(content_bytes).decode("ascii")
+                image_parts.append(
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:{ct};base64,{b64}"},
+                    }
+                )
+                continue
+            # Persist to a tempfile so we can reuse the existing extractor.
+            from pathlib import Path
+            from tempfile import NamedTemporaryFile
+
+            with NamedTemporaryFile(delete=False) as tmp:
+                tmp.write(content_bytes)
+                tmp_path = Path(tmp.name)
+            try:
+                extracted = extract_text(tmp_path, ct)
+            finally:
+                try:
+                    tmp_path.unlink()
+                except OSError:
+                    pass
+            if extracted:
+                text_parts.append(extracted)
+
+    if not text_parts and not image_parts and not use_lead_history:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Geen invoer: geef ruwe tekst, een bestand, of zet"
+                " use_lead_history=true om uit lead-historie te genereren."
+            ),
+        )
+
+    lead_context = await _build_lead_context(db, lead)
+    combined_text = "\n\n".join(text_parts).strip()
+    if not combined_text and not image_parts:
+        # Fallback: only history. Tell the LLM that's intentional.
+        combined_text = (
+            "(Er is geen nieuwe ruwe invoer. Schrijf de update op basis van de"
+            " context van de lead hieronder — vat samen wat er recent gebeurd"
+            " is en wat de huidige stand is.)"
+        )
+
+    llm = await get_llm_service(db)
+    if llm is None:
+        raise HTTPException(status_code=503, detail="Geen LLM-service beschikbaar.")
+
+    prompt = build_lead_update_prompt(
+        raw_text=combined_text or "(zie afbeelding)",
+        lead_context=lead_context,
+        initiatief_naam=lead.initiatief.naam if lead.initiatief else None,
+    )
+
+    try:
+        if image_parts:
+            content: list[dict] = [{"type": "text", "text": prompt}]
+            content.extend(image_parts)
+            response = await llm._client.chat.completions.create(
+                model=llm._model,
+                max_tokens=2048,
+                messages=[{"role": "user", "content": content}],
+            )
+            response_text = response.choices[0].message.content or ""
+        else:
+            response_text = await llm._complete(prompt)
+        parsed = _robust_parse_json(response_text)
+    except Exception:
+        logger.exception("Failed to parse lead-update with LLM")
+        raise HTTPException(
+            status_code=500,
+            detail="Fout bij het verwerken van de update.",
+        )
+
+    suggested_to = await _suggested_recipients(db, lead_id)
+    return LeadUpdateExtractResult(
+        titel=parsed.get("titel"),
+        body_internal=parsed.get("body_internal"),
+        body_public=parsed.get("body_public"),
+        mail_subject=parsed.get("mail_subject"),
+        suggested_to=suggested_to,
+        suggested_cc=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# CRUD + publish
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/{lead_id}/updates",
+    response_model=list[LeadUpdatePostResponse],
+)
+async def list_updates(
+    lead_id: UUID,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    init_ctx: InitiatiefContext = Depends(get_initiatief_context),
+) -> list[LeadUpdatePostResponse]:
+    lead = await db.get(Lead, lead_id)
+    if lead is None:
+        raise HTTPException(status_code=404, detail="Lead niet gevonden")
+    _check_lead_access(lead, init_ctx)
+
+    stmt = (
+        select(LeadUpdatePost)
+        .where(LeadUpdatePost.lead_id == lead_id)
+        .options(selectinload(LeadUpdatePost.published_by))
+        .order_by(LeadUpdatePost.created_at.desc())
+    )
+    result = await db.execute(stmt)
+    return [_to_response(p) for p in result.scalars().all()]
+
+
+@router.post(
+    "/{lead_id}/updates",
+    response_model=LeadUpdatePostResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_update(
+    lead_id: UUID,
+    data: LeadUpdatePostCreate,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    init_ctx: InitiatiefContext = Depends(get_initiatief_context),
+) -> LeadUpdatePostResponse:
+    lead = await db.get(Lead, lead_id)
+    if lead is None:
+        raise HTTPException(status_code=404, detail="Lead niet gevonden")
+    _check_lead_access(lead, init_ctx)
+
+    actor_id = current_user.id if current_user else None
+    post = LeadUpdatePost(
+        lead_id=lead_id,
+        titel=data.titel,
+        body_internal=data.body_internal,
+        body_public=data.body_public,
+        mail_subject=data.mail_subject,
+        mail_to=list(data.mail_to) if data.mail_to else None,
+        mail_cc=list(data.mail_cc) if data.mail_cc else None,
+        source_raw_text=data.source_raw_text,
+        created_by_id=actor_id,
+    )
+    if data.publish:
+        post.published_at = datetime.now(UTC)
+        post.published_by_id = actor_id
+
+    db.add(post)
+    await db.flush()
+    await db.refresh(post)
+    await db.refresh(post, attribute_names=["published_by"])
+
+    await log_activity(
+        db,
+        current_user,
+        None,
+        "lead_update.created",
+        details={
+            "lead_id": str(lead_id),
+            "lead_title": lead.title,
+            "post_id": str(post.id),
+            "published": data.publish,
+        },
+    )
+    return _to_response(post)
+
+
+@router.put(
+    "/{lead_id}/updates/{post_id}",
+    response_model=LeadUpdatePostResponse,
+)
+async def edit_update(
+    lead_id: UUID,
+    post_id: UUID,
+    data: LeadUpdatePostEdit,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    init_ctx: InitiatiefContext = Depends(get_initiatief_context),
+) -> LeadUpdatePostResponse:
+    lead = await db.get(Lead, lead_id)
+    if lead is None:
+        raise HTTPException(status_code=404, detail="Lead niet gevonden")
+    _check_lead_access(lead, init_ctx)
+
+    post = require_found(await _load_post(db, lead_id, post_id), "Update")
+    payload = data.model_dump(exclude_unset=True)
+    for key, value in payload.items():
+        if key in {"mail_to", "mail_cc"} and value is not None:
+            value = list(value)
+        setattr(post, key, value)
+    await db.flush()
+    await db.refresh(post)
+    await db.refresh(post, attribute_names=["published_by"])
+    return _to_response(post)
+
+
+@router.post(
+    "/{lead_id}/updates/{post_id}/publish",
+    response_model=LeadUpdatePostResponse,
+)
+async def publish_update(
+    lead_id: UUID,
+    post_id: UUID,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    init_ctx: InitiatiefContext = Depends(get_initiatief_context),
+) -> LeadUpdatePostResponse:
+    lead = await db.get(Lead, lead_id)
+    if lead is None:
+        raise HTTPException(status_code=404, detail="Lead niet gevonden")
+    _check_lead_access(lead, init_ctx)
+
+    post = require_found(await _load_post(db, lead_id, post_id), "Update")
+    post.published_at = datetime.now(UTC)
+    post.published_by_id = current_user.id if current_user else None
+    await db.flush()
+    await db.refresh(post)
+    await db.refresh(post, attribute_names=["published_by"])
+    return _to_response(post)
+
+
+@router.post(
+    "/{lead_id}/updates/{post_id}/unpublish",
+    response_model=LeadUpdatePostResponse,
+)
+async def unpublish_update(
+    lead_id: UUID,
+    post_id: UUID,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    init_ctx: InitiatiefContext = Depends(get_initiatief_context),
+) -> LeadUpdatePostResponse:
+    lead = await db.get(Lead, lead_id)
+    if lead is None:
+        raise HTTPException(status_code=404, detail="Lead niet gevonden")
+    _check_lead_access(lead, init_ctx)
+
+    post = require_found(await _load_post(db, lead_id, post_id), "Update")
+    post.published_at = None
+    await db.flush()
+    await db.refresh(post)
+    await db.refresh(post, attribute_names=["published_by"])
+    return _to_response(post)
+
+
+@router.delete(
+    "/{lead_id}/updates/{post_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_update(
+    lead_id: UUID,
+    post_id: UUID,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    init_ctx: InitiatiefContext = Depends(get_initiatief_context),
+) -> None:
+    lead = await db.get(Lead, lead_id)
+    if lead is None:
+        raise HTTPException(status_code=404, detail="Lead niet gevonden")
+    _check_lead_access(lead, init_ctx)
+
+    post = await _load_post(db, lead_id, post_id)
+    if post is None:
+        raise HTTPException(status_code=404, detail="Update niet gevonden")
+    await db.delete(post)
+    await db.flush()
+
+
+# ---------------------------------------------------------------------------
+# .eml download — Outlook-friendly editable draft
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{lead_id}/updates/{post_id}/eml")
+async def download_update_eml(
+    lead_id: UUID,
+    post_id: UUID,
+    current_user: OptionalUser,
+    db: AsyncSession = Depends(get_db),
+    init_ctx: InitiatiefContext = Depends(get_initiatief_context),
+) -> Response:
+    """Stream a .eml that opens as an editable draft in Outlook (Windows)."""
+    lead = await db.get(Lead, lead_id)
+    if lead is None:
+        raise HTTPException(status_code=404, detail="Lead niet gevonden")
+    _check_lead_access(lead, init_ctx)
+
+    post = require_found(await _load_post(db, lead_id, post_id), "Update")
+
+    body_html = markdown_to_html(post.body_internal or "")
+    eml_bytes = build_outlook_draft_eml(
+        subject=post.mail_subject or post.titel or "",
+        to=list(post.mail_to or []),
+        cc=list(post.mail_cc or []),
+        body_html=body_html,
+    )
+    safe_title = "".join(
+        c if c.isalnum() or c in "-_" else "-" for c in (post.titel or "update")
+    )[:60]
+    filename = f"update-{safe_title}.eml"
+    return Response(
+        content=eml_bytes,
+        media_type="message/rfc822",
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+        },
+    )

--- a/backend/bouwmeester/api/routes/lead_update.py
+++ b/backend/bouwmeester/api/routes/lead_update.py
@@ -192,9 +192,11 @@ def _load_lead_attachments_for_llm(
     text_parts: list[str] = []
     image_parts: list[dict] = []
 
+    # ``created_at`` has a server_default so post-flush it's never None, but
+    # be defensive: an in-memory model that hasn't hit the DB has no value.
     sorted_attachments = sorted(
         (a for a in attachments if a.pad),
-        key=lambda a: a.created_at,
+        key=lambda a: a.created_at or datetime.min.replace(tzinfo=UTC),
         reverse=True,
     )[:_MAX_ATTACHMENTS_FOR_PARSE]
 
@@ -589,8 +591,12 @@ async def download_update_eml(
         cc=list(post.mail_cc or []),
         body_html=body_html,
     )
+    # ASCII-only — non-ASCII filenames in Content-Disposition need RFC 5987
+    # encoding which Outlook/legacy clients handle inconsistently. Strip to
+    # the safe set instead.
     safe_title = "".join(
-        c if c.isalnum() or c in "-_" else "-" for c in (post.titel or "update")
+        c if (c.isascii() and (c.isalnum() or c in "-_")) else "-"
+        for c in (post.titel or "update")
     )[:60]
     filename = f"update-{safe_title}.eml"
     return Response(

--- a/backend/bouwmeester/api/routes/public_initiatief.py
+++ b/backend/bouwmeester/api/routes/public_initiatief.py
@@ -11,7 +11,9 @@ from bouwmeester.models.initiatief import Initiatief
 from bouwmeester.models.initiatief_update import InitiatiefUpdatePost
 from bouwmeester.models.lead import Lead
 from bouwmeester.models.lead_column import LeadColumn
+from bouwmeester.models.lead_update import LeadUpdatePost
 from bouwmeester.schema.initiatief_update import InitiatiefUpdatePostPublicResponse
+from bouwmeester.schema.lead_update import LeadUpdatePostPublicResponse
 
 router = APIRouter(prefix="/public/initiatieven", tags=["public-initiatief"])
 
@@ -21,6 +23,7 @@ class PublicCasus(BaseModel):
 
     titel: str
     samenvatting: str | None = None
+    updates: list[LeadUpdatePostPublicResponse] = []
 
 
 class PublicInitiatiefResponse(BaseModel):
@@ -80,19 +83,41 @@ async def get_public_initiatief(
         LeadColumn.initiatief_id == initiatief.id,
         LeadColumn.is_public_visible.is_(True),
     )
-    casussen_result = await db.execute(
-        select(Lead.public_title, Lead.public_summary)
+    leads_result = await db.execute(
+        select(Lead)
         .where(
             Lead.initiatief_id == initiatief.id,
             Lead.public_visible.is_(True),
             Lead.public_title.is_not(None),
             Lead.stage.in_(public_slugs_subq),
         )
+        .options(selectinload(Lead.updates).selectinload(LeadUpdatePost.published_by))
         .order_by(Lead.created_at.desc())
     )
-    casussen = [
-        PublicCasus(titel=row[0], samenvatting=row[1]) for row in casussen_result.all()
-    ]
+    casussen: list[PublicCasus] = []
+    for lead in leads_result.scalars().all():
+        published = sorted(
+            (u for u in lead.updates if u.published_at is not None and u.body_public),
+            key=lambda u: u.published_at,
+            reverse=True,
+        )
+        casussen.append(
+            PublicCasus(
+                titel=lead.public_title or "",
+                samenvatting=lead.public_summary,
+                updates=[
+                    LeadUpdatePostPublicResponse(
+                        titel=u.titel,
+                        body_public=u.body_public,
+                        published_at=u.published_at,
+                        published_by_naam=(
+                            u.published_by.naam if u.published_by else None
+                        ),
+                    )
+                    for u in published
+                ],
+            )
+        )
 
     return PublicInitiatiefResponse(
         naam=initiatief.naam,

--- a/backend/bouwmeester/migrations/versions/61a63e103355_add_lead_update_table.py
+++ b/backend/bouwmeester/migrations/versions/61a63e103355_add_lead_update_table.py
@@ -59,9 +59,23 @@ def upgrade() -> None:
         ["published_at"],
         unique=False,
     )
+    op.create_index(
+        op.f("ix_lead_update_published_by_id"),
+        "lead_update",
+        ["published_by_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_lead_update_created_by_id"),
+        "lead_update",
+        ["created_by_id"],
+        unique=False,
+    )
 
 
 def downgrade() -> None:
+    op.drop_index(op.f("ix_lead_update_created_by_id"), table_name="lead_update")
+    op.drop_index(op.f("ix_lead_update_published_by_id"), table_name="lead_update")
     op.drop_index(op.f("ix_lead_update_published_at"), table_name="lead_update")
     op.drop_index(op.f("ix_lead_update_lead_id"), table_name="lead_update")
     op.drop_table("lead_update")

--- a/backend/bouwmeester/migrations/versions/61a63e103355_add_lead_update_table.py
+++ b/backend/bouwmeester/migrations/versions/61a63e103355_add_lead_update_table.py
@@ -1,0 +1,67 @@
+"""add lead_update table
+
+Revision ID: 61a63e103355
+Revises: b3c5e7f8d2a1
+Create Date: 2026-05-08 14:10:23.084133
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "61a63e103355"
+down_revision: str | None = "b3c5e7f8d2a1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "lead_update",
+        sa.Column(
+            "id", sa.UUID(), server_default=sa.text("gen_random_uuid()"), nullable=False
+        ),
+        sa.Column("lead_id", sa.UUID(), nullable=False),
+        sa.Column("titel", sa.String(), nullable=False),
+        sa.Column("body_internal", sa.Text(), nullable=True),
+        sa.Column("body_public", sa.Text(), nullable=True),
+        sa.Column("mail_subject", sa.String(), nullable=True),
+        sa.Column("mail_to", postgresql.JSON(astext_type=sa.Text()), nullable=True),
+        sa.Column("mail_cc", postgresql.JSON(astext_type=sa.Text()), nullable=True),
+        sa.Column("source_raw_text", sa.Text(), nullable=True),
+        sa.Column("published_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("published_by_id", sa.UUID(), nullable=True),
+        sa.Column("created_by_id", sa.UUID(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["created_by_id"], ["person.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["lead_id"], ["lead.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["published_by_id"], ["person.id"], ondelete="SET NULL"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_lead_update_lead_id"), "lead_update", ["lead_id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_lead_update_published_at"),
+        "lead_update",
+        ["published_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_lead_update_published_at"), table_name="lead_update")
+    op.drop_index(op.f("ix_lead_update_lead_id"), table_name="lead_update")
+    op.drop_table("lead_update")

--- a/backend/bouwmeester/models/__init__.py
+++ b/backend/bouwmeester/models/__init__.py
@@ -31,6 +31,7 @@ from bouwmeester.models.lead_activity import LeadActivity  # noqa: F401
 from bouwmeester.models.lead_attachment import LeadAttachment  # noqa: F401
 from bouwmeester.models.lead_column import LeadColumn  # noqa: F401
 from bouwmeester.models.lead_node import LeadNode  # noqa: F401
+from bouwmeester.models.lead_update import LeadUpdatePost  # noqa: F401
 from bouwmeester.models.maatregel import Maatregel  # noqa: F401
 from bouwmeester.models.mattermost_channel_link import (  # noqa: F401
     MattermostChannelLink,
@@ -115,6 +116,7 @@ __all__ = [
     "LeadAttachment",
     "LeadColumn",
     "LeadNode",
+    "LeadUpdatePost",
     "LeadTag",
     "Maatregel",
     "MattermostChannelLink",

--- a/backend/bouwmeester/models/lead.py
+++ b/backend/bouwmeester/models/lead.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from bouwmeester.models.lead_activity import LeadActivity
     from bouwmeester.models.lead_attachment import LeadAttachment
     from bouwmeester.models.lead_node import LeadNode
+    from bouwmeester.models.lead_update import LeadUpdatePost
     from bouwmeester.models.person import Person
     from bouwmeester.models.tag import LeadTag
 
@@ -124,4 +125,10 @@ class Lead(Base):
         "LeadTag",
         back_populates="lead",
         cascade="all, delete-orphan",
+    )
+    updates: Mapped[list["LeadUpdatePost"]] = relationship(
+        "LeadUpdatePost",
+        back_populates="lead",
+        cascade="all, delete-orphan",
+        order_by="LeadUpdatePost.created_at.desc()",
     )

--- a/backend/bouwmeester/models/lead_update.py
+++ b/backend/bouwmeester/models/lead_update.py
@@ -49,11 +49,13 @@ class LeadUpdatePost(Base):
         UUID(as_uuid=True),
         ForeignKey("person.id", ondelete="SET NULL"),
         nullable=True,
+        index=True,
     )
     created_by_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("person.id", ondelete="SET NULL"),
         nullable=True,
+        index=True,
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()

--- a/backend/bouwmeester/models/lead_update.py
+++ b/backend/bouwmeester/models/lead_update.py
@@ -1,0 +1,71 @@
+"""LeadUpdatePost model — published update on a lead, used for community page + mail."""
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional
+
+from sqlalchemy import DateTime, ForeignKey, Text, func, text
+from sqlalchemy.dialects.postgresql import JSON, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from bouwmeester.core.database import Base
+
+if TYPE_CHECKING:
+    from bouwmeester.models.lead import Lead
+    from bouwmeester.models.person import Person
+
+
+class LeadUpdatePost(Base):
+    """Per-lead update post: rich body for the project team mail and a short
+    public version that surfaces under the casus on /c/:slug.
+
+    `published_at` IS NULL means draft.
+    """
+
+    __tablename__ = "lead_update"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    lead_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("lead.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    titel: Mapped[str] = mapped_column(nullable=False)
+    body_internal: Mapped[str | None] = mapped_column(Text, nullable=True)
+    body_public: Mapped[str | None] = mapped_column(Text, nullable=True)
+    mail_subject: Mapped[str | None] = mapped_column(nullable=True)
+    mail_to: Mapped[list[str] | None] = mapped_column(JSON, nullable=True)
+    mail_cc: Mapped[list[str] | None] = mapped_column(JSON, nullable=True)
+    source_raw_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    published_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, index=True
+    )
+    published_by_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("person.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    created_by_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("person.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), onupdate=func.now(), nullable=True
+    )
+
+    lead: Mapped["Lead"] = relationship("Lead", back_populates="updates")
+    published_by: Mapped[Optional["Person"]] = relationship(
+        "Person", foreign_keys=[published_by_id]
+    )
+    created_by: Mapped[Optional["Person"]] = relationship(
+        "Person", foreign_keys=[created_by_id]
+    )

--- a/backend/bouwmeester/schema/__init__.py
+++ b/backend/bouwmeester/schema/__init__.py
@@ -142,6 +142,13 @@ from bouwmeester.schema.lead_column import (
     LeadColumnResponse,
     LeadColumnUpdate,
 )
+from bouwmeester.schema.lead_update import (
+    LeadUpdateExtractResult,
+    LeadUpdatePostCreate,
+    LeadUpdatePostEdit,
+    LeadUpdatePostPublicResponse,
+    LeadUpdatePostResponse,
+)
 from bouwmeester.schema.llm import (
     CorpusGapOverviewResponse,
     CorpusGapSummaryItem,
@@ -556,6 +563,12 @@ __all__ = [
     "InitiatiefUpdatePostEdit",
     "InitiatiefUpdatePostPublicResponse",
     "InitiatiefUpdatePostResponse",
+    # lead_update (per-lead update post)
+    "LeadUpdateExtractResult",
+    "LeadUpdatePostCreate",
+    "LeadUpdatePostEdit",
+    "LeadUpdatePostPublicResponse",
+    "LeadUpdatePostResponse",
     # stakeholder_assessment
     "StakeholderAssessmentCreate",
     "StakeholderAssessmentResponse",

--- a/backend/bouwmeester/schema/lead_update.py
+++ b/backend/bouwmeester/schema/lead_update.py
@@ -1,0 +1,64 @@
+"""Pydantic schemas for LeadUpdatePost."""
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
+
+
+class LeadUpdatePostCreate(BaseModel):
+    titel: str = Field(min_length=1, max_length=300)
+    body_internal: str | None = Field(None, max_length=50000)
+    body_public: str | None = Field(None, max_length=5000)
+    mail_subject: str | None = Field(None, max_length=300)
+    mail_to: list[EmailStr] | None = None
+    mail_cc: list[EmailStr] | None = None
+    source_raw_text: str | None = Field(None, max_length=50000)
+    publish: bool = False
+
+
+class LeadUpdatePostEdit(BaseModel):
+    titel: str | None = Field(None, min_length=1, max_length=300)
+    body_internal: str | None = Field(None, max_length=50000)
+    body_public: str | None = Field(None, max_length=5000)
+    mail_subject: str | None = Field(None, max_length=300)
+    mail_to: list[EmailStr] | None = None
+    mail_cc: list[EmailStr] | None = None
+
+
+class LeadUpdatePostResponse(BaseModel):
+    id: UUID
+    lead_id: UUID
+    titel: str
+    body_internal: str | None = None
+    body_public: str | None = None
+    mail_subject: str | None = None
+    mail_to: list[str] | None = None
+    mail_cc: list[str] | None = None
+    published_at: datetime | None = None
+    published_by_id: UUID | None = None
+    published_by_naam: str | None = None
+    created_at: datetime
+    updated_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class LeadUpdatePostPublicResponse(BaseModel):
+    """Subset safe to expose under a casus on /c/:slug."""
+
+    titel: str
+    body_public: str | None = None
+    published_at: datetime
+    published_by_naam: str | None = None
+
+
+class LeadUpdateExtractResult(BaseModel):
+    """LLM-extracted draft for a lead-update; user reviews + edits before save."""
+
+    titel: str | None = None
+    body_internal: str | None = None
+    body_public: str | None = None
+    mail_subject: str | None = None
+    suggested_to: list[str] = Field(default_factory=list)
+    suggested_cc: list[str] = Field(default_factory=list)

--- a/backend/bouwmeester/services/eml_builder.py
+++ b/backend/bouwmeester/services/eml_builder.py
@@ -1,0 +1,54 @@
+"""Build .eml files Outlook (Windows) opens as a new editable draft.
+
+The X-Unsent: 1 header is what flips Outlook from read-mode to compose-mode
+when the user double-clicks the saved message. Without it the .eml opens as a
+read-only received message and the recipients cannot be edited inline.
+"""
+
+from email.message import EmailMessage
+
+
+def build_outlook_draft_eml(
+    *,
+    subject: str,
+    to: list[str],
+    cc: list[str] | None = None,
+    body_html: str,
+    body_text: str | None = None,
+    from_addr: str | None = None,
+) -> bytes:
+    """Return raw bytes of an RFC 5322 message ready as a .eml download.
+
+    `body_html` is the rich body (already HTML, not Markdown). `body_text` is
+    the plain-text fallback; if omitted we strip tags from the HTML so the
+    message remains a proper multipart/alternative.
+    """
+    msg = EmailMessage()
+    msg["Subject"] = subject or ""
+    if from_addr:
+        msg["From"] = from_addr
+    if to:
+        msg["To"] = ", ".join(addr for addr in to if addr)
+    if cc:
+        msg["Cc"] = ", ".join(addr for addr in cc if addr)
+    msg["X-Unsent"] = "1"
+
+    plain = body_text if body_text is not None else _strip_html(body_html)
+    msg.set_content(plain or "")
+    msg.add_alternative(body_html or "", subtype="html")
+
+    return bytes(msg)
+
+
+def _strip_html(html: str) -> str:
+    """Cheap HTML→text fallback for the plain-text alternative.
+
+    We don't pull in a parser dependency here: this is a fallback most clients
+    won't render anyway (Outlook will pick the HTML alternative).
+    """
+    import re
+
+    text = re.sub(r"<br\s*/?>", "\n", html, flags=re.IGNORECASE)
+    text = re.sub(r"</p\s*>", "\n\n", text, flags=re.IGNORECASE)
+    text = re.sub(r"<[^>]+>", "", text)
+    return text.strip()

--- a/backend/bouwmeester/services/llm/prompts.py
+++ b/backend/bouwmeester/services/llm/prompts.py
@@ -285,6 +285,51 @@ def build_lead_intake_prompt(
     )
 
 
+def build_lead_update_prompt(
+    raw_text: str,
+    lead_context: str,
+    initiatief_naam: str | None = None,
+) -> str:
+    """Build a prompt that turns raw input + lead context into two update versions.
+
+    `lead_context` is a paragraph the route assembles: lead title, organisatie,
+    initiatief metadata (naam, beschrijving), recent activities, contact names.
+    `initiatief_naam` is also passed separately so subject lines can include
+    it without the LLM having to fish it out of the context blob.
+    """
+    initiatief_label = initiatief_naam or "(initiatief onbekend)"
+    return (
+        "Je schrijft een update over een lopende lead binnen een initiatief"
+        " bij de Nederlandse overheid. De update bestaat uit drie tekstdelen"
+        " plus een mail-onderwerp. Schrijf in het Nederlands, zakelijk maar"
+        " toegankelijk. Verzin niets dat niet in de context of de ruwe invoer"
+        " staat — vraag liever om iets weg te laten dan om het te bedenken.\n\n"
+        f"INITIATIEF: {initiatief_label}\n\n"
+        f"CONTEXT (lead + initiatief + historie):\n"
+        f"{lead_context[:MAX_TEXT_IN_PROMPT]}\n\n"
+        f"RUWE INVOER VAN DE GEBRUIKER:\n{raw_text[:MAX_TEXT_IN_PROMPT]}\n\n"
+        "Lever vier velden:\n"
+        "- titel: korte titel voor de update (max 80 tekens),"
+        " bv. 'Pilot gestart met MinJenV'.\n"
+        "- body_internal: 2-5 alinea's voor het project-/trajectteam."
+        " Mag namen, knelpunten, vervolgafspraken en concrete getallen"
+        " bevatten. Markdown toegestaan: alinea's, **vet**, lijsten met '-'.\n"
+        "- body_public: 1 tot 3 zinnen voor de publieke community-pagina van"
+        " het initiatief. GEEN interne namen, GEEN citaten, GEEN bedragen of"
+        " stappen die intern zijn. Wel mag genoemd worden welke organisatie"
+        " het betreft en wat het thema is, op hoofdlijnen.\n"
+        "- mail_subject: Subject voor de mail aan het team. Begin met de"
+        f" naam van het initiatief, bv. '{initiatief_label} — ...'.\n\n"
+        "Geef je antwoord als JSON (en ALLEEN JSON, geen andere tekst):\n"
+        "{\n"
+        '  "titel": "...",\n'
+        '  "body_internal": "...",\n'
+        '  "body_public": "...",\n'
+        '  "mail_subject": "..."\n'
+        "}"
+    )
+
+
 MAX_CANDIDATES_IN_PROMPT = 30
 
 

--- a/backend/bouwmeester/services/markdown_min.py
+++ b/backend/bouwmeester/services/markdown_min.py
@@ -1,0 +1,43 @@
+"""Minimal Markdown to HTML converter for the lead-update mail body.
+
+We intentionally do NOT pull in a full Markdown parser. The LLM only emits
+paragraphs, ``-`` bullet lists and ``**bold**`` per the prompt; anything more
+ornate would also raise the visual surface for issues in Outlook anyway.
+"""
+
+import html
+import re
+
+
+def markdown_to_html(text: str) -> str:
+    if not text:
+        return ""
+
+    # Split into paragraph blocks separated by blank lines.
+    blocks = re.split(r"\n\s*\n", text.strip())
+    out: list[str] = []
+    for block in blocks:
+        lines = [ln.rstrip() for ln in block.splitlines() if ln.strip()]
+        if not lines:
+            continue
+        if all(_is_bullet(ln) for ln in lines):
+            items = "".join(
+                f"<li>{_inline(ln.lstrip('-* ').strip())}</li>" for ln in lines
+            )
+            out.append(f"<ul>{items}</ul>")
+        else:
+            joined = "<br>".join(_inline(ln) for ln in lines)
+            out.append(f"<p>{joined}</p>")
+
+    return "\n".join(out)
+
+
+def _is_bullet(line: str) -> bool:
+    stripped = line.lstrip()
+    return stripped.startswith("- ") or stripped.startswith("* ")
+
+
+def _inline(text: str) -> str:
+    escaped = html.escape(text)
+    escaped = re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", escaped)
+    return escaped

--- a/backend/tests/test_eml_builder.py
+++ b/backend/tests/test_eml_builder.py
@@ -1,0 +1,36 @@
+"""Unit tests for the .eml builder used by lead-updates."""
+
+from email import message_from_bytes
+
+from bouwmeester.services.eml_builder import build_outlook_draft_eml
+
+
+def test_x_unsent_header_present():
+    eml = build_outlook_draft_eml(subject="hi", to=["a@b.nl"], body_html="<p>hi</p>")
+    msg = message_from_bytes(eml)
+    assert msg["X-Unsent"] == "1"
+
+
+def test_to_cc_subject_and_html_alternative():
+    eml = build_outlook_draft_eml(
+        subject="Onderwerp",
+        to=["a@b.nl", "c@d.nl"],
+        cc=["e@f.nl"],
+        body_html="<p>Hallo</p>",
+    )
+    msg = message_from_bytes(eml)
+    assert msg["Subject"] == "Onderwerp"
+    assert "a@b.nl" in msg["To"]
+    assert "c@d.nl" in msg["To"]
+    assert msg["Cc"] == "e@f.nl"
+    assert msg.is_multipart()
+    payload_types = [p.get_content_type() for p in msg.walk()]
+    assert "text/plain" in payload_types
+    assert "text/html" in payload_types
+
+
+def test_empty_to_and_cc_omitted():
+    eml = build_outlook_draft_eml(subject="hi", to=[], cc=None, body_html="<p>x</p>")
+    msg = message_from_bytes(eml)
+    assert msg["To"] is None
+    assert msg["Cc"] is None

--- a/backend/tests/test_eml_builder.py
+++ b/backend/tests/test_eml_builder.py
@@ -34,3 +34,27 @@ def test_empty_to_and_cc_omitted():
     msg = message_from_bytes(eml)
     assert msg["To"] is None
     assert msg["Cc"] is None
+
+
+def test_markdown_to_html_handles_multiple_bold_segments():
+    """Regression: ``**a** **b**`` must produce two <strong>, not one greedy
+    span swallowing the space between them."""
+    from bouwmeester.services.markdown_min import markdown_to_html
+
+    out = markdown_to_html("**a** **b**")
+    assert out == "<p><strong>a</strong> <strong>b</strong></p>"
+
+
+def test_markdown_to_html_escapes_html_in_input():
+    from bouwmeester.services.markdown_min import markdown_to_html
+
+    out = markdown_to_html("<script>alert(1)</script> & co")
+    assert "<script>" not in out
+    assert "&amp;" in out
+
+
+def test_markdown_to_html_renders_bullet_list():
+    from bouwmeester.services.markdown_min import markdown_to_html
+
+    out = markdown_to_html("- een\n- twee")
+    assert out == "<ul><li>een</li><li>twee</li></ul>"

--- a/backend/tests/test_lead_update_routes.py
+++ b/backend/tests/test_lead_update_routes.py
@@ -122,6 +122,34 @@ async def test_unknown_lead_returns_404(client):
     assert resp.status_code == 404
 
 
+async def test_internal_listing_returns_full_payload_for_lead_members(
+    client, sample_lead
+):
+    """Authenticated users that can see the lead get the full update payload —
+    including body_internal, mail_subject, mail_to. The boundary is at the
+    public /c/:slug endpoint (covered in test_public_initiatief), not here.
+    """
+    create = await client.post(
+        f"/api/leads/{sample_lead.id}/updates",
+        json={
+            "titel": "T",
+            "body_internal": "intern",
+            "body_public": "publiek",
+            "mail_subject": "subject",
+            "mail_to": ["to@x.nl"],
+            "mail_cc": ["cc@x.nl"],
+        },
+    )
+    assert create.status_code == 201
+    listing = await client.get(f"/api/leads/{sample_lead.id}/updates")
+    assert listing.status_code == 200
+    post = listing.json()[0]
+    assert post["body_internal"] == "intern"
+    assert post["mail_subject"] == "subject"
+    assert post["mail_to"] == ["to@x.nl"]
+    assert post["mail_cc"] == ["cc@x.nl"]
+
+
 async def test_load_lead_attachments_for_llm_picks_text_and_image(tmp_path):
     """Unit test the helper that feeds existing lead-attachments into the LLM."""
     from datetime import UTC, datetime
@@ -166,6 +194,68 @@ async def test_load_lead_attachments_for_llm_picks_text_and_image(tmp_path):
     assert len(image_parts) == 1
     assert image_parts[0]["type"] == "image_url"
     assert image_parts[0]["image_url"]["url"].startswith("data:image/png;base64,")
+
+
+async def test_parse_round_trip_with_mocked_llm(client, sample_lead, monkeypatch):
+    """End-to-end parse: raw_text → mocked LLM → structured response."""
+    from unittest.mock import AsyncMock
+
+    fake_llm_response = (
+        '{"titel": "Mock-titel",'
+        ' "body_internal": "Lange interne tekst",'
+        ' "body_public": "Korte publieke versie",'
+        ' "mail_subject": "Onderwerp"}'
+    )
+
+    fake_llm = AsyncMock()
+    fake_llm._complete = AsyncMock(return_value=fake_llm_response)
+
+    async def fake_get_llm_service(_db):
+        return fake_llm
+
+    monkeypatch.setattr(
+        "bouwmeester.services.llm.factory.get_llm_service",
+        fake_get_llm_service,
+    )
+
+    resp = await client.post(
+        f"/api/leads/{sample_lead.id}/updates/parse",
+        data={"raw_text": "Korte invoer van de gebruiker"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["titel"] == "Mock-titel"
+    assert body["body_internal"] == "Lange interne tekst"
+    assert body["body_public"] == "Korte publieke versie"
+    assert body["mail_subject"] == "Onderwerp"
+    assert body["suggested_to"] == []  # geen contacten op deze lead
+    fake_llm._complete.assert_awaited_once()
+
+
+async def test_parse_strips_markdown_codeblock_from_llm_response(
+    client, sample_lead, monkeypatch
+):
+    """LLM wraps JSON in ```json fences sometimes — _robust_parse_json strips."""
+    from unittest.mock import AsyncMock
+
+    fake_response = '```json\n{"titel": "X", "body_internal": "y"}\n```'
+    fake_llm = AsyncMock()
+    fake_llm._complete = AsyncMock(return_value=fake_response)
+
+    async def fake_get_llm_service(_db):
+        return fake_llm
+
+    monkeypatch.setattr(
+        "bouwmeester.services.llm.factory.get_llm_service",
+        fake_get_llm_service,
+    )
+
+    resp = await client.post(
+        f"/api/leads/{sample_lead.id}/updates/parse",
+        data={"raw_text": "input"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["titel"] == "X"
 
 
 async def test_load_lead_attachments_for_llm_skips_oversized(tmp_path):

--- a/backend/tests/test_lead_update_routes.py
+++ b/backend/tests/test_lead_update_routes.py
@@ -120,3 +120,75 @@ async def test_parse_requires_input(client, sample_lead):
 async def test_unknown_lead_returns_404(client):
     resp = await client.get(f"/api/leads/{uuid.uuid4()}/updates")
     assert resp.status_code == 404
+
+
+async def test_load_lead_attachments_for_llm_picks_text_and_image(tmp_path):
+    """Unit test the helper that feeds existing lead-attachments into the LLM."""
+    from datetime import UTC, datetime
+    from unittest.mock import patch
+
+    from bouwmeester.api.routes import lead_update as lu_module
+    from bouwmeester.models.lead_attachment import LeadAttachment
+
+    txt_file = tmp_path / "notitie.txt"
+    txt_file.write_text("Dit is een notitie uit een eerder gesprek.", encoding="utf-8")
+    png_file = tmp_path / "screenshot.png"
+    # 1x1 transparent PNG — small but valid bytes the helper will base64.
+    png_file.write_bytes(
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+        b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\x9cc\x00"
+        b"\x01\x00\x00\x05\x00\x01\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82"
+    )
+
+    attachments = [
+        LeadAttachment(
+            id=uuid.uuid4(),
+            lead_id=uuid.uuid4(),
+            bestandsnaam="notitie.txt",
+            content_type="text/plain",
+            pad="notitie.txt",
+            created_at=datetime.now(UTC),
+        ),
+        LeadAttachment(
+            id=uuid.uuid4(),
+            lead_id=uuid.uuid4(),
+            bestandsnaam="screenshot.png",
+            content_type="image/png",
+            pad="screenshot.png",
+            created_at=datetime.now(UTC),
+        ),
+    ]
+
+    with patch.object(lu_module, "LEADS_BIJLAGEN_ROOT", tmp_path):
+        text_parts, image_parts = lu_module._load_lead_attachments_for_llm(attachments)
+
+    assert any("notitie uit een eerder gesprek" in t for t in text_parts)
+    assert len(image_parts) == 1
+    assert image_parts[0]["type"] == "image_url"
+    assert image_parts[0]["image_url"]["url"].startswith("data:image/png;base64,")
+
+
+async def test_load_lead_attachments_for_llm_skips_oversized(tmp_path):
+    from datetime import UTC, datetime
+    from unittest.mock import patch
+
+    from bouwmeester.api.routes import lead_update as lu_module
+    from bouwmeester.models.lead_attachment import LeadAttachment
+
+    big = tmp_path / "huge.txt"
+    big.write_bytes(b"x" * (lu_module._MAX_ATTACHMENT_BYTES + 1))
+
+    attachments = [
+        LeadAttachment(
+            id=uuid.uuid4(),
+            lead_id=uuid.uuid4(),
+            bestandsnaam="huge.txt",
+            content_type="text/plain",
+            pad="huge.txt",
+            created_at=datetime.now(UTC),
+        )
+    ]
+    with patch.object(lu_module, "LEADS_BIJLAGEN_ROOT", tmp_path):
+        text_parts, image_parts = lu_module._load_lead_attachments_for_llm(attachments)
+    assert text_parts == []
+    assert image_parts == []

--- a/backend/tests/test_lead_update_routes.py
+++ b/backend/tests/test_lead_update_routes.py
@@ -1,0 +1,122 @@
+"""Tests for LeadUpdatePost CRUD, publish flow, and .eml download."""
+
+import uuid
+
+import pytest
+
+from bouwmeester.models.lead import Lead
+
+
+@pytest.fixture
+async def sample_lead(db_session):
+    lead = Lead(id=uuid.uuid4(), title="Test lead", stage="inbox")
+    db_session.add(lead)
+    await db_session.flush()
+    return lead
+
+
+async def test_create_draft_update(client, sample_lead):
+    resp = await client.post(
+        f"/api/leads/{sample_lead.id}/updates",
+        json={
+            "titel": "Eerste",
+            "body_internal": "Lange interne tekst",
+            "body_public": "Korte publieke versie",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["titel"] == "Eerste"
+    assert body["body_public"] == "Korte publieke versie"
+    assert body["published_at"] is None
+
+
+async def test_create_and_publish(client, sample_lead):
+    resp = await client.post(
+        f"/api/leads/{sample_lead.id}/updates",
+        json={"titel": "Direct publiek", "publish": True},
+    )
+    assert resp.status_code == 201
+    assert resp.json()["published_at"] is not None
+
+
+async def test_edit_update(client, sample_lead):
+    create = await client.post(
+        f"/api/leads/{sample_lead.id}/updates",
+        json={"titel": "Origineel"},
+    )
+    post_id = create.json()["id"]
+    edit = await client.put(
+        f"/api/leads/{sample_lead.id}/updates/{post_id}",
+        json={"titel": "Bijgewerkt", "body_internal": "Nieuw"},
+    )
+    assert edit.status_code == 200
+    assert edit.json()["titel"] == "Bijgewerkt"
+    assert edit.json()["body_internal"] == "Nieuw"
+
+
+async def test_publish_then_unpublish_keeps_published_by(client, sample_lead):
+    create = await client.post(
+        f"/api/leads/{sample_lead.id}/updates",
+        json={"titel": "Audit", "publish": True},
+    )
+    post_id = create.json()["id"]
+    publisher_id = create.json()["published_by_id"]
+    unpub = await client.post(
+        f"/api/leads/{sample_lead.id}/updates/{post_id}/unpublish"
+    )
+    assert unpub.status_code == 200
+    assert unpub.json()["published_at"] is None
+    assert unpub.json()["published_by_id"] == publisher_id
+
+
+async def test_delete_update(client, sample_lead):
+    create = await client.post(
+        f"/api/leads/{sample_lead.id}/updates",
+        json={"titel": "Weg ermee"},
+    )
+    post_id = create.json()["id"]
+    delete = await client.delete(f"/api/leads/{sample_lead.id}/updates/{post_id}")
+    assert delete.status_code == 204
+
+    listing = await client.get(f"/api/leads/{sample_lead.id}/updates")
+    assert listing.status_code == 200
+    assert all(p["id"] != post_id for p in listing.json())
+
+
+async def test_eml_download_outlook_headers(client, sample_lead):
+    create = await client.post(
+        f"/api/leads/{sample_lead.id}/updates",
+        json={
+            "titel": "Mail-test",
+            "body_internal": "Beste team,\n\nEen update.",
+            "mail_subject": "Subject van mail",
+            "mail_to": ["a@example.org", "b@example.org"],
+            "mail_cc": ["c@example.org"],
+        },
+    )
+    post_id = create.json()["id"]
+    eml = await client.get(f"/api/leads/{sample_lead.id}/updates/{post_id}/eml")
+    assert eml.status_code == 200
+    body = eml.text
+    assert "X-Unsent: 1" in body
+    assert "Subject: Subject van mail" in body
+    assert "a@example.org" in body
+    assert "b@example.org" in body
+    assert "Cc: c@example.org" in body
+    assert eml.headers["content-type"].startswith("message/rfc822")
+    assert "attachment" in eml.headers["content-disposition"].lower()
+
+
+async def test_parse_requires_input(client, sample_lead):
+    """Without raw_text, files, or use_lead_history we must 400."""
+    resp = await client.post(
+        f"/api/leads/{sample_lead.id}/updates/parse",
+        data={},
+    )
+    assert resp.status_code == 400
+
+
+async def test_unknown_lead_returns_404(client):
+    resp = await client.get(f"/api/leads/{uuid.uuid4()}/updates")
+    assert resp.status_code == 404

--- a/backend/tests/test_public_initiatief.py
+++ b/backend/tests/test_public_initiatief.py
@@ -210,6 +210,7 @@ async def test_casussen_only_visible_when_opted_in(client, db_session):
     assert casussen[0] == {
         "titel": "Pilot Gemeente Utrecht",
         "samenvatting": "We werken samen met Utrecht aan een pilot voor X.",
+        "updates": [],
     }
     # Internal title mag nooit lekken
     body_text = resp.text
@@ -248,8 +249,8 @@ async def test_casussen_response_shape_no_extra_lead_fields(client, db_session):
     )
     resp = await client.get("/api/public/initiatieven/by-slug/shape")
     casus = resp.json()["casussen"][0]
-    # Strikt: alleen titel + samenvatting
-    assert set(casus.keys()) == {"titel", "samenvatting"}
+    # Strikt: alleen titel + samenvatting + (lege) updates-feed.
+    assert set(casus.keys()) == {"titel", "samenvatting", "updates"}
     for forbidden in (
         "id",
         "initiatief_id",
@@ -261,3 +262,88 @@ async def test_casussen_response_shape_no_extra_lead_fields(client, db_session):
         "engagement_type",
     ):
         assert forbidden not in casus
+
+
+async def _create_lead_update(
+    db_session,
+    *,
+    lead_id: uuid.UUID,
+    titel: str,
+    body_internal: str | None = "Interne tekst (mag NIET lekken)",
+    body_public: str | None = "Korte publieke samenvatting",
+    published: bool = False,
+    mail_subject: str | None = "geheim onderwerp",
+    mail_to: list[str] | None = None,
+):
+    from bouwmeester.models.lead_update import LeadUpdatePost
+
+    post = LeadUpdatePost(
+        id=uuid.uuid4(),
+        lead_id=lead_id,
+        titel=titel,
+        body_internal=body_internal,
+        body_public=body_public,
+        mail_subject=mail_subject,
+        mail_to=mail_to or ["intern@team.nl"],
+        published_at=datetime.now(UTC) if published else None,
+    )
+    db_session.add(post)
+    await db_session.flush()
+    return post
+
+
+async def test_casus_published_updates_visible(client, db_session):
+    init = await _create_initiatief(
+        db_session, naam="Met updates", slug="met-updates", public=True
+    )
+    lead = await _create_lead(
+        db_session,
+        initiatief_id=init.id,
+        title="INTERN",
+        stage="eerste_gesprek",
+        public_visible=True,
+        public_title="Mijn casus",
+        public_summary="Korte samenvatting",
+    )
+    await _create_lead_update(
+        db_session, lead_id=lead.id, titel="Update 1", published=True
+    )
+    await _create_lead_update(
+        db_session, lead_id=lead.id, titel="Concept (mag niet lekken)", published=False
+    )
+
+    resp = await client.get("/api/public/initiatieven/by-slug/met-updates")
+    assert resp.status_code == 200
+    casus = resp.json()["casussen"][0]
+    assert len(casus["updates"]) == 1, "alleen gepubliceerde updates mogen lekken"
+    update = casus["updates"][0]
+    assert update["titel"] == "Update 1"
+    assert update["body_public"] == "Korte publieke samenvatting"
+    # Internal/mail-velden mogen nooit in de publieke response zitten.
+    assert "body_internal" not in update
+    assert "mail_subject" not in update
+    assert "mail_to" not in update
+
+
+async def test_casus_updates_skip_those_without_body_public(client, db_session):
+    init = await _create_initiatief(
+        db_session, naam="No body", slug="no-body", public=True
+    )
+    lead = await _create_lead(
+        db_session,
+        initiatief_id=init.id,
+        title="INTERN",
+        stage="eerste_gesprek",
+        public_visible=True,
+        public_title="Casus",
+    )
+    await _create_lead_update(
+        db_session,
+        lead_id=lead.id,
+        titel="Wel intern, geen publieke tekst",
+        body_public=None,
+        published=True,
+    )
+    resp = await client.get("/api/public/initiatieven/by-slug/no-body")
+    casus = resp.json()["casussen"][0]
+    assert casus["updates"] == []

--- a/frontend/src/api/leadUpdates.ts
+++ b/frontend/src/api/leadUpdates.ts
@@ -45,11 +45,17 @@ export async function deleteLeadUpdate(leadId: string, postId: string): Promise<
 
 export async function parseLeadUpdate(
   leadId: string,
-  options: { rawText?: string; useLeadHistory?: boolean; files?: File[] },
+  options: {
+    rawText?: string;
+    useLeadHistory?: boolean;
+    includeAttachments?: boolean;
+    files?: File[];
+  },
 ): Promise<LeadUpdateExtractResult> {
   const formData = new FormData();
   if (options.rawText) formData.append('raw_text', options.rawText);
   if (options.useLeadHistory) formData.append('use_lead_history', 'true');
+  if (options.includeAttachments) formData.append('include_attachments', 'true');
   if (options.files) {
     for (const file of options.files) formData.append('files', file);
   }

--- a/frontend/src/api/leadUpdates.ts
+++ b/frontend/src/api/leadUpdates.ts
@@ -1,0 +1,72 @@
+import { apiDelete, apiGet, apiPost, apiPut, BASE_URL, getCsrfToken } from '@/api/client';
+import type {
+  LeadUpdateExtractResult,
+  LeadUpdatePost,
+  LeadUpdatePostCreate,
+  LeadUpdatePostEdit,
+} from '@/types';
+
+export async function listLeadUpdates(leadId: string): Promise<LeadUpdatePost[]> {
+  return apiGet<LeadUpdatePost[]>(`/api/leads/${leadId}/updates`);
+}
+
+export async function createLeadUpdate(
+  leadId: string,
+  data: LeadUpdatePostCreate,
+): Promise<LeadUpdatePost> {
+  return apiPost<LeadUpdatePost>(`/api/leads/${leadId}/updates`, data);
+}
+
+export async function editLeadUpdate(
+  leadId: string,
+  postId: string,
+  data: LeadUpdatePostEdit,
+): Promise<LeadUpdatePost> {
+  return apiPut<LeadUpdatePost>(`/api/leads/${leadId}/updates/${postId}`, data);
+}
+
+export async function publishLeadUpdate(
+  leadId: string,
+  postId: string,
+): Promise<LeadUpdatePost> {
+  return apiPost<LeadUpdatePost>(`/api/leads/${leadId}/updates/${postId}/publish`);
+}
+
+export async function unpublishLeadUpdate(
+  leadId: string,
+  postId: string,
+): Promise<LeadUpdatePost> {
+  return apiPost<LeadUpdatePost>(`/api/leads/${leadId}/updates/${postId}/unpublish`);
+}
+
+export async function deleteLeadUpdate(leadId: string, postId: string): Promise<void> {
+  return apiDelete(`/api/leads/${leadId}/updates/${postId}`);
+}
+
+export async function parseLeadUpdate(
+  leadId: string,
+  options: { rawText?: string; useLeadHistory?: boolean; files?: File[] },
+): Promise<LeadUpdateExtractResult> {
+  const formData = new FormData();
+  if (options.rawText) formData.append('raw_text', options.rawText);
+  if (options.useLeadHistory) formData.append('use_lead_history', 'true');
+  if (options.files) {
+    for (const file of options.files) formData.append('files', file);
+  }
+  const url = `${BASE_URL}/api/leads/${leadId}/updates/parse`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'X-CSRF-Token': getCsrfToken() },
+    body: formData,
+    credentials: 'include',
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Parse failed: ${response.status} ${text}`);
+  }
+  return response.json();
+}
+
+export function getLeadUpdateEmlUrl(leadId: string, postId: string): string {
+  return `${BASE_URL}/api/leads/${leadId}/updates/${postId}/eml`;
+}

--- a/frontend/src/components/leads/LeadDetailPanel.tsx
+++ b/frontend/src/components/leads/LeadDetailPanel.tsx
@@ -27,6 +27,7 @@ import { RichTextDisplay } from '@/components/common/RichTextDisplay';
 import { LinkLeadNodeModal } from './LinkLeadNodeModal';
 import { AddLeadContactModal } from './AddLeadContactModal';
 import { LeadGitHubLinks } from './LeadGitHubLinks';
+import { LeadUpdatesSection } from './LeadUpdatesSection';
 import { MattermostChannelsSection } from '@/components/mattermost/MattermostChannelsSection';
 import { Badge } from '@/components/common/Badge';
 import { DetailSection } from '@/components/common/DetailSection';
@@ -798,6 +799,8 @@ export function LeadDetailPanel({ leadId, open, onClose, zIndex }: LeadDetailPan
               </DetailSection>
             );
           })()}
+
+          <LeadUpdatesSection leadId={lead.id} />
 
           {/* Tags */}
           {(leadTags ?? []).length > 0 && (

--- a/frontend/src/components/leads/LeadUpdatesSection.tsx
+++ b/frontend/src/components/leads/LeadUpdatesSection.tsx
@@ -1,0 +1,460 @@
+import { useState } from 'react';
+import { Megaphone, Mail, Sparkles, Trash2, Pencil, Globe, EyeOff, Upload } from 'lucide-react';
+
+import { Button } from '@/components/common/Button';
+import { ConfirmDialog } from '@/components/common/ConfirmDialog';
+import { DetailSection } from '@/components/common/DetailSection';
+import { RichTextFormField } from '@/components/common/RichTextFormField';
+import { getLeadUpdateEmlUrl } from '@/api/leadUpdates';
+import {
+  useCreateLeadUpdate,
+  useDeleteLeadUpdate,
+  useEditLeadUpdate,
+  useLeadUpdates,
+  useParseLeadUpdate,
+  usePublishLeadUpdate,
+  useUnpublishLeadUpdate,
+} from '@/hooks/useLeadUpdates';
+import { formatDateLong } from '@/utils/dates';
+import type { LeadUpdatePost } from '@/types';
+
+interface Draft {
+  titel: string;
+  body_internal: string;
+  body_public: string;
+  mail_subject: string;
+  mail_to: string[];
+  mail_cc: string[];
+  source_raw_text: string;
+}
+
+const emptyDraft = (): Draft => ({
+  titel: '',
+  body_internal: '',
+  body_public: '',
+  mail_subject: '',
+  mail_to: [],
+  mail_cc: [],
+  source_raw_text: '',
+});
+
+export function LeadUpdatesSection({ leadId }: { leadId: string }) {
+  const { data: posts = [] } = useLeadUpdates(leadId);
+  const createMutation = useCreateLeadUpdate();
+  const editMutation = useEditLeadUpdate();
+  const publishMutation = usePublishLeadUpdate();
+  const unpublishMutation = useUnpublishLeadUpdate();
+  const deleteMutation = useDeleteLeadUpdate();
+  const parseMutation = useParseLeadUpdate();
+
+  const [composing, setComposing] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [draft, setDraft] = useState<Draft>(emptyDraft());
+  const [rawText, setRawText] = useState('');
+  const [files, setFiles] = useState<File[]>([]);
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const concepts = posts.filter((p) => !p.published_at);
+  const published = posts.filter((p) => p.published_at);
+
+  const startCompose = () => {
+    setDraft(emptyDraft());
+    setRawText('');
+    setFiles([]);
+    setEditingId(null);
+    setComposing(true);
+    setError(null);
+  };
+
+  const startEdit = (post: LeadUpdatePost) => {
+    setDraft({
+      titel: post.titel,
+      body_internal: post.body_internal ?? '',
+      body_public: post.body_public ?? '',
+      mail_subject: post.mail_subject ?? '',
+      mail_to: post.mail_to ?? [],
+      mail_cc: post.mail_cc ?? [],
+      source_raw_text: '',
+    });
+    setRawText('');
+    setFiles([]);
+    setEditingId(post.id);
+    setComposing(true);
+    setError(null);
+  };
+
+  const cancel = () => {
+    setComposing(false);
+    setEditingId(null);
+    setError(null);
+  };
+
+  const runExtract = async (useLeadHistory: boolean) => {
+    setError(null);
+    try {
+      const result = await parseMutation.mutateAsync({
+        leadId,
+        rawText: rawText || undefined,
+        useLeadHistory,
+        files: files.length ? files : undefined,
+      });
+      setDraft((d) => ({
+        ...d,
+        titel: result.titel ?? d.titel,
+        body_internal: result.body_internal ?? d.body_internal,
+        body_public: result.body_public ?? d.body_public,
+        mail_subject: result.mail_subject ?? d.mail_subject,
+        mail_to: d.mail_to.length ? d.mail_to : result.suggested_to ?? [],
+        mail_cc: d.mail_cc.length ? d.mail_cc : result.suggested_cc ?? [],
+        source_raw_text: rawText,
+      }));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Onbekende fout bij AI-extract.');
+    }
+  };
+
+  const handleSave = async (publish: boolean) => {
+    if (!draft.titel.trim()) return;
+    const payload = {
+      titel: draft.titel,
+      body_internal: draft.body_internal || null,
+      body_public: draft.body_public || null,
+      mail_subject: draft.mail_subject || null,
+      mail_to: draft.mail_to.length ? draft.mail_to : null,
+      mail_cc: draft.mail_cc.length ? draft.mail_cc : null,
+    };
+    if (editingId) {
+      await editMutation.mutateAsync({ leadId, postId: editingId, data: payload });
+      if (publish) {
+        await publishMutation.mutateAsync({ leadId, postId: editingId });
+      }
+    } else {
+      await createMutation.mutateAsync({
+        leadId,
+        data: {
+          ...payload,
+          source_raw_text: draft.source_raw_text || null,
+          publish,
+        },
+      });
+    }
+    cancel();
+  };
+
+  const handleDelete = async () => {
+    if (!confirmDelete) return;
+    await deleteMutation.mutateAsync({ leadId, postId: confirmDelete });
+    setConfirmDelete(null);
+  };
+
+  return (
+    <DetailSection title="Updates" icon={<Megaphone className="h-3.5 w-3.5" />}>
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-xs text-text-secondary">
+          {posts.length === 0 ? 'Nog geen updates' : `${posts.length} totaal`}
+        </span>
+        {!composing && (
+          <Button variant="secondary" size="sm" onClick={startCompose}>
+            Nieuwe update
+          </Button>
+        )}
+      </div>
+
+      {composing && (
+        <div className="rounded-xl border border-border p-3 mb-3 space-y-3">
+          {!editingId && (
+            <div className="space-y-2 rounded-lg bg-surface-subtle p-2">
+              <label className="text-xs font-medium text-text-secondary">
+                Ruwe invoer (plak tekst, of upload bestand)
+              </label>
+              <textarea
+                value={rawText}
+                onChange={(e) => setRawText(e.target.value)}
+                rows={4}
+                placeholder="Plak hier een mailfragment, gespreksnotitie, of korte beschrijving..."
+                className="w-full text-sm rounded-lg border border-border px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary"
+              />
+              <div className="flex items-center gap-2 flex-wrap">
+                <label className="inline-flex items-center gap-1 text-xs cursor-pointer text-text-secondary hover:text-text">
+                  <Upload className="h-3.5 w-3.5" />
+                  Bestand toevoegen
+                  <input
+                    type="file"
+                    multiple
+                    accept=".pdf,.docx,.doc,.odt,.txt,image/*"
+                    className="hidden"
+                    onChange={(e) => setFiles(Array.from(e.target.files ?? []))}
+                  />
+                </label>
+                {files.length > 0 && (
+                  <span className="text-xs text-text-secondary">
+                    {files.map((f) => f.name).join(', ')}
+                  </span>
+                )}
+              </div>
+              <div className="flex items-center gap-2 flex-wrap">
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => runExtract(false)}
+                  disabled={
+                    parseMutation.isPending ||
+                    (!rawText.trim() && files.length === 0)
+                  }
+                >
+                  <Sparkles className="h-3.5 w-3.5 mr-1" />
+                  AI: extract uit invoer
+                </Button>
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => runExtract(true)}
+                  disabled={parseMutation.isPending}
+                  title="Genereer een update op basis van de lead-historie (notes, contacten, recente activity)"
+                >
+                  <Sparkles className="h-3.5 w-3.5 mr-1" />
+                  AI: uit lead-historie
+                </Button>
+                {parseMutation.isPending && (
+                  <span className="text-xs text-text-secondary">Bezig...</span>
+                )}
+              </div>
+              {error && <p className="text-xs text-red-600">{error}</p>}
+            </div>
+          )}
+
+          <input
+            type="text"
+            value={draft.titel}
+            onChange={(e) => setDraft({ ...draft, titel: e.target.value })}
+            placeholder="Titel"
+            className="w-full text-sm rounded-lg border border-border px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+
+          <RichTextFormField
+            label="Interne mailtekst (voor team)"
+            value={draft.body_internal}
+            onChange={(v) => setDraft({ ...draft, body_internal: v })}
+            rows={6}
+          />
+
+          <RichTextFormField
+            label="Publieke samenvatting (community-pagina)"
+            value={draft.body_public}
+            onChange={(v) => setDraft({ ...draft, body_public: v })}
+            rows={3}
+          />
+
+          <div className="grid grid-cols-1 gap-2">
+            <div>
+              <label className="text-xs font-medium text-text-secondary">
+                Mail-onderwerp
+              </label>
+              <input
+                type="text"
+                value={draft.mail_subject}
+                onChange={(e) => setDraft({ ...draft, mail_subject: e.target.value })}
+                className="w-full text-sm rounded-lg border border-border px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary"
+              />
+            </div>
+            <EmailListInput
+              label="To"
+              value={draft.mail_to}
+              onChange={(v) => setDraft({ ...draft, mail_to: v })}
+            />
+            <EmailListInput
+              label="Cc"
+              value={draft.mail_cc}
+              onChange={(v) => setDraft({ ...draft, mail_cc: v })}
+            />
+          </div>
+
+          <div className="flex justify-end gap-2">
+            <Button variant="secondary" size="sm" onClick={cancel}>
+              Annuleren
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => handleSave(false)}
+              disabled={!draft.titel.trim()}
+            >
+              Opslaan als concept
+            </Button>
+            <Button
+              size="sm"
+              onClick={() => handleSave(true)}
+              disabled={!draft.titel.trim()}
+            >
+              {editingId ? 'Opslaan + publiceren' : 'Direct publiceren'}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {concepts.length > 0 && (
+        <div className="mb-3">
+          <div className="text-xs text-text-secondary mb-1">Concepten</div>
+          <ul className="divide-y divide-border rounded-xl border border-border">
+            {concepts.map((post) => (
+              <UpdateRow
+                key={post.id}
+                leadId={leadId}
+                post={post}
+                onEdit={() => startEdit(post)}
+                onPublish={() =>
+                  publishMutation.mutate({ leadId, postId: post.id })
+                }
+                onUnpublish={() =>
+                  unpublishMutation.mutate({ leadId, postId: post.id })
+                }
+                onDelete={() => setConfirmDelete(post.id)}
+              />
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {published.length > 0 && (
+        <div>
+          <div className="text-xs text-text-secondary mb-1">Gepubliceerd</div>
+          <ul className="divide-y divide-border rounded-xl border border-border">
+            {published.map((post) => (
+              <UpdateRow
+                key={post.id}
+                leadId={leadId}
+                post={post}
+                onEdit={() => startEdit(post)}
+                onPublish={() =>
+                  publishMutation.mutate({ leadId, postId: post.id })
+                }
+                onUnpublish={() =>
+                  unpublishMutation.mutate({ leadId, postId: post.id })
+                }
+                onDelete={() => setConfirmDelete(post.id)}
+              />
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <ConfirmDialog
+        open={!!confirmDelete}
+        title="Update verwijderen?"
+        message="Weet je zeker dat je deze update wilt verwijderen?"
+        onConfirm={handleDelete}
+        onCancel={() => setConfirmDelete(null)}
+      />
+    </DetailSection>
+  );
+}
+
+function UpdateRow({
+  leadId,
+  post,
+  onEdit,
+  onPublish,
+  onUnpublish,
+  onDelete,
+}: {
+  leadId: string;
+  post: LeadUpdatePost;
+  onEdit: () => void;
+  onPublish: () => void;
+  onUnpublish: () => void;
+  onDelete: () => void;
+}) {
+  const isPublished = !!post.published_at;
+  return (
+    <li className="p-2 flex items-start gap-3">
+      <div className="flex-1 min-w-0">
+        <div className="text-sm font-medium truncate">{post.titel}</div>
+        <div className="text-xs text-text-secondary">
+          {isPublished
+            ? `Gepubliceerd ${formatDateLong(post.published_at!)}${post.published_by_naam ? ` · ${post.published_by_naam}` : ''}`
+            : `Concept · ${formatDateLong(post.created_at)}`}
+        </div>
+        {post.body_public && (
+          <div className="text-xs text-text-secondary mt-1 line-clamp-2 whitespace-pre-wrap">
+            {post.body_public}
+          </div>
+        )}
+      </div>
+      <div className="flex items-center gap-1 shrink-0">
+        <a
+          href={getLeadUpdateEmlUrl(leadId, post.id)}
+          download
+          className="inline-flex items-center text-xs text-text-secondary hover:text-text px-1.5 py-1 rounded hover:bg-surface-subtle"
+          title="Download .eml — opent als nieuw concept in Outlook (Windows) met onderwerp en ontvangers ingevuld"
+        >
+          <Mail className="h-3.5 w-3.5 mr-1" />
+          Outlook
+        </a>
+        <button
+          onClick={onEdit}
+          className="text-text-secondary hover:text-text p-1 rounded hover:bg-surface-subtle"
+          title="Bewerken"
+        >
+          <Pencil className="h-3.5 w-3.5" />
+        </button>
+        {isPublished ? (
+          <button
+            onClick={onUnpublish}
+            className="text-text-secondary hover:text-text p-1 rounded hover:bg-surface-subtle"
+            title="Depubliceren"
+          >
+            <EyeOff className="h-3.5 w-3.5" />
+          </button>
+        ) : (
+          <button
+            onClick={onPublish}
+            className="text-text-secondary hover:text-text p-1 rounded hover:bg-surface-subtle"
+            title="Publiceren"
+          >
+            <Globe className="h-3.5 w-3.5" />
+          </button>
+        )}
+        <button
+          onClick={onDelete}
+          className="text-text-secondary hover:text-red-600 p-1 rounded hover:bg-surface-subtle"
+          title="Verwijderen"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    </li>
+  );
+}
+
+function EmailListInput({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: string[];
+  onChange: (next: string[]) => void;
+}) {
+  const [text, setText] = useState(value.join(', '));
+  return (
+    <div>
+      <label className="text-xs font-medium text-text-secondary">{label}</label>
+      <input
+        type="text"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onBlur={() => {
+          const list = text
+            .split(/[,;\s]+/)
+            .map((s) => s.trim())
+            .filter(Boolean);
+          onChange(list);
+          setText(list.join(', '));
+        }}
+        placeholder="email@example.org, ..."
+        className="w-full text-sm rounded-lg border border-border px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary"
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/leads/LeadUpdatesSection.tsx
+++ b/frontend/src/components/leads/LeadUpdatesSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Megaphone, Mail, Sparkles, Trash2, Pencil, Globe, EyeOff, Upload } from 'lucide-react';
 
 import { Button } from '@/components/common/Button';
@@ -114,6 +114,9 @@ export function LeadUpdatesSection({ leadId }: { leadId: string }) {
         mail_cc: d.mail_cc.length ? d.mail_cc : result.suggested_cc ?? [],
         source_raw_text: rawText,
       }));
+      // Reset the upload list so the same files don't get re-sent on the
+      // next click; the extracted output is now in draft state.
+      setFiles([]);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Onbekende fout bij AI-extract.');
     }
@@ -292,14 +295,14 @@ export function LeadUpdatesSection({ leadId }: { leadId: string }) {
               variant="secondary"
               size="sm"
               onClick={() => handleSave(false)}
-              disabled={!draft.titel.trim()}
+              disabled={!draft.titel.trim() || parseMutation.isPending}
             >
               Opslaan als concept
             </Button>
             <Button
               size="sm"
               onClick={() => handleSave(true)}
-              disabled={!draft.titel.trim()}
+              disabled={!draft.titel.trim() || parseMutation.isPending}
             >
               {editingId ? 'Opslaan + publiceren' : 'Direct publiceren'}
             </Button>
@@ -453,6 +456,12 @@ function EmailListInput({
   onChange: (next: string[]) => void;
 }) {
   const [text, setText] = useState(value.join(', '));
+  // Sync local edit-text with the canonical value when the parent updates
+  // it (e.g. after AI suggested recipients land via setDraft). Without this
+  // the input keeps showing the previous string until the user focuses+blurs.
+  useEffect(() => {
+    setText(value.join(', '));
+  }, [value]);
   return (
     <div>
       <label className="text-xs font-medium text-text-secondary">{label}</label>

--- a/frontend/src/components/leads/LeadUpdatesSection.tsx
+++ b/frontend/src/components/leads/LeadUpdatesSection.tsx
@@ -52,6 +52,7 @@ export function LeadUpdatesSection({ leadId }: { leadId: string }) {
   const [draft, setDraft] = useState<Draft>(emptyDraft());
   const [rawText, setRawText] = useState('');
   const [files, setFiles] = useState<File[]>([]);
+  const [includeAttachments, setIncludeAttachments] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -62,6 +63,7 @@ export function LeadUpdatesSection({ leadId }: { leadId: string }) {
     setDraft(emptyDraft());
     setRawText('');
     setFiles([]);
+    setIncludeAttachments(false);
     setEditingId(null);
     setComposing(true);
     setError(null);
@@ -97,6 +99,9 @@ export function LeadUpdatesSection({ leadId }: { leadId: string }) {
         leadId,
         rawText: rawText || undefined,
         useLeadHistory,
+        // Lead-history mode pulls attachments automatically; for raw-input
+        // mode it's the user's choice via the checkbox.
+        includeAttachments: useLeadHistory ? false : includeAttachments,
         files: files.length ? files : undefined,
       });
       setDraft((d) => ({
@@ -193,6 +198,15 @@ export function LeadUpdatesSection({ leadId }: { leadId: string }) {
                   </span>
                 )}
               </div>
+              <label className="inline-flex items-center gap-1.5 text-xs text-text-secondary">
+                <input
+                  type="checkbox"
+                  checked={includeAttachments}
+                  onChange={(e) => setIncludeAttachments(e.target.checked)}
+                  className="rounded border-border"
+                />
+                Neem bestaande bijlagen op deze lead mee (screenshots, documenten)
+              </label>
               <div className="flex items-center gap-2 flex-wrap">
                 <Button
                   size="sm"
@@ -200,7 +214,7 @@ export function LeadUpdatesSection({ leadId }: { leadId: string }) {
                   onClick={() => runExtract(false)}
                   disabled={
                     parseMutation.isPending ||
-                    (!rawText.trim() && files.length === 0)
+                    (!rawText.trim() && files.length === 0 && !includeAttachments)
                   }
                 >
                   <Sparkles className="h-3.5 w-3.5 mr-1" />
@@ -211,7 +225,7 @@ export function LeadUpdatesSection({ leadId }: { leadId: string }) {
                   variant="secondary"
                   onClick={() => runExtract(true)}
                   disabled={parseMutation.isPending}
-                  title="Genereer een update op basis van de lead-historie (notes, contacten, recente activity)"
+                  title="Genereer een update op basis van notities, contacten, recente activity én bestaande bijlagen op deze lead"
                 >
                   <Sparkles className="h-3.5 w-3.5 mr-1" />
                   AI: uit lead-historie

--- a/frontend/src/components/leads/LeadUpdatesSection.tsx
+++ b/frontend/src/components/leads/LeadUpdatesSection.tsx
@@ -342,10 +342,12 @@ export function LeadUpdatesSection({ leadId }: { leadId: string }) {
       <ConfirmDialog
         open={!!confirmDelete}
         title="Update verwijderen?"
-        message="Weet je zeker dat je deze update wilt verwijderen?"
         onConfirm={handleDelete}
-        onCancel={() => setConfirmDelete(null)}
-      />
+        onClose={() => setConfirmDelete(null)}
+        variant="danger"
+      >
+        Weet je zeker dat je deze update wilt verwijderen?
+      </ConfirmDialog>
     </DetailSection>
   );
 }

--- a/frontend/src/hooks/useLeadUpdates.ts
+++ b/frontend/src/hooks/useLeadUpdates.ts
@@ -1,0 +1,100 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import {
+  createLeadUpdate,
+  deleteLeadUpdate,
+  editLeadUpdate,
+  listLeadUpdates,
+  parseLeadUpdate,
+  publishLeadUpdate,
+  unpublishLeadUpdate,
+} from '@/api/leadUpdates';
+import type {
+  LeadUpdateExtractResult,
+  LeadUpdatePost,
+  LeadUpdatePostCreate,
+  LeadUpdatePostEdit,
+} from '@/types';
+
+const queryKey = (leadId: string) => ['leadUpdates', leadId] as const;
+
+export function useLeadUpdates(leadId: string | null) {
+  return useQuery<LeadUpdatePost[]>({
+    queryKey: queryKey(leadId ?? ''),
+    queryFn: () => listLeadUpdates(leadId as string),
+    enabled: !!leadId,
+  });
+}
+
+export function useCreateLeadUpdate() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ leadId, data }: { leadId: string; data: LeadUpdatePostCreate }) =>
+      createLeadUpdate(leadId, data),
+    onSuccess: (_post, { leadId }) => {
+      qc.invalidateQueries({ queryKey: queryKey(leadId) });
+    },
+  });
+}
+
+export function useEditLeadUpdate() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      leadId,
+      postId,
+      data,
+    }: {
+      leadId: string;
+      postId: string;
+      data: LeadUpdatePostEdit;
+    }) => editLeadUpdate(leadId, postId, data),
+    onSuccess: (_post, { leadId }) => {
+      qc.invalidateQueries({ queryKey: queryKey(leadId) });
+    },
+  });
+}
+
+export function usePublishLeadUpdate() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ leadId, postId }: { leadId: string; postId: string }) =>
+      publishLeadUpdate(leadId, postId),
+    onSuccess: (_post, { leadId }) => {
+      qc.invalidateQueries({ queryKey: queryKey(leadId) });
+    },
+  });
+}
+
+export function useUnpublishLeadUpdate() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ leadId, postId }: { leadId: string; postId: string }) =>
+      unpublishLeadUpdate(leadId, postId),
+    onSuccess: (_post, { leadId }) => {
+      qc.invalidateQueries({ queryKey: queryKey(leadId) });
+    },
+  });
+}
+
+export function useDeleteLeadUpdate() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ leadId, postId }: { leadId: string; postId: string }) =>
+      deleteLeadUpdate(leadId, postId),
+    onSuccess: (_v, { leadId }) => {
+      qc.invalidateQueries({ queryKey: queryKey(leadId) });
+    },
+  });
+}
+
+export function useParseLeadUpdate() {
+  return useMutation<
+    LeadUpdateExtractResult,
+    Error,
+    { leadId: string; rawText?: string; useLeadHistory?: boolean; files?: File[] }
+  >({
+    mutationFn: ({ leadId, rawText, useLeadHistory, files }) =>
+      parseLeadUpdate(leadId, { rawText, useLeadHistory, files }),
+  });
+}

--- a/frontend/src/hooks/useLeadUpdates.ts
+++ b/frontend/src/hooks/useLeadUpdates.ts
@@ -92,9 +92,15 @@ export function useParseLeadUpdate() {
   return useMutation<
     LeadUpdateExtractResult,
     Error,
-    { leadId: string; rawText?: string; useLeadHistory?: boolean; files?: File[] }
+    {
+      leadId: string;
+      rawText?: string;
+      useLeadHistory?: boolean;
+      includeAttachments?: boolean;
+      files?: File[];
+    }
   >({
-    mutationFn: ({ leadId, rawText, useLeadHistory, files }) =>
-      parseLeadUpdate(leadId, { rawText, useLeadHistory, files }),
+    mutationFn: ({ leadId, rawText, useLeadHistory, includeAttachments, files }) =>
+      parseLeadUpdate(leadId, { rawText, useLeadHistory, includeAttachments, files }),
   });
 }

--- a/frontend/src/hooks/useLeadUpdates.ts
+++ b/frontend/src/hooks/useLeadUpdates.ts
@@ -16,11 +16,11 @@ import type {
   LeadUpdatePostEdit,
 } from '@/types';
 
-const queryKey = (leadId: string) => ['leadUpdates', leadId] as const;
+const queryKey = (leadId: string | null) => ['leadUpdates', leadId] as const;
 
 export function useLeadUpdates(leadId: string | null) {
   return useQuery<LeadUpdatePost[]>({
-    queryKey: queryKey(leadId ?? ''),
+    queryKey: queryKey(leadId),
     queryFn: () => listLeadUpdates(leadId as string),
     enabled: !!leadId,
   });

--- a/frontend/src/pages/PublicInitiatiefPage.tsx
+++ b/frontend/src/pages/PublicInitiatiefPage.tsx
@@ -237,6 +237,29 @@ function CasusCard({ casus, accent }: { casus: PublicCasus; accent: string }) {
           {casus.samenvatting}
         </p>
       )}
+      {casus.updates.length > 0 && (
+        <ul className="mt-4 space-y-3 border-t border-slate-100 pt-3">
+          {casus.updates.map((u, idx) => (
+            <li key={idx} className="text-sm">
+              <div className="flex items-baseline gap-2 mb-0.5">
+                <span className="font-medium text-slate-800">{u.titel}</span>
+                <span className="text-xs text-slate-400">
+                  {new Date(u.published_at).toLocaleDateString('nl-NL', {
+                    day: 'numeric',
+                    month: 'short',
+                    year: 'numeric',
+                  })}
+                </span>
+              </div>
+              {u.body_public && (
+                <p className="text-sm text-slate-600 leading-relaxed whitespace-pre-wrap">
+                  {u.body_public}
+                </p>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
     </li>
   );
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1993,9 +1993,62 @@ export interface PublicInitiatiefUpdate {
   published_by_naam: string | null;
 }
 
+export interface LeadUpdatePost {
+  id: string;
+  lead_id: string;
+  titel: string;
+  body_internal: string | null;
+  body_public: string | null;
+  mail_subject: string | null;
+  mail_to: string[] | null;
+  mail_cc: string[] | null;
+  published_at: string | null;
+  published_by_id: string | null;
+  published_by_naam: string | null;
+  created_at: string;
+  updated_at: string | null;
+}
+
+export interface LeadUpdatePostCreate {
+  titel: string;
+  body_internal?: string | null;
+  body_public?: string | null;
+  mail_subject?: string | null;
+  mail_to?: string[] | null;
+  mail_cc?: string[] | null;
+  source_raw_text?: string | null;
+  publish?: boolean;
+}
+
+export interface LeadUpdatePostEdit {
+  titel?: string;
+  body_internal?: string | null;
+  body_public?: string | null;
+  mail_subject?: string | null;
+  mail_to?: string[] | null;
+  mail_cc?: string[] | null;
+}
+
+export interface LeadUpdateExtractResult {
+  titel: string | null;
+  body_internal: string | null;
+  body_public: string | null;
+  mail_subject: string | null;
+  suggested_to: string[];
+  suggested_cc: string[];
+}
+
+export interface PublicLeadUpdate {
+  titel: string;
+  body_public: string | null;
+  published_at: string;
+  published_by_naam: string | null;
+}
+
 export interface PublicCasus {
   titel: string;
   samenvatting: string | null;
+  updates: PublicLeadUpdate[];
 }
 
 export interface PublicInitiatief {


### PR DESCRIPTION
## Wat

Per lead kun je nu updates schrijven met twee versies:

1. **Interne mailtekst** — uitgebreide versie voor het project-/trajectteam, downloadbaar als `.eml`. Outlook (Windows) opent die als nieuw, bewerkbaar concept met onderwerp en ontvangers ingevuld (dankzij de `X-Unsent: 1` header).
2. **Publieke samenvatting** — 1-3 zinnen die onder de bijbehorende casus verschijnen op de `/c/:slug` community-pagina van het initiatief.

## Hoe

Nieuwe sectie "Updates" in `LeadDetailPanel`. Compose-flow:

- Plak ruwe tekst, of drop bestand(en) (PDF/DOCX/TXT/afbeelding).
- Klik "AI: extract uit invoer" — LLM produceert titel + interne body + publieke body + mail-onderwerp.
- Of: "AI: uit lead-historie" — geen invoer nodig, model schrijft op basis van recente activities, contacten, initiatief-context.
- Bewerk vrij, sla op als concept of publiceer direct.
- Per update: download `.eml`, bewerken, (de)publiceren, verwijderen.

To-adressen worden voorgesteld op basis van lead-contacten met email; vrij bewerkbaar voor de download.

De prompt is generiek over alle initiatieven (niet hardcoded op één team) en krijgt initiatief-naam + beschrijving mee als grondslag.

## Test plan

- [ ] `just up && just migrate` — migratie loopt zonder errors
- [ ] Open een lead → "Nieuwe update" → plak tekst → "AI: extract" → vier velden gevuld
- [ ] Variant: lege invoer + "AI: uit lead-historie" — werkt op basis van bestaande notes
- [ ] Variant: PDF/DOCX/screenshot uploaden — geëxtraheerde tekst belandt in prompt
- [ ] "Direct publiceren" → publish-tijdstamp verschijnt
- [ ] "Outlook"-knop → `.eml` download → openen op Windows opent bewerkbaar concept met onderwerp + To/Cc + opgemaakte body
- [ ] Open `/c/{initiatief-slug}` zonder login — gepubliceerde update verschijnt onder de casus
- [ ] Update depubliceren → verdwijnt van publieke pagina, blijft als concept zichtbaar in lead-detail