### PR TITLE
Mattermost-ingest: download native file-uploads naar LeadAttachment

### DIFF
--- a/backend/bouwmeester/services/mattermost_ingest_service.py
+++ b/backend/bouwmeester/services/mattermost_ingest_service.py
@@ -452,6 +452,15 @@ class MattermostIngestService:
                         file_id=file_id,
                         meta=meta_by_id.get(file_id),
                     )
+                except ValueError:
+                    # Mattermost niet (volledig) geconfigureerd, bv. geen
+                    # bot-token. Niet zinvol om de loop af te maken; alle
+                    # volgende files zouden dezelfde error geven.
+                    logger.warning(
+                        "Mattermost niet geconfigureerd, sla %d file(s) over",
+                        len(file_ids),
+                    )
+                    return
                 except Exception:
                     logger.exception(
                         "Kon Mattermost-file %s voor lead %s niet ingesten",
@@ -490,7 +499,7 @@ class MattermostIngestService:
             logger.warning("Geen file-info voor %s, skip", file_id)
             return
 
-        claimed_ct = info.get("mime_type") or "application/octet-stream"
+        claimed_ct = (info.get("mime_type") or "application/octet-stream").lower()
         if claimed_ct not in ALLOWED_CONTENT_TYPES:
             logger.info(
                 "Mattermost-file %s heeft niet-toegestaan type %s, skip",

--- a/backend/bouwmeester/services/mattermost_ingest_service.py
+++ b/backend/bouwmeester/services/mattermost_ingest_service.py
@@ -3,8 +3,9 @@
 Per binnenkomend ``posted``-event:
 - skip bot-eigen berichten en niet-gekoppelde kanalen
 - match auteur via bestaande ``mattermost_user``-link
-- voor lead-scope met ``auto_note_enabled``: maak ``LeadActivity`` (note)
-  en haal doc-links op naar ``LeadAttachment(soort=link)``
+- voor lead-scope met ``auto_note_enabled``: maak ``LeadActivity`` (note),
+  haal doc-links op naar ``LeadAttachment(soort=link)`` en download
+  native Mattermost file-uploads naar ``LeadAttachment(soort=file)``
 - voor initiatief-scope met ``suggest_leads_enabled``: nog niet — komt in
   PR3 (hier alleen ``mattermost_post_link``-record)
 - altijd: schrijf ``mattermost_post_link`` zodat de post niet opnieuw
@@ -21,6 +22,13 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from bouwmeester.core.database import async_session
+from bouwmeester.core.storage import (
+    ALLOWED_CONTENT_TYPES,
+    MAX_UPLOAD_SIZE,
+    ensure_bijlagen_dir,
+    verify_content_type,
+    write_upload_to_disk,
+)
 from bouwmeester.models.initiatief import Initiatief
 from bouwmeester.models.lead import Lead
 from bouwmeester.models.lead_activity import LeadActivity
@@ -390,8 +398,140 @@ class MattermostIngestService:
             )
             if existing.scalar_one_or_none() is None:
                 self.session.add(attachment)
+
+        await self._ingest_post_files(lead_id=lead_id, post=post, post_id=post_id)
         await self.session.flush()
         return activity.id
+
+    async def _ingest_post_files(
+        self,
+        *,
+        lead_id: UUID,
+        post: dict,
+        post_id: str,
+    ) -> None:
+        """Download native Mattermost file-uploads naar ``LeadAttachment``.
+
+        Mattermost stuurt ``file_ids`` mee in ``posted``-events; de rijkere
+        ``metadata.files`` is niet altijd aanwezig maar bevat naam + mime
+        + size zodat we per-file één API-call kunnen besparen. Per file:
+
+        - haal info op (uit ``metadata.files`` of via ``get_file_info``)
+        - check tegen ``ALLOWED_CONTENT_TYPES``
+        - download met ``MAX_UPLOAD_SIZE`` cap
+        - magic-byte verificatie
+        - schrijf naar disk via bestaand storage-pad
+        - dedupe op ``(lead_id, source='mattermost', source_ref)`` waarbij
+          ``source_ref = "{post_id}:{file_id}"``
+
+        Per-file ``try/except`` zodat één rotte file de andere files en
+        de note zelf niet sloopt.
+        """
+        file_ids = post.get("file_ids") or []
+        if not file_ids:
+            return
+
+        # metadata.files (indien aanwezig) heeft naam/mime/size — dat
+        # bespaart een get_file_info-call per bestand.
+        meta_by_id: dict[str, dict] = {}
+        for f in (post.get("metadata") or {}).get("files") or []:
+            fid = f.get("id")
+            if fid:
+                meta_by_id[fid] = f
+
+        from bouwmeester.services.mattermost_service import MattermostService
+
+        service = MattermostService(self.session)
+        try:
+            for file_id in file_ids:
+                try:
+                    await self._ingest_one_file(
+                        service=service,
+                        lead_id=lead_id,
+                        post_id=post_id,
+                        file_id=file_id,
+                        meta=meta_by_id.get(file_id),
+                    )
+                except Exception:
+                    logger.exception(
+                        "Kon Mattermost-file %s voor lead %s niet ingesten",
+                        file_id,
+                        lead_id,
+                    )
+        finally:
+            await service.close()
+
+    async def _ingest_one_file(
+        self,
+        *,
+        service,
+        lead_id: UUID,
+        post_id: str,
+        file_id: str,
+        meta: dict | None,
+    ) -> None:
+        """Verwerk één file_id. Helper van ``_ingest_post_files`` zodat de
+        try/except-loop daar leesbaar blijft."""
+        source_ref = f"{post_id}:{file_id}"
+
+        # Dedupe vooraf — voorkomt overbodige download bij replay.
+        existing = await self.session.execute(
+            select(LeadAttachment.id).where(
+                LeadAttachment.lead_id == lead_id,
+                LeadAttachment.source == "mattermost",
+                LeadAttachment.source_ref == source_ref,
+            )
+        )
+        if existing.scalar_one_or_none() is not None:
+            return
+
+        info = meta or await service.get_file_info(file_id)
+        if not info:
+            logger.warning("Geen file-info voor %s, skip", file_id)
+            return
+
+        claimed_ct = info.get("mime_type") or "application/octet-stream"
+        if claimed_ct not in ALLOWED_CONTENT_TYPES:
+            logger.info(
+                "Mattermost-file %s heeft niet-toegestaan type %s, skip",
+                file_id,
+                claimed_ct,
+            )
+            return
+
+        content = await service.download_file(file_id, max_bytes=MAX_UPLOAD_SIZE)
+        if content is None:
+            return
+
+        if not verify_content_type(content, claimed_ct):
+            logger.info(
+                "Mattermost-file %s magic bytes komen niet overeen met %s, skip",
+                file_id,
+                claimed_ct,
+            )
+            return
+
+        leads_dir = ensure_bijlagen_dir() / "leads"
+        original_name = info.get("name") or f"bijlage-{file_id}"
+        filename, relative_path, _ = write_upload_to_disk(
+            content, original_name, leads_dir, item_id=lead_id
+        )
+        # write_upload_to_disk geeft pad relatief tot leads_dir; DB slaat
+        # op tov LEADS_BIJLAGEN_ROOT, dus pre-pend "leads/".
+        relative_path = f"leads/{relative_path}"
+
+        attachment = LeadAttachment(
+            lead_id=lead_id,
+            soort="file",
+            bestandsnaam=filename,
+            content_type=claimed_ct,
+            bestandsgrootte=len(content),
+            pad=relative_path,
+            source="mattermost",
+            source_ref=source_ref,
+        )
+        self.session.add(attachment)
+        await self.session.flush()
 
     async def _create_suggested_lead(
         self,

--- a/backend/bouwmeester/services/mattermost_service.py
+++ b/backend/bouwmeester/services/mattermost_service.py
@@ -501,6 +501,61 @@ class MattermostService:
         except httpx.HTTPError:
             return mattermost_user_id
 
+    async def get_file_info(self, file_id: str) -> dict | None:
+        """Haal metadata van een Mattermost-bestand op.
+
+        Returns ``None`` bij elke fout zodat de caller (ingest) een rotte
+        file kan overslaan zonder de hele post-verwerking te laten klappen.
+        """
+        client = await self._get_client()
+        try:
+            resp = await client.get(f"/api/v4/files/{file_id}/info")
+            resp.raise_for_status()
+            return resp.json()
+        except httpx.HTTPError:
+            logger.warning("Kon file-info voor %s niet ophalen", file_id)
+            return None
+
+    async def download_file(self, file_id: str, *, max_bytes: int) -> bytes | None:
+        """Download een Mattermost-bestand, met cap op ``max_bytes``.
+
+        Streamt zodat een veel-te-groot bestand niet eerst volledig in
+        geheugen geladen wordt. Bij overschrijden van ``max_bytes``,
+        netwerkfout, of niet-200-status returnen we ``None``. De caller
+        moet dan deze ene file overslaan.
+
+        Eigen timeout van 30s, ruimer dan de default 10s op het client-
+        niveau, omdat file-downloads merkbaar trager zijn dan API-calls.
+        """
+        client = await self._get_client()
+        try:
+            async with client.stream(
+                "GET",
+                f"/api/v4/files/{file_id}",
+                timeout=30.0,
+            ) as resp:
+                if resp.status_code != 200:
+                    logger.warning(
+                        "Download file %s gaf status %s",
+                        file_id,
+                        resp.status_code,
+                    )
+                    return None
+                buffer = bytearray()
+                async for chunk in resp.aiter_bytes():
+                    buffer.extend(chunk)
+                    if len(buffer) > max_bytes:
+                        logger.warning(
+                            "File %s overschrijdt max_bytes (%d), abort",
+                            file_id,
+                            max_bytes,
+                        )
+                        return None
+                return bytes(buffer)
+        except httpx.HTTPError:
+            logger.warning("Kon file %s niet downloaden", file_id)
+            return None
+
     async def is_bot_member_of_channel(self, channel_id: str) -> bool:
         """Check of de bot momenteel lid is van een kanaal.
 

--- a/backend/tests/test_mattermost_ingest.py
+++ b/backend/tests/test_mattermost_ingest.py
@@ -532,6 +532,363 @@ async def test_initiatief_channel_writes_only_post_link(db_session, sample_initi
 
 
 # ---------------------------------------------------------------------------
+# Native file-uploads
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def lead_bijlagen_tmp(tmp_path):
+    """Patch bijlagen-root voor ingest-file-tests zodat we niet naar
+    /data/bijlagen schrijven."""
+    from unittest.mock import patch
+
+    with patch("bouwmeester.core.storage.bijlagen_root", return_value=tmp_path):
+        yield tmp_path
+
+
+def _setup_lead_channel(db_session, lead) -> str:
+    cid = _id()
+    db_session.add(
+        MattermostChannelLink(
+            channel_id=cid,
+            channel_name="proj",
+            channel_display_name="Project",
+            scope_type=SCOPE_LEAD,
+            scope_id=lead.id,
+            auto_note_enabled=True,
+        )
+    )
+    return cid
+
+
+async def test_lead_channel_downloads_native_file_upload(
+    db_session, sample_lead, lead_bijlagen_tmp
+):
+    """post.file_ids met één PDF -> LeadAttachment(soort='file') + bytes
+    op disk, met juiste velden."""
+    from unittest.mock import AsyncMock, patch
+
+    cid = _setup_lead_channel(db_session, sample_lead)
+    await db_session.flush()
+
+    pdf_bytes = b"%PDF-1.4 fake"
+
+    ingest = MattermostIngestService(db_session)
+    post = {
+        "id": _id(),
+        "channel_id": cid,
+        "user_id": _id(),
+        "create_at": 1_700_000_000_000,
+        "message": "Hier het rapport.",
+        "file_ids": ["fid1"],
+        "metadata": {
+            "files": [
+                {
+                    "id": "fid1",
+                    "name": "rapport.pdf",
+                    "mime_type": "application/pdf",
+                    "size": len(pdf_bytes),
+                }
+            ]
+        },
+    }
+
+    with patch(
+        "bouwmeester.services.mattermost_service.MattermostService.download_file",
+        new=AsyncMock(return_value=pdf_bytes),
+    ):
+        await ingest.ingest_post(post)
+
+    attachments = (
+        (
+            await db_session.execute(
+                select(LeadAttachment).where(
+                    LeadAttachment.lead_id == sample_lead.id,
+                    LeadAttachment.soort == "file",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(attachments) == 1
+    att = attachments[0]
+    assert att.bestandsnaam == "rapport.pdf"
+    assert att.content_type == "application/pdf"
+    assert att.bestandsgrootte == len(pdf_bytes)
+    assert att.source == "mattermost"
+    assert att.source_ref == f"{post['id']}:fid1"
+    assert att.pad is not None
+    assert att.pad.startswith("leads/")
+
+    # Bestand staat op disk en is leesbaar.
+    on_disk = lead_bijlagen_tmp / att.pad
+    assert on_disk.exists()
+    assert on_disk.read_bytes() == pdf_bytes
+
+
+async def test_lead_channel_dedupes_native_file_upload(
+    db_session, sample_lead, lead_bijlagen_tmp
+):
+    """Twee keer dezelfde post-id+file-id geeft maar één LeadAttachment."""
+    from unittest.mock import AsyncMock, patch
+
+    cid = _setup_lead_channel(db_session, sample_lead)
+    await db_session.flush()
+
+    pdf_bytes = b"%PDF-1.4 fake"
+    post_id_str = _id()
+    post = {
+        "id": post_id_str,
+        "channel_id": cid,
+        "user_id": _id(),
+        "create_at": 1_700_000_000_000,
+        "message": "rapport",
+        "file_ids": ["fidA"],
+        "metadata": {
+            "files": [
+                {
+                    "id": "fidA",
+                    "name": "x.pdf",
+                    "mime_type": "application/pdf",
+                    "size": len(pdf_bytes),
+                }
+            ]
+        },
+    }
+
+    ingest = MattermostIngestService(db_session)
+    with patch(
+        "bouwmeester.services.mattermost_service.MattermostService.download_file",
+        new=AsyncMock(return_value=pdf_bytes),
+    ):
+        # Eerste keer via volledige ingest_post (post_link wordt aangemaakt).
+        await ingest.ingest_post(post)
+        # Tweede keer alleen de file-helper aanroepen — simuleert recovery
+        # waar dezelfde file op een al-bekende post nog eens binnenkomt.
+        await ingest._ingest_post_files(
+            lead_id=sample_lead.id, post=post, post_id=post_id_str
+        )
+
+    attachments = (
+        (
+            await db_session.execute(
+                select(LeadAttachment).where(
+                    LeadAttachment.lead_id == sample_lead.id,
+                    LeadAttachment.soort == "file",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(attachments) == 1
+
+
+async def test_lead_channel_skips_disallowed_file_type(
+    db_session, sample_lead, lead_bijlagen_tmp
+):
+    """mime_type=application/x-msdownload -> geen file-attachment, maar
+    note + post_link gaan wel door. download_file wordt niet aangeroepen."""
+    from unittest.mock import AsyncMock, patch
+
+    cid = _setup_lead_channel(db_session, sample_lead)
+    await db_session.flush()
+
+    download = AsyncMock(return_value=b"MZ")
+    post = {
+        "id": _id(),
+        "channel_id": cid,
+        "user_id": _id(),
+        "create_at": 1_700_000_000_000,
+        "message": "kijk eens",
+        "file_ids": ["badfid"],
+        "metadata": {
+            "files": [
+                {
+                    "id": "badfid",
+                    "name": "evil.exe",
+                    "mime_type": "application/x-msdownload",
+                    "size": 2,
+                }
+            ]
+        },
+    }
+
+    ingest = MattermostIngestService(db_session)
+    with patch(
+        "bouwmeester.services.mattermost_service.MattermostService.download_file",
+        new=download,
+    ):
+        await ingest.ingest_post(post)
+
+    file_attachments = (
+        (
+            await db_session.execute(
+                select(LeadAttachment).where(
+                    LeadAttachment.lead_id == sample_lead.id,
+                    LeadAttachment.soort == "file",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert file_attachments == []
+    # Allowlist-check vóór download zodat we geen MM-bandwidth verbranden.
+    download.assert_not_called()
+    # Note + post_link bestaan wel.
+    activity = (
+        await db_session.execute(
+            select(LeadActivity).where(LeadActivity.lead_id == sample_lead.id)
+        )
+    ).scalar_one()
+    assert activity.activity_type == "note"
+    post_link = (
+        await db_session.execute(
+            select(MattermostPostLink).where(MattermostPostLink.post_id == post["id"])
+        )
+    ).scalar_one()
+    assert post_link.lead_activity_id == activity.id
+
+
+async def test_lead_channel_one_corrupt_file_does_not_block_others(
+    db_session, sample_lead, lead_bijlagen_tmp
+):
+    """Twee files: één goed, één breekt. Goede komt door, de hele post
+    crasht niet."""
+    from unittest.mock import AsyncMock, patch
+
+    cid = _setup_lead_channel(db_session, sample_lead)
+    await db_session.flush()
+
+    good_bytes = b"%PDF-1.4 ok"
+
+    async def fake_download(file_id, *, max_bytes):
+        if file_id == "good":
+            return good_bytes
+        return None
+
+    post = {
+        "id": _id(),
+        "channel_id": cid,
+        "user_id": _id(),
+        "create_at": 1_700_000_000_000,
+        "message": "twee bestanden",
+        "file_ids": ["good", "broken"],
+        "metadata": {
+            "files": [
+                {
+                    "id": "good",
+                    "name": "ok.pdf",
+                    "mime_type": "application/pdf",
+                    "size": len(good_bytes),
+                },
+                {
+                    "id": "broken",
+                    "name": "stuk.pdf",
+                    "mime_type": "application/pdf",
+                    "size": 999,
+                },
+            ]
+        },
+    }
+
+    ingest = MattermostIngestService(db_session)
+    with patch(
+        "bouwmeester.services.mattermost_service.MattermostService.download_file",
+        new=AsyncMock(side_effect=fake_download),
+    ):
+        await ingest.ingest_post(post)
+
+    attachments = (
+        (
+            await db_session.execute(
+                select(LeadAttachment).where(
+                    LeadAttachment.lead_id == sample_lead.id,
+                    LeadAttachment.soort == "file",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(attachments) == 1
+    assert attachments[0].bestandsnaam == "ok.pdf"
+    assert attachments[0].source_ref == f"{post['id']}:good"
+
+    # Note + post_link gaan ook gewoon door.
+    activity = (
+        await db_session.execute(
+            select(LeadActivity).where(LeadActivity.lead_id == sample_lead.id)
+        )
+    ).scalar_one()
+    assert activity.activity_type == "note"
+    post_link = (
+        await db_session.execute(
+            select(MattermostPostLink).where(MattermostPostLink.post_id == post["id"])
+        )
+    ).scalar_one()
+    assert post_link.lead_activity_id == activity.id
+
+
+async def test_lead_channel_falls_back_to_get_file_info(
+    db_session, sample_lead, lead_bijlagen_tmp
+):
+    """Zonder metadata.files moet ingest get_file_info aanroepen voor naam +
+    mime."""
+    from unittest.mock import AsyncMock, patch
+
+    cid = _setup_lead_channel(db_session, sample_lead)
+    await db_session.flush()
+
+    pdf_bytes = b"%PDF-1.4 fb"
+    info = AsyncMock(
+        return_value={
+            "id": "fidZ",
+            "name": "fallback.pdf",
+            "mime_type": "application/pdf",
+            "size": len(pdf_bytes),
+        }
+    )
+    download = AsyncMock(return_value=pdf_bytes)
+
+    post = {
+        "id": _id(),
+        "channel_id": cid,
+        "user_id": _id(),
+        "create_at": 1_700_000_000_000,
+        "message": "geen metadata",
+        "file_ids": ["fidZ"],
+        # Geen "metadata"-key — dwingt fallback naar get_file_info.
+    }
+
+    ingest = MattermostIngestService(db_session)
+    with (
+        patch(
+            "bouwmeester.services.mattermost_service.MattermostService.get_file_info",
+            new=info,
+        ),
+        patch(
+            "bouwmeester.services.mattermost_service.MattermostService.download_file",
+            new=download,
+        ),
+    ):
+        await ingest.ingest_post(post)
+
+    info.assert_called_once_with("fidZ")
+    att = (
+        await db_session.execute(
+            select(LeadAttachment).where(
+                LeadAttachment.lead_id == sample_lead.id,
+                LeadAttachment.soort == "file",
+            )
+        )
+    ).scalar_one()
+    assert att.bestandsnaam == "fallback.pdf"
+
+
+# ---------------------------------------------------------------------------
 # DM-pad: link-codes via websocket-event ipv polling
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_mattermost_ingest.py
+++ b/backend/tests/test_mattermost_ingest.py
@@ -630,7 +630,9 @@ async def test_lead_channel_downloads_native_file_upload(
 async def test_lead_channel_dedupes_native_file_upload(
     db_session, sample_lead, lead_bijlagen_tmp
 ):
-    """Twee keer dezelfde post-id+file-id geeft maar één LeadAttachment."""
+    """De pre-download dedupe-check in _ingest_one_file voorkomt dubbele
+    LeadAttachments bij replay op dezelfde (post_id, file_id), zelfs als
+    de outer post_link short-circuit niet greep (bv. directe call)."""
     from unittest.mock import AsyncMock, patch
 
     cid = _setup_lead_channel(db_session, sample_lead)


### PR DESCRIPTION
## Summary
- Posts in lead-gekoppelde Mattermost-kanalen met `file_ids` worden gedownload en als `LeadAttachment(soort='file')` aan de lead gehangen, naast de bestaande doc-link-extractie.
- Hergebruikt het storage-pad van de bestaande lead-upload-route: `ALLOWED_CONTENT_TYPES`-allowlist, `verify_content_type` magic-byte check, `MAX_UPLOAD_SIZE` (20 MB) cap, en `write_upload_to_disk` voor het schrijven onder `leads/<lead_id>/<uuid>_<safe_name>`.
- Dedupe op `(lead_id, source='mattermost', source_ref="<post_id>:<file_id>")` zodat replay/recovery niet dupliceert.
- Eén rotte file blokkeert de andere files of de note niet (per-file try/except).
- Geen migratie: `LeadAttachment` heeft `pad`/`content_type`/`bestandsgrootte`/`source`/`source_ref` al.
- `MattermostService` krijgt twee nieuwe helpers: `get_file_info` (metadata) en `download_file` (streamend, met cap en eigen 30s timeout, los van de default 10s op API-calls).

## Buiten scope
- Edits (`post_edited`-events): de bestaande `MattermostPostLink.post_id` uniqueness short-circuit voorkomt herverwerking sowieso. Aparte PR als we late-attached files willen meepikken.
- VLAM-extractie van geuploade PDFs/images: blijft een aparte follow-up.

## Test plan
- [x] Backend pre-commit hooks groen (ruff, eslint, tsc).
- [x] 5 nieuwe tests in `test_mattermost_ingest.py` slagen lokaal.
- [x] Bestaande `test_mattermost_ingest.py`-tests blijven groen (op één pre-existing flaky `test_lead_channel_renders_at_mentions_as_tiptap` na, niet door deze PR veroorzaakt).
- [x] `test_route_authorization_inventory.py` + `test_mattermost.py` groen.
- [ ] Manuele test in dev-omgeving: PDF aanhangen in een gekoppeld kanaal en verifiëren dat hij in de lead-detailweergave verschijnt met "via mm"-badge en download-knop.