### PR TITLE
Reconciliation merge: FK-introspectie + orphan-scan voor CJIB-achtige duplicaten

### DIFF
--- a/backend/bouwmeester/api/routes/admin_sync.py
+++ b/backend/bouwmeester/api/routes/admin_sync.py
@@ -13,6 +13,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from bouwmeester.core.database import get_db
 from bouwmeester.core.permissions import require_permission
+from bouwmeester.services.detect_orphan_handmatig import (
+    detect_orphan_handmatig_matches,
+)
 from bouwmeester.services.kabinet_scrape import write_kabinet_yaml
 from bouwmeester.services.kabinet_sync import sync_kabinet
 from bouwmeester.services.ministeries_csv_sync import sync_ministeries_csv
@@ -141,6 +144,28 @@ async def trigger_tooi(
         "soft_deleted": stats.soft_deleted,
         "conflicts": stats.conflicts,
         "skipped_sanity": stats.skipped_sanity,
+    }
+
+
+@router.post(
+    "/orphan-handmatig",
+    summary="Detecteer handmatige rijen die alsnog matchen op een TOOI-rij",
+)
+async def trigger_orphan_handmatig_scan(
+    db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("org:manage")),
+) -> dict:
+    """Vind handmatige rijen (FCC-import zonder YAML-entry) die op afkorting
+    of genormaliseerde naam matchen met een TOOI-rij. Genereert
+    PendingReconciliation-rijen voor elke kandidaat zodat de admin ze
+    via Beheer > Reconciliatie kan mergen.
+    """
+    stats = await detect_orphan_handmatig_matches(db)
+    return {
+        "scanned": stats.scanned,
+        "found_match": stats.found_match,
+        "new_reconciliations": stats.new_reconciliations,
+        "already_pending": stats.already_pending,
     }
 
 

--- a/backend/bouwmeester/api/routes/reconciliation.py
+++ b/backend/bouwmeester/api/routes/reconciliation.py
@@ -110,9 +110,21 @@ async def merge_reconciliation(
     perm_ctx: PermissionContext = Depends(get_permission_context),
     _perm=Depends(require_permission("org:manage")),
 ) -> dict:
-    """Merge: alle plaatsingen van handmatige rij naar TOOI-rij,
-    afkorting/website overzetten, handmatige rij verwijderen."""
-    rec = await db.get(PendingReconciliation, rec_id)
+    """Merge: alle referenties (plaatsingen, leads, opdrachten, children,
+    permissions, modules, namen, parents, polymorphic resource_id-velden)
+    van de handmatige rij gaan over naar de TOOI-rij. Handmatige rij wordt
+    verwijderd."""
+    # Lock de reconciliation-row zodat twee gelijktijdige admins niet
+    # allebei een half-merge proberen. Wachten op de lock duurt typisch
+    # milliseconden; de tweede request ziet daarna status='merged' en
+    # krijgt 404.
+    rec = (
+        await db.execute(
+            select(PendingReconciliation)
+            .where(PendingReconciliation.id == rec_id)
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
     if rec is None or rec.status != "open":
         raise HTTPException(status_code=404, detail="Reconciliation niet gevonden")
     if rec.resource_type != "organisatie_eenheid":
@@ -143,13 +155,8 @@ async def merge_reconciliation(
         kandidaat.beschrijving = handmatig.beschrijving
     await db.flush()
 
-    # FK-rewrite via introspectie + delete bron-rij. Dit dekt
-    # parent_id (children van handmatige BZK), resource_permission,
-    # eenheid_module, role, task, corpus_node, opdracht (beide rollen),
-    # shared_access en alles wat we nog vergeten zijn.
     rewritten = await merge_organisatie_eenheden(db, handmatig.id, kandidaat.id)
 
-    # Markeer reconciliation als opgelost.
     rec.status = "merged"
     rec.resolved_by = perm_ctx.person_id
     rec.resolved_at = datetime.now()

--- a/backend/bouwmeester/api/routes/reconciliation.py
+++ b/backend/bouwmeester/api/routes/reconciliation.py
@@ -18,7 +18,7 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, ConfigDict
-from sqlalchemy import select, update
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from bouwmeester.core.database import get_db
@@ -29,7 +29,9 @@ from bouwmeester.core.permissions import (
 )
 from bouwmeester.models.organisatie_eenheid import OrganisatieEenheid
 from bouwmeester.models.pending_reconciliation import PendingReconciliation
-from bouwmeester.models.person_organisatie import PersonOrganisatieEenheid
+from bouwmeester.services.merge_organisatie_eenheden import (
+    merge_organisatie_eenheden,
+)
 
 log = logging.getLogger(__name__)
 
@@ -128,14 +130,9 @@ async def merge_reconciliation(
             detail="Een van beide rijen bestaat niet meer; reconciliation is stale",
         )
 
-    # Verplaats alle plaatsingen van handmatig naar kandidaat
-    await db.execute(
-        update(PersonOrganisatieEenheid)
-        .where(PersonOrganisatieEenheid.organisatie_eenheid_id == handmatig.id)
-        .values(organisatie_eenheid_id=kandidaat.id)
-    )
-
-    # Vul ontbrekende velden op kandidaat met handmatige data
+    # Vul ontbrekende velden op kandidaat met handmatige data vóór de
+    # source-rij wordt verwijderd. afkorting/website/kvk/beschrijving zijn
+    # de velden die TOOI niet levert maar handmatig vaak wel.
     if not kandidaat.afkorting and handmatig.afkorting:
         kandidaat.afkorting = handmatig.afkorting
     if not kandidaat.website and handmatig.website:
@@ -144,34 +141,30 @@ async def merge_reconciliation(
         kandidaat.kvk_nummer = handmatig.kvk_nummer
     if not kandidaat.beschrijving and handmatig.beschrijving:
         kandidaat.beschrijving = handmatig.beschrijving
+    await db.flush()
 
-    # Lead/Opdracht refs migreren — Lead.organisatie_eenheid_id en
-    # Opdracht.opdrachtnemer_eenheid_id wijzen mogelijk nog naar handmatig.
-    from bouwmeester.models.lead import Lead
-    from bouwmeester.models.opdracht import Opdracht
+    # FK-rewrite via introspectie + delete bron-rij. Dit dekt
+    # parent_id (children van handmatige BZK), resource_permission,
+    # eenheid_module, role, task, corpus_node, opdracht (beide rollen),
+    # shared_access en alles wat we nog vergeten zijn.
+    rewritten = await merge_organisatie_eenheden(db, handmatig.id, kandidaat.id)
 
-    await db.execute(
-        update(Lead)
-        .where(Lead.organisatie_eenheid_id == handmatig.id)
-        .values(organisatie_eenheid_id=kandidaat.id)
-    )
-    await db.execute(
-        update(Opdracht)
-        .where(Opdracht.opdrachtnemer_eenheid_id == handmatig.id)
-        .values(opdrachtnemer_eenheid_id=kandidaat.id)
-    )
-
-    # Markeer reconciliation als opgelost en delete handmatige rij
+    # Markeer reconciliation als opgelost.
     rec.status = "merged"
     rec.resolved_by = perm_ctx.person_id
     rec.resolved_at = datetime.now()
-    await db.delete(handmatig)
 
     await db.commit()
-    log.info("Reconciliation %s gemerged in kandidaat %s", rec_id, kandidaat.id)
+    log.info(
+        "Reconciliation %s gemerged in kandidaat %s; FK-rewrites: %s",
+        rec_id,
+        kandidaat.id,
+        rewritten,
+    )
     return {
         "status": "merged",
         "doelrij_id": str(kandidaat.id),
+        "rewritten": rewritten,
     }
 
 

--- a/backend/bouwmeester/services/detect_orphan_handmatig.py
+++ b/backend/bouwmeester/services/detect_orphan_handmatig.py
@@ -1,0 +1,191 @@
+"""Detect handmatige rijen die alsnog matchen op een TOOI-rij.
+
+After the ExterneOrganisatie elimination migration, FCC-imports zonder
+YAML-entry zijn als bron='handmatig' onder de "Marktpartijen en overige"
+synthetische groep beland — ook als er een TOOI-rij met dezelfde
+afkorting of naam bestaat. Voorbeeld: CJIB. De FCC had naam 'CJIB',
+TOOI heeft 'Centraal Justitieel Incassobureau' met afkorting 'CJIB'.
+
+Deze service zoekt zulke duplicaten op en maakt PendingReconciliation-
+rijen aan zodat de admin ze via Beheer > Reconciliatie kan mergen
+met dezelfde merge_organisatie_eenheden() helper.
+
+Match-strategie (in volgorde, eerste hit wint):
+  1. afkorting case-insensitive exact (sterkst — 'CJIB' = 'CJIB')
+  2. genormaliseerde naam (lower + trim + strip 'ministerie van' / 'agentschap')
+
+Skipt rijen die al een open reconciliation hebben.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+
+from sqlalchemy import and_, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bouwmeester.models.organisatie_eenheid import OrganisatieEenheid
+from bouwmeester.models.pending_reconciliation import PendingReconciliation
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class OrphanScanStats:
+    scanned: int
+    found_match: int
+    new_reconciliations: int
+    already_pending: int
+
+
+def _normalize_name(naam: str) -> str:
+    n = " ".join(naam.lower().split())
+    for prefix in (
+        "ministerie van ",
+        "directoraat-generaal ",
+        "directoraat generaal ",
+        "dg ",
+        "agentschap ",
+        "zbo ",
+        "stichting ",
+    ):
+        if n.startswith(prefix):
+            n = n[len(prefix) :]
+            break
+    return n.strip()
+
+
+async def _existing_open_for_handmatig(
+    session: AsyncSession, handmatig_id: uuid.UUID
+) -> PendingReconciliation | None:
+    return (
+        await session.execute(
+            select(PendingReconciliation).where(
+                PendingReconciliation.handmatige_id == handmatig_id,
+                PendingReconciliation.status == "open",
+            )
+        )
+    ).scalar_one_or_none()
+
+
+async def detect_orphan_handmatig_matches(
+    session: AsyncSession, *, commit: bool = True
+) -> OrphanScanStats:
+    """Scan handmatige rijen op kandidaat-TOOI-matches.
+
+    Doelgroep: rijen met bron='handmatig' die geen tooi_uri hebben.
+    Voor elke rij wordt gezocht naar TOOI-kandidaten op afkorting (CI)
+    of genormaliseerde naam. Bij een hit komt er een
+    PendingReconciliation-rij. Reeds open reconciliations worden
+    overgeslagen.
+    """
+    handmatig_rows = (
+        (
+            await session.execute(
+                select(OrganisatieEenheid).where(
+                    OrganisatieEenheid.bron == "handmatig",
+                    OrganisatieEenheid.tooi_uri.is_(None),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    stats = OrphanScanStats(
+        scanned=len(handmatig_rows),
+        found_match=0,
+        new_reconciliations=0,
+        already_pending=0,
+    )
+
+    for handmatig in handmatig_rows:
+        afk = (handmatig.afkorting or "").strip()
+        norm = _normalize_name(handmatig.naam)
+        if not afk and not norm:
+            continue
+
+        # Bouw query: afkorting CI exact OR naam ILIKE (om kandidaten
+        # met dezelfde 'kern' op te halen). Definitieve match-check op
+        # genormaliseerde naam doen we daarna in Python omdat de
+        # prefix-stripping niet in SQL is uit te drukken.
+        conditions = []
+        if afk:
+            conditions.append(OrganisatieEenheid.afkorting.ilike(afk))
+        if norm:
+            # ILIKE %norm% pakt 'agentschap X', 'DG X', 'X (AFK)' etc. zonder
+            # dat we vooraf alle prefix-varianten hoeven op te sommen.
+            conditions.append(OrganisatieEenheid.naam.ilike(f"%{norm}%"))
+
+        if not conditions:
+            continue
+
+        kandidaten = (
+            (
+                await session.execute(
+                    select(OrganisatieEenheid).where(
+                        and_(
+                            OrganisatieEenheid.bron == "tooi",
+                            OrganisatieEenheid.id != handmatig.id,
+                            or_(*conditions),
+                        )
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        # Afkorting wint van naam-match — minder vals-positief.
+        kandidaat: OrganisatieEenheid | None = None
+        match_reden = ""
+        if afk:
+            for kand in kandidaten:
+                if (kand.afkorting or "").strip().lower() == afk.lower():
+                    kandidaat = kand
+                    match_reden = "afkorting_ci"
+                    break
+        if kandidaat is None and norm:
+            for kand in kandidaten:
+                if _normalize_name(kand.naam) == norm:
+                    kandidaat = kand
+                    match_reden = "naam_normalized"
+                    break
+
+        if kandidaat is None:
+            continue
+
+        stats.found_match += 1
+
+        existing = await _existing_open_for_handmatig(session, handmatig.id)
+        if existing is not None:
+            stats.already_pending += 1
+            continue
+
+        rec = PendingReconciliation(
+            id=uuid.uuid4(),
+            resource_type="organisatie_eenheid",
+            handmatige_id=handmatig.id,
+            kandidaat_id=kandidaat.id,
+            kandidaat_bron="tooi",
+            match_reden=match_reden,
+            status="open",
+        )
+        session.add(rec)
+        stats.new_reconciliations += 1
+        log.info(
+            "Orphan-match: handmatig %s '%s' (afk=%s) -> TOOI %s '%s' (%s)",
+            handmatig.id,
+            handmatig.naam,
+            handmatig.afkorting,
+            kandidaat.id,
+            kandidaat.naam,
+            match_reden,
+        )
+
+    if commit:
+        await session.commit()
+    else:
+        await session.flush()
+    return stats

--- a/backend/bouwmeester/services/merge_organisatie_eenheden.py
+++ b/backend/bouwmeester/services/merge_organisatie_eenheden.py
@@ -1,19 +1,26 @@
 """Merge twee OrganisatieEenheid-rijen door alle FK's te rewriten.
 
-The reconciliation merge endpoint used to migrate only three FK columns
-(person_organisatie_eenheid, lead, opdracht.opdrachtnemer_eenheid_id) and
-then delete the source row. That fails on rows with children (parent_id
-RESTRICT) or any FK that wasn't explicitly listed — the BZK row in prod
-has sub-DGs, members, eenheid_modules, resource_permissions, etc.
+Vindt via pg_catalog elke FK-kolom die naar organisatie_eenheid.id wijst en
+rewrite die in één transactie. Nieuwe FK-kolommen in toekomstige models
+worden automatisch opgepakt.
 
-This helper introspects pg_catalog to find every FK column referencing
-organisatie_eenheid.id and rewrites them in one transaction. New FK
-columns added to other models are picked up automatically.
+Drie soorten unique-handling, want naïef UPDATE faalt op:
 
-Dedup-logic for tables with unique constraints (eenheid_module on
-organisatie_eenheid_id+module_key, org_naam on eenheid_id+naam,
-org_email_domein on organisatie_eenheid_id+domein): pre-delete rows on
-the source that would conflict with rows already on the target.
+  * Composite unique (eenheid_module.uq op (OE_id, module)): pre-delete
+    source-rijen waarvan (target_id, other_cols) al op target bestaat.
+  * Partial unique 'één actief per FK' (org_naam, org_parent met
+    WHERE geldig_tot IS NULL): sluit source's actieve rij af voordat
+    de UPDATE een tweede actieve op target zou creëren.
+  * Partial unique 'één actief per (FK, group)' (person_organisatie met
+    WHERE eind_datum IS NULL): per group_col (person_id): sluit source's
+    actieve rij af alleen waar target ook een actief heeft. Historische
+    rijen blijven met hun eigen eind_datum, krijgen alleen OE_id rewrite.
+
+Buiten de FK-graph zitten nog twee polymorphic-tabellen die logisch ook
+naar organisatie_eenheid kunnen wijzen via (resource_type, resource_id):
+resource_permission (wordt apart afgehandeld omdat het beide angles in
+één rij heeft) en activity/notification/stakeholder_assessment (kolommen-
+bestaan-check eerst — asyncpg aborteert anders de transactie).
 """
 
 from __future__ import annotations
@@ -34,23 +41,35 @@ class FkRef:
     column: str
 
 
-# Tables with composite unique constraints involving the FK column.
-# Maps (table, fk_column) -> list of other columns in the unique constraint.
-# Before rewriting source rows to target, we delete source rows whose
-# (target_id, other_cols) tuple already exists on target — otherwise
-# the rewrite would violate the unique constraint.
+# Tables with a regular composite UNIQUE constraint over the FK column.
+# Maps (table, fk_column) -> list of other columns in the unique tuple.
+# Pre-rewrite we delete source rows whose (target_id, other_cols) tuple
+# already exists on target — otherwise the UPDATE would violate the unique.
+# Only use for non-partial uniques. Partial uniques go through
+# _PARTIAL_PER_GROUP_TABLES, NOT here, because partial uniques don't restrict
+# historical (eind_datum/geldig_tot non-null) rows that we want to keep.
+# eenheid_module: uq_eenheid_module on (organisatie_eenheid_id, module)
 _DEDUP_RULES: dict[tuple[str, str], list[str]] = {
     ("eenheid_module", "organisatie_eenheid_id"): ["module"],
-    ("organisatie_email_domein", "organisatie_eenheid_id"): ["domein"],
-    ("person_organisatie_eenheid", "organisatie_eenheid_id"): ["person_id"],
 }
 
-# Tables with a partial unique constraint (WHERE geldig_tot IS NULL).
-# At most one active row per eenheid. When merging, close the source's
-# active row before rewriting so target's active row stays the canonical one.
-_PARTIAL_UNIQUE_TABLES: list[tuple[str, str]] = [
+# Tables with a partial unique 'one active row per <fk>' (WHERE geldig_tot
+# IS NULL). When merging, close source's active row if target already has
+# one. Historical rows on source are rewritten unchanged.
+_PARTIAL_UNIQUE_BY_FK: list[tuple[str, str]] = [
     ("organisatie_eenheid_naam", "eenheid_id"),
     ("organisatie_eenheid_parent", "eenheid_id"),
+]
+
+# Tables with a partial unique 'one active row per (fk, group_col)'
+# (WHERE eind_datum IS NULL). E.g. person_organisatie_eenheid:
+# uq_active_placement on (person_id, organisatie_eenheid_id) WHERE
+# eind_datum IS NULL. Per group_col-value on source: if target has an
+# active row for that group, close source's active row instead of
+# letting two collide. Historical rows are rewritten as-is.
+_PARTIAL_UNIQUE_PER_GROUP: list[tuple[str, str, str, str]] = [
+    # (table, fk_col, group_col, eind_col)
+    ("person_organisatie_eenheid", "organisatie_eenheid_id", "person_id", "eind_datum"),
 ]
 
 
@@ -150,22 +169,61 @@ async def _close_source_active_row(
     return result.rowcount or 0
 
 
-async def _dedupe_resource_permission(
+async def _close_source_active_per_group(
+    session: AsyncSession,
+    table: str,
+    fk_col: str,
+    group_col: str,
+    eind_col: str,
+    source_id: uuid.UUID,
+    target_id: uuid.UUID,
+) -> int:
+    """Close source's active row PER group_col-value if target has one.
+
+    For person_organisatie_eenheid: partial unique (person_id, OE_id) WHERE
+    eind_datum IS NULL. Per person: if target already has an active placement
+    AND source has an active placement, close the source's eind_datum to
+    today so they don't collide on rewrite. Historical placements on source
+    (eind_datum already set) are kept and just get their OE_id rewritten.
+    """
+    sql = text(
+        f"UPDATE {table} SET {eind_col} = CURRENT_DATE "  # noqa: S608
+        f"WHERE {fk_col} = :source_id "
+        f"AND {eind_col} IS NULL "
+        f"AND EXISTS ("
+        f"  SELECT 1 FROM {table} tgt "
+        f"  WHERE tgt.{fk_col} = :target_id "
+        f"  AND tgt.{eind_col} IS NULL "
+        f"  AND tgt.{group_col} = {table}.{group_col}"
+        f")"
+    )
+    result = await session.execute(
+        sql, {"source_id": source_id, "target_id": target_id}
+    )
+    return result.rowcount or 0
+
+
+async def _dedupe_and_rewrite_resource_permission(
     session: AsyncSession, source_id: uuid.UUID, target_id: uuid.UUID
 ) -> int:
-    """resource_permission has a polymorphic FK and a separate FK column.
+    """resource_permission heeft twee verschillende referentie-vormen.
 
-    There are two angles here:
-      1. resource_permission.organisatie_eenheid_id (the FK column) — if this
-         is set, the row is *attached to* an eenheid via permission-context.
-         Unique on (resource_type, resource_id, person_id) does NOT involve
-         this column directly.
-      2. resource_permission.resource_id — when resource_type='organisatie_eenheid'
-         this points at an eenheid too. Rewrite that as well.
+    Echte unique: (person_id, organisatie_eenheid_id, resource_type,
+    resource_id, rol). Mijn dedup moet álle vijf velden meetellen, inclusief
+    rol — anders verlies ik permissions waar source en target verschillende
+    rollen hebben op dezelfde resource.
+
+    Twee plekken waar OE-id kan zitten:
+      A. organisatie_eenheid_id (FK column) — 'wie krijgt deze permissie'
+      B. resource_id when resource_type='organisatie_eenheid' — 'op welke
+         resource is de permissie van toepassing'
+
+    Dedup voor beide angles vóór UPDATE, anders krijg je unique-violations.
+    Returns: aantal dedupes (informatief).
     """
     n = 0
-    # Angle 1: dedupe on (resource_type, resource_id, person_id) when both
-    # source and target have a permission for the same resource+person.
+    # Angle A: source.organisatie_eenheid_id = source_id wordt target_id.
+    # Dedupe op (person_id, target_id, resource_type, resource_id, rol).
     result = await session.execute(
         text(
             "DELETE FROM resource_permission src "
@@ -175,15 +233,42 @@ async def _dedupe_resource_permission(
             "  WHERE tgt.organisatie_eenheid_id = :target_id "
             "  AND tgt.resource_type = src.resource_type "
             "  AND tgt.resource_id = src.resource_id "
+            "  AND tgt.rol = src.rol "
             "  AND tgt.person_id IS NOT DISTINCT FROM src.person_id"
             ")"
         ),
         {"source_id": source_id, "target_id": target_id},
     )
     n += result.rowcount or 0
+    await session.execute(
+        text(
+            "UPDATE resource_permission SET organisatie_eenheid_id = :target_id "
+            "WHERE organisatie_eenheid_id = :source_id"
+        ),
+        {"source_id": source_id, "target_id": target_id},
+    )
 
-    # Angle 2: rewrite resource_id where resource_type='organisatie_eenheid'.
-    # This is not picked up by the FK-introspection (no FK constraint).
+    # Angle B: source.resource_id (where resource_type='organisatie_eenheid')
+    # wordt target_id. Dedupe op (person_id, organisatie_eenheid_id,
+    # 'organisatie_eenheid', target_id, rol).
+    result = await session.execute(
+        text(
+            "DELETE FROM resource_permission src "
+            "WHERE src.resource_type = 'organisatie_eenheid' "
+            "AND src.resource_id = :source_id "
+            "AND EXISTS ("
+            "  SELECT 1 FROM resource_permission tgt "
+            "  WHERE tgt.resource_type = 'organisatie_eenheid' "
+            "  AND tgt.resource_id = :target_id "
+            "  AND tgt.rol = src.rol "
+            "  AND tgt.person_id IS NOT DISTINCT FROM src.person_id "
+            "  AND tgt.organisatie_eenheid_id "
+            "      IS NOT DISTINCT FROM src.organisatie_eenheid_id"
+            ")"
+        ),
+        {"source_id": source_id, "target_id": target_id},
+    )
+    n += result.rowcount or 0
     await session.execute(
         text(
             "UPDATE resource_permission SET resource_id = :target_id "
@@ -278,24 +363,26 @@ async def merge_organisatie_eenheden(
             continue
 
         if fk.table == "resource_permission" and fk.column == "organisatie_eenheid_id":
-            await _dedupe_resource_permission(session, source_id, target_id)
-            result = await session.execute(
-                text(
-                    "UPDATE resource_permission "
-                    "SET organisatie_eenheid_id = :target_id "
-                    "WHERE organisatie_eenheid_id = :source_id"
-                ),
-                {"source_id": source_id, "target_id": target_id},
+            # Behandelt zowel organisatie_eenheid_id (de FK-kolom) als
+            # resource_id waar resource_type='organisatie_eenheid'. Inclusief
+            # rol in de unique-check zodat rollen niet verloren gaan.
+            n = await _dedupe_and_rewrite_resource_permission(
+                session, source_id, target_id
             )
-            n = result.rowcount or 0
             if n:
                 rewritten[f"{fk.table}.{fk.column}"] = n
             continue
 
-        if (fk.table, fk.column) in _PARTIAL_UNIQUE_TABLES:
+        if (fk.table, fk.column) in _PARTIAL_UNIQUE_BY_FK:
             await _close_source_active_row(
                 session, fk.table, fk.column, source_id, target_id
             )
+
+        for ptable, pfk, pgroup, peind in _PARTIAL_UNIQUE_PER_GROUP:
+            if fk.table == ptable and fk.column == pfk:
+                await _close_source_active_per_group(
+                    session, ptable, pfk, pgroup, peind, source_id, target_id
+                )
 
         await _dedupe_before_rewrite(session, fk, source_id, target_id)
 

--- a/backend/bouwmeester/services/merge_organisatie_eenheden.py
+++ b/backend/bouwmeester/services/merge_organisatie_eenheden.py
@@ -1,0 +1,323 @@
+"""Merge twee OrganisatieEenheid-rijen door alle FK's te rewriten.
+
+The reconciliation merge endpoint used to migrate only three FK columns
+(person_organisatie_eenheid, lead, opdracht.opdrachtnemer_eenheid_id) and
+then delete the source row. That fails on rows with children (parent_id
+RESTRICT) or any FK that wasn't explicitly listed — the BZK row in prod
+has sub-DGs, members, eenheid_modules, resource_permissions, etc.
+
+This helper introspects pg_catalog to find every FK column referencing
+organisatie_eenheid.id and rewrites them in one transaction. New FK
+columns added to other models are picked up automatically.
+
+Dedup-logic for tables with unique constraints (eenheid_module on
+organisatie_eenheid_id+module_key, org_naam on eenheid_id+naam,
+org_email_domein on organisatie_eenheid_id+domein): pre-delete rows on
+the source that would conflict with rows already on the target.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class FkRef:
+    table: str
+    column: str
+
+
+# Tables with composite unique constraints involving the FK column.
+# Maps (table, fk_column) -> list of other columns in the unique constraint.
+# Before rewriting source rows to target, we delete source rows whose
+# (target_id, other_cols) tuple already exists on target — otherwise
+# the rewrite would violate the unique constraint.
+_DEDUP_RULES: dict[tuple[str, str], list[str]] = {
+    ("eenheid_module", "organisatie_eenheid_id"): ["module"],
+    ("organisatie_email_domein", "organisatie_eenheid_id"): ["domein"],
+    ("person_organisatie_eenheid", "organisatie_eenheid_id"): ["person_id"],
+}
+
+# Tables with a partial unique constraint (WHERE geldig_tot IS NULL).
+# At most one active row per eenheid. When merging, close the source's
+# active row before rewriting so target's active row stays the canonical one.
+_PARTIAL_UNIQUE_TABLES: list[tuple[str, str]] = [
+    ("organisatie_eenheid_naam", "eenheid_id"),
+    ("organisatie_eenheid_parent", "eenheid_id"),
+]
+
+
+async def _discover_fk_columns(session: AsyncSession) -> list[FkRef]:
+    """Return every (table, column) FK that references organisatie_eenheid.id."""
+    rows = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                    cl.relname AS table_name,
+                    att.attname AS column_name
+                FROM pg_constraint con
+                JOIN pg_class cl ON cl.oid = con.conrelid
+                JOIN pg_class refcl ON refcl.oid = con.confrelid
+                JOIN pg_attribute att ON att.attrelid = con.conrelid
+                  AND att.attnum = ANY(con.conkey)
+                WHERE con.contype = 'f'
+                  AND refcl.relname = 'organisatie_eenheid'
+                ORDER BY cl.relname, att.attname
+                """
+            )
+        )
+    ).all()
+    return [FkRef(table=r.table_name, column=r.column_name) for r in rows]
+
+
+async def _dedupe_before_rewrite(
+    session: AsyncSession,
+    fk: FkRef,
+    source_id: uuid.UUID,
+    target_id: uuid.UUID,
+) -> int:
+    """Delete source-rows whose composite key already exists on target.
+
+    Returns the number of rows deleted. Without this step the UPDATE
+    further down would violate a unique constraint.
+    """
+    other_cols = _DEDUP_RULES.get((fk.table, fk.column))
+    if not other_cols:
+        return 0
+    on_clauses = " AND ".join(f"src.{c} = tgt.{c}" for c in other_cols)
+    sql = text(
+        f"DELETE FROM {fk.table} src "  # noqa: S608 — table/cols from whitelist
+        f"WHERE src.{fk.column} = :source_id "
+        f"AND EXISTS ("
+        f"  SELECT 1 FROM {fk.table} tgt "
+        f"  WHERE tgt.{fk.column} = :target_id AND {on_clauses}"
+        f")"
+    )
+    result = await session.execute(
+        sql, {"source_id": source_id, "target_id": target_id}
+    )
+    n = result.rowcount or 0
+    if n:
+        log.info(
+            "Merge dedup: %d %s row(s) on source had a target-twin, deleted",
+            n,
+            fk.table,
+        )
+    return n
+
+
+async def _close_source_active_row(
+    session: AsyncSession,
+    table: str,
+    fk_col: str,
+    source_id: uuid.UUID,
+    target_id: uuid.UUID,
+) -> int:
+    """Close source's active row if target already has an active row.
+
+    Both organisatie_eenheid_naam and organisatie_eenheid_parent enforce
+    'one active row per eenheid' via a partial unique index. Naive UPDATE
+    of fk_col would put two active rows on target. Solution: end the
+    source's active row first (geldig_tot=today). The historical
+    geldig_tot rows on source can then be rewritten safely.
+    """
+    target_has_active = (
+        await session.execute(
+            text(
+                f"SELECT 1 FROM {table} "  # noqa: S608
+                f"WHERE {fk_col} = :target_id AND geldig_tot IS NULL LIMIT 1"
+            ),
+            {"target_id": target_id},
+        )
+    ).first()
+    if not target_has_active:
+        return 0
+    result = await session.execute(
+        text(
+            f"UPDATE {table} SET geldig_tot = CURRENT_DATE "  # noqa: S608
+            f"WHERE {fk_col} = :source_id AND geldig_tot IS NULL"
+        ),
+        {"source_id": source_id},
+    )
+    return result.rowcount or 0
+
+
+async def _dedupe_resource_permission(
+    session: AsyncSession, source_id: uuid.UUID, target_id: uuid.UUID
+) -> int:
+    """resource_permission has a polymorphic FK and a separate FK column.
+
+    There are two angles here:
+      1. resource_permission.organisatie_eenheid_id (the FK column) — if this
+         is set, the row is *attached to* an eenheid via permission-context.
+         Unique on (resource_type, resource_id, person_id) does NOT involve
+         this column directly.
+      2. resource_permission.resource_id — when resource_type='organisatie_eenheid'
+         this points at an eenheid too. Rewrite that as well.
+    """
+    n = 0
+    # Angle 1: dedupe on (resource_type, resource_id, person_id) when both
+    # source and target have a permission for the same resource+person.
+    result = await session.execute(
+        text(
+            "DELETE FROM resource_permission src "
+            "WHERE src.organisatie_eenheid_id = :source_id "
+            "AND EXISTS ("
+            "  SELECT 1 FROM resource_permission tgt "
+            "  WHERE tgt.organisatie_eenheid_id = :target_id "
+            "  AND tgt.resource_type = src.resource_type "
+            "  AND tgt.resource_id = src.resource_id "
+            "  AND tgt.person_id IS NOT DISTINCT FROM src.person_id"
+            ")"
+        ),
+        {"source_id": source_id, "target_id": target_id},
+    )
+    n += result.rowcount or 0
+
+    # Angle 2: rewrite resource_id where resource_type='organisatie_eenheid'.
+    # This is not picked up by the FK-introspection (no FK constraint).
+    await session.execute(
+        text(
+            "UPDATE resource_permission SET resource_id = :target_id "
+            "WHERE resource_type = 'organisatie_eenheid' "
+            "AND resource_id = :source_id"
+        ),
+        {"source_id": source_id, "target_id": target_id},
+    )
+    return n
+
+
+async def _columns_exist(session: AsyncSession, table: str, columns: list[str]) -> bool:
+    """Return True if the table has all named columns in the public schema."""
+    rows = (
+        await session.execute(
+            text(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_schema = 'public' AND table_name = :t "
+                "AND column_name = ANY(:cols)"
+            ),
+            {"t": table, "cols": columns},
+        )
+    ).all()
+    return len(rows) == len(columns)
+
+
+async def _rewrite_polymorphic_resource_ids(
+    session: AsyncSession, source_id: uuid.UUID, target_id: uuid.UUID
+) -> None:
+    """Tables with polymorphic (resource_type, resource_id) columns.
+
+    These have no FK to organisatie_eenheid but logically reference it.
+    Verify columns exist in the schema first — calling UPDATE on a
+    non-existent column aborts the postgres transaction even when wrapped
+    in try/except (asyncpg behavior).
+    """
+    polymorphic_targets = [
+        ("stakeholder_assessment", "scope_type", "scope_id", "organisatie_eenheid"),
+        ("activity", "resource_type", "resource_id", "organisatie_eenheid"),
+        ("notification", "resource_type", "resource_id", "organisatie_eenheid"),
+    ]
+    for table, type_col, id_col, type_value in polymorphic_targets:
+        if not await _columns_exist(session, table, [type_col, id_col]):
+            continue
+        await session.execute(
+            text(
+                f"UPDATE {table} SET {id_col} = :target_id "  # noqa: S608
+                f"WHERE {type_col} = :type_value "
+                f"AND {id_col} = :source_id"
+            ),
+            {
+                "source_id": source_id,
+                "target_id": target_id,
+                "type_value": type_value,
+            },
+        )
+
+
+async def merge_organisatie_eenheden(
+    session: AsyncSession, source_id: uuid.UUID, target_id: uuid.UUID
+) -> dict[str, int]:
+    """Move every reference from source to target, then delete source.
+
+    Returns a dict {table: rows_rewritten} for telemetry. Caller is
+    responsible for committing — this function only flushes.
+    """
+    if source_id == target_id:
+        raise ValueError("source en target zijn dezelfde rij")
+
+    fks = await _discover_fk_columns(session)
+    log.info("Merge %s -> %s: %d FK columns gevonden", source_id, target_id, len(fks))
+
+    rewritten: dict[str, int] = {}
+    for fk in fks:
+        # Skip the self-FK on organisatie_eenheid.parent_id when source itself
+        # is one of those rows — handled separately to avoid setting parent
+        # to a row that is about to be deleted, or to itself.
+        if fk.table == "organisatie_eenheid" and fk.column == "parent_id":
+            # Children of source -> target. After this, source has no children
+            # so the RESTRICT FK won't block the delete.
+            result = await session.execute(
+                text(
+                    "UPDATE organisatie_eenheid SET parent_id = :target_id "
+                    "WHERE parent_id = :source_id AND id <> :source_id"
+                ),
+                {"source_id": source_id, "target_id": target_id},
+            )
+            n = result.rowcount or 0
+            if n:
+                rewritten[f"{fk.table}.{fk.column}"] = n
+                log.info("  parent_id: %d children verhuisd", n)
+            continue
+
+        if fk.table == "resource_permission" and fk.column == "organisatie_eenheid_id":
+            await _dedupe_resource_permission(session, source_id, target_id)
+            result = await session.execute(
+                text(
+                    "UPDATE resource_permission "
+                    "SET organisatie_eenheid_id = :target_id "
+                    "WHERE organisatie_eenheid_id = :source_id"
+                ),
+                {"source_id": source_id, "target_id": target_id},
+            )
+            n = result.rowcount or 0
+            if n:
+                rewritten[f"{fk.table}.{fk.column}"] = n
+            continue
+
+        if (fk.table, fk.column) in _PARTIAL_UNIQUE_TABLES:
+            await _close_source_active_row(
+                session, fk.table, fk.column, source_id, target_id
+            )
+
+        await _dedupe_before_rewrite(session, fk, source_id, target_id)
+
+        result = await session.execute(
+            text(
+                f"UPDATE {fk.table} SET {fk.column} = :target_id "  # noqa: S608
+                f"WHERE {fk.column} = :source_id"
+            ),
+            {"source_id": source_id, "target_id": target_id},
+        )
+        n = result.rowcount or 0
+        if n:
+            rewritten[f"{fk.table}.{fk.column}"] = n
+
+    await _rewrite_polymorphic_resource_ids(session, source_id, target_id)
+
+    # Now safe to delete the source row — all FKs point at target.
+    await session.execute(
+        text("DELETE FROM organisatie_eenheid WHERE id = :source_id"),
+        {"source_id": source_id},
+    )
+    await session.flush()
+
+    log.info("Merge %s -> %s klaar: %s", source_id, target_id, rewritten)
+    return rewritten

--- a/backend/bouwmeester/services/merge_organisatie_eenheden.py
+++ b/backend/bouwmeester/services/merge_organisatie_eenheden.py
@@ -298,33 +298,45 @@ async def _columns_exist(session: AsyncSession, table: str, columns: list[str]) 
 async def _rewrite_polymorphic_resource_ids(
     session: AsyncSession, source_id: uuid.UUID, target_id: uuid.UUID
 ) -> None:
-    """Tables with polymorphic (resource_type, resource_id) columns.
+    """Tables with polymorphic (type_col, id_col) referring to organisatie_eenheid.
 
-    These have no FK to organisatie_eenheid but logically reference it.
-    Verify columns exist in the schema first — calling UPDATE on a
-    non-existent column aborts the postgres transaction even when wrapped
-    in try/except (asyncpg behavior).
+    These have no FK constraint but logically reference an eenheid.
+    stakeholder_assessment is the relevant one today (scope_type +
+    scope_id). The unique (person_id, scope_type, scope_id) means we
+    must dedup vóór de rewrite, anders krijgen we een violation als één
+    persoon assessments op zowel source als target heeft.
+
+    Columns-exist check is een vangnet voor schema-drift, niet de actieve
+    behoefte — schrappen mag zodra we zeker zijn dat het schema stabiel is.
     """
-    polymorphic_targets = [
-        ("stakeholder_assessment", "scope_type", "scope_id", "organisatie_eenheid"),
-        ("activity", "resource_type", "resource_id", "organisatie_eenheid"),
-        ("notification", "resource_type", "resource_id", "organisatie_eenheid"),
-    ]
-    for table, type_col, id_col, type_value in polymorphic_targets:
-        if not await _columns_exist(session, table, [type_col, id_col]):
-            continue
-        await session.execute(
-            text(
-                f"UPDATE {table} SET {id_col} = :target_id "  # noqa: S608
-                f"WHERE {type_col} = :type_value "
-                f"AND {id_col} = :source_id"
-            ),
-            {
-                "source_id": source_id,
-                "target_id": target_id,
-                "type_value": type_value,
-            },
-        )
+    table = "stakeholder_assessment"
+    if not await _columns_exist(session, table, ["scope_type", "scope_id"]):
+        return
+
+    # Dedup: assessments op source verwijderen waar dezelfde person al een
+    # assessment op target heeft (anders unique-violation bij UPDATE).
+    await session.execute(
+        text(
+            "DELETE FROM stakeholder_assessment src "
+            "WHERE src.scope_type = 'organisatie_eenheid' "
+            "AND src.scope_id = :source_id "
+            "AND EXISTS ("
+            "  SELECT 1 FROM stakeholder_assessment tgt "
+            "  WHERE tgt.scope_type = 'organisatie_eenheid' "
+            "  AND tgt.scope_id = :target_id "
+            "  AND tgt.person_id = src.person_id"
+            ")"
+        ),
+        {"source_id": source_id, "target_id": target_id},
+    )
+    await session.execute(
+        text(
+            "UPDATE stakeholder_assessment SET scope_id = :target_id "
+            "WHERE scope_type = 'organisatie_eenheid' "
+            "AND scope_id = :source_id"
+        ),
+        {"source_id": source_id, "target_id": target_id},
+    )
 
 
 async def merge_organisatie_eenheden(
@@ -398,6 +410,22 @@ async def merge_organisatie_eenheden(
             rewritten[f"{fk.table}.{fk.column}"] = n
 
     await _rewrite_polymorphic_resource_ids(session, source_id, target_id)
+
+    # Cleanup self-references die na rewrite kunnen ontstaan. Voorbeeld:
+    # source had organisatie_eenheid_parent-rij (eenheid=source, parent=target)
+    # omdat handmatige BZK al onder TOOI-BZK hing. Na rewrite van eenheid_id
+    # wordt dat (eenheid=target, parent=target) — self-loop, semantisch
+    # onzin en kan tree-rendering kapot maken. Idem shared_access.
+    for sql in (
+        "DELETE FROM organisatie_eenheid_parent "
+        "WHERE eenheid_id = :target_id AND parent_id = :target_id",
+        "DELETE FROM shared_access "
+        "WHERE source_eenheid_id = :target_id "
+        "AND target_eenheid_id = :target_id",
+        "UPDATE organisatie_eenheid SET parent_id = NULL "
+        "WHERE id = :target_id AND parent_id = :target_id",
+    ):
+        await session.execute(text(sql), {"target_id": target_id})
 
     # Now safe to delete the source row — all FKs point at target.
     await session.execute(

--- a/backend/tests/test_detect_orphan_handmatig.py
+++ b/backend/tests/test_detect_orphan_handmatig.py
@@ -1,0 +1,145 @@
+"""Tests voor detect_orphan_handmatig: vind FCC-rijen die alsnog op TOOI matchen."""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bouwmeester.models.organisatie_eenheid import OrganisatieEenheid
+from bouwmeester.models.pending_reconciliation import PendingReconciliation
+from bouwmeester.services.detect_orphan_handmatig import (
+    detect_orphan_handmatig_matches,
+)
+
+
+@pytest.fixture
+async def schone_pending(db_session: AsyncSession):
+    from sqlalchemy import text
+
+    await db_session.execute(text("DELETE FROM pending_reconciliation"))
+    await db_session.flush()
+
+
+async def test_orphan_match_op_afkorting_genereert_reconciliation(
+    db_session: AsyncSession, schone_pending
+):
+    """FCC-rij 'CJIB' afk='CJIB' -> match TOOI 'Centraal Justitieel...' afk='CJIB'."""
+    fcc = OrganisatieEenheid(
+        id=uuid.uuid4(),
+        naam="CJIB",
+        type="uitvoeringsorganisatie",
+        bron="handmatig",
+        afkorting="CJIB",
+    )
+    tooi = OrganisatieEenheid(
+        id=uuid.uuid4(),
+        naam="Centraal Justitieel Incassobureau",
+        type="zbo",
+        bron="tooi",
+        tooi_uri="https://identifier.overheid.nl/tooi/id/test/cjib",
+        afkorting="CJIB",
+    )
+    db_session.add_all([fcc, tooi])
+    await db_session.flush()
+
+    stats = await detect_orphan_handmatig_matches(db_session, commit=False)
+    assert stats.found_match == 1
+    assert stats.new_reconciliations == 1
+
+    rec = (
+        (
+            await db_session.execute(
+                select(PendingReconciliation).where(
+                    PendingReconciliation.handmatige_id == fcc.id
+                )
+            )
+        )
+        .scalars()
+        .first()
+    )
+    assert rec is not None
+    assert rec.kandidaat_id == tooi.id
+    assert rec.match_reden == "afkorting_ci"
+
+
+async def test_orphan_skipt_rijen_met_tooi_uri(
+    db_session: AsyncSession, schone_pending
+):
+    """Rij die al een tooi_uri heeft is geen orphan-handmatig."""
+    al_gekoppeld = OrganisatieEenheid(
+        id=uuid.uuid4(),
+        naam="Logius",
+        type="zbo",
+        bron="handmatig",
+        tooi_uri="https://identifier.overheid.nl/tooi/id/test/logius",
+        afkorting="Logius",
+    )
+    tooi = OrganisatieEenheid(
+        id=uuid.uuid4(),
+        naam="Logius (TOOI)",
+        type="zbo",
+        bron="tooi",
+        tooi_uri="https://identifier.overheid.nl/tooi/id/test/logius2",
+        afkorting="Logius",
+    )
+    db_session.add_all([al_gekoppeld, tooi])
+    await db_session.flush()
+
+    stats = await detect_orphan_handmatig_matches(db_session, commit=False)
+    assert stats.found_match == 0
+
+
+async def test_orphan_skipt_reeds_open_reconciliation(
+    db_session: AsyncSession, schone_pending
+):
+    """Tweede scan-run levert geen duplicate-pending."""
+    fcc = OrganisatieEenheid(
+        id=uuid.uuid4(),
+        naam="DUO-rij",
+        type="uitvoeringsorganisatie",
+        bron="handmatig",
+        afkorting="DUO",
+    )
+    tooi = OrganisatieEenheid(
+        id=uuid.uuid4(),
+        naam="Dienst Uitvoering Onderwijs",
+        type="agentschap",
+        bron="tooi",
+        tooi_uri="https://identifier.overheid.nl/tooi/id/test/duo",
+        afkorting="DUO",
+    )
+    db_session.add_all([fcc, tooi])
+    await db_session.flush()
+
+    s1 = await detect_orphan_handmatig_matches(db_session, commit=False)
+    assert s1.new_reconciliations == 1
+
+    s2 = await detect_orphan_handmatig_matches(db_session, commit=False)
+    assert s2.new_reconciliations == 0
+    assert s2.already_pending == 1
+
+
+async def test_orphan_match_op_genormaliseerde_naam(
+    db_session: AsyncSession, schone_pending
+):
+    """Handmatig 'X' matcht TOOI 'agentschap X' via prefix-stripping."""
+    fcc = OrganisatieEenheid(
+        id=uuid.uuid4(),
+        naam="Telecom Beheer",
+        type="uitvoeringsorganisatie",
+        bron="handmatig",
+    )
+    tooi = OrganisatieEenheid(
+        id=uuid.uuid4(),
+        naam="Agentschap Telecom Beheer",
+        type="agentschap",
+        bron="tooi",
+        tooi_uri="https://identifier.overheid.nl/tooi/id/test/at",
+    )
+    db_session.add_all([fcc, tooi])
+    await db_session.flush()
+
+    stats = await detect_orphan_handmatig_matches(db_session, commit=False)
+    assert stats.found_match == 1
+    assert stats.new_reconciliations == 1

--- a/backend/tests/test_detect_orphan_handmatig.py
+++ b/backend/tests/test_detect_orphan_handmatig.py
@@ -25,27 +25,26 @@ async def test_orphan_match_op_afkorting_genereert_reconciliation(
     db_session: AsyncSession, schone_pending
 ):
     """FCC-rij 'CJIB' afk='CJIB' -> match TOOI 'Centraal Justitieel...' afk='CJIB'."""
+    # Unieke afkorting voorkomt botsing met seed-data in CI.
     fcc = OrganisatieEenheid(
         id=uuid.uuid4(),
-        naam="CJIB",
+        naam="CJIB-test-rij",
         type="uitvoeringsorganisatie",
         bron="handmatig",
-        afkorting="CJIB",
+        afkorting="CJIB-XYZ",
     )
     tooi = OrganisatieEenheid(
         id=uuid.uuid4(),
-        naam="Centraal Justitieel Incassobureau",
+        naam="Centraal Justitieel Incassobureau (test)",
         type="zbo",
         bron="tooi",
-        tooi_uri="https://identifier.overheid.nl/tooi/id/test/cjib",
-        afkorting="CJIB",
+        tooi_uri="https://identifier.overheid.nl/tooi/id/test/cjib-xyz",
+        afkorting="CJIB-XYZ",
     )
     db_session.add_all([fcc, tooi])
     await db_session.flush()
 
-    stats = await detect_orphan_handmatig_matches(db_session, commit=False)
-    assert stats.found_match == 1
-    assert stats.new_reconciliations == 1
+    await detect_orphan_handmatig_matches(db_session, commit=False)
 
     rec = (
         (
@@ -66,14 +65,19 @@ async def test_orphan_match_op_afkorting_genereert_reconciliation(
 async def test_orphan_skipt_rijen_met_tooi_uri(
     db_session: AsyncSession, schone_pending
 ):
-    """Rij die al een tooi_uri heeft is geen orphan-handmatig."""
+    """Rij die al een tooi_uri heeft is geen orphan-handmatig.
+
+    Verifieerd door te checken dat geen reconciliation-rij naar deze
+    handmatige rij wijst — globaal found_match-aantal kan groter zijn
+    door seed-data met andere matches.
+    """
     al_gekoppeld = OrganisatieEenheid(
         id=uuid.uuid4(),
         naam="Logius",
         type="zbo",
         bron="handmatig",
         tooi_uri="https://identifier.overheid.nl/tooi/id/test/logius",
-        afkorting="Logius",
+        afkorting="Logius-test-skip",
     )
     tooi = OrganisatieEenheid(
         id=uuid.uuid4(),
@@ -81,13 +85,25 @@ async def test_orphan_skipt_rijen_met_tooi_uri(
         type="zbo",
         bron="tooi",
         tooi_uri="https://identifier.overheid.nl/tooi/id/test/logius2",
-        afkorting="Logius",
+        afkorting="Logius-test-skip",
     )
     db_session.add_all([al_gekoppeld, tooi])
     await db_session.flush()
 
-    stats = await detect_orphan_handmatig_matches(db_session, commit=False)
-    assert stats.found_match == 0
+    await detect_orphan_handmatig_matches(db_session, commit=False)
+
+    rec_voor_deze_rij = (
+        (
+            await db_session.execute(
+                select(PendingReconciliation).where(
+                    PendingReconciliation.handmatige_id == al_gekoppeld.id
+                )
+            )
+        )
+        .scalars()
+        .first()
+    )
+    assert rec_voor_deze_rij is None
 
 
 async def test_orphan_skipt_reeds_open_reconciliation(
@@ -96,28 +112,50 @@ async def test_orphan_skipt_reeds_open_reconciliation(
     """Tweede scan-run levert geen duplicate-pending."""
     fcc = OrganisatieEenheid(
         id=uuid.uuid4(),
-        naam="DUO-rij",
+        naam="DUO-rij-test",
         type="uitvoeringsorganisatie",
         bron="handmatig",
-        afkorting="DUO",
+        afkorting="DUO-test-idem",
     )
     tooi = OrganisatieEenheid(
         id=uuid.uuid4(),
-        naam="Dienst Uitvoering Onderwijs",
+        naam="Dienst Uitvoering Onderwijs (test)",
         type="agentschap",
         bron="tooi",
-        tooi_uri="https://identifier.overheid.nl/tooi/id/test/duo",
-        afkorting="DUO",
+        tooi_uri="https://identifier.overheid.nl/tooi/id/test/duo-test",
+        afkorting="DUO-test-idem",
     )
     db_session.add_all([fcc, tooi])
     await db_session.flush()
 
-    s1 = await detect_orphan_handmatig_matches(db_session, commit=False)
-    assert s1.new_reconciliations == 1
+    await detect_orphan_handmatig_matches(db_session, commit=False)
+    rec1 = (
+        (
+            await db_session.execute(
+                select(PendingReconciliation).where(
+                    PendingReconciliation.handmatige_id == fcc.id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rec1) == 1
 
-    s2 = await detect_orphan_handmatig_matches(db_session, commit=False)
-    assert s2.new_reconciliations == 0
-    assert s2.already_pending == 1
+    # Tweede run: geen tweede rij voor dezelfde handmatige id.
+    await detect_orphan_handmatig_matches(db_session, commit=False)
+    rec2 = (
+        (
+            await db_session.execute(
+                select(PendingReconciliation).where(
+                    PendingReconciliation.handmatige_id == fcc.id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rec2) == 1
 
 
 async def test_orphan_match_op_genormaliseerde_naam(
@@ -126,20 +164,33 @@ async def test_orphan_match_op_genormaliseerde_naam(
     """Handmatig 'X' matcht TOOI 'agentschap X' via prefix-stripping."""
     fcc = OrganisatieEenheid(
         id=uuid.uuid4(),
-        naam="Telecom Beheer",
+        naam="Test-Naam-Match-Beheer",
         type="uitvoeringsorganisatie",
         bron="handmatig",
     )
     tooi = OrganisatieEenheid(
         id=uuid.uuid4(),
-        naam="Agentschap Telecom Beheer",
+        naam="Agentschap Test-Naam-Match-Beheer",
         type="agentschap",
         bron="tooi",
-        tooi_uri="https://identifier.overheid.nl/tooi/id/test/at",
+        tooi_uri="https://identifier.overheid.nl/tooi/id/test/at-test",
     )
     db_session.add_all([fcc, tooi])
     await db_session.flush()
 
-    stats = await detect_orphan_handmatig_matches(db_session, commit=False)
-    assert stats.found_match == 1
-    assert stats.new_reconciliations == 1
+    await detect_orphan_handmatig_matches(db_session, commit=False)
+
+    rec = (
+        (
+            await db_session.execute(
+                select(PendingReconciliation).where(
+                    PendingReconciliation.handmatige_id == fcc.id
+                )
+            )
+        )
+        .scalars()
+        .first()
+    )
+    assert rec is not None
+    assert rec.kandidaat_id == tooi.id
+    assert rec.match_reden == "naam_normalized"

--- a/backend/tests/test_reconciliation.py
+++ b/backend/tests/test_reconciliation.py
@@ -179,3 +179,105 @@ async def test_reconciliation_merge_404_op_reeds_gemerged(
     await db_session.flush()
     resp = await client.post(f"/api/admin/reconciliation/{rec.id}/merge")
     assert resp.status_code == 404
+
+
+async def test_reconciliation_merge_verplaatst_children(
+    client, db_session: AsyncSession, reconciliation_setup
+):
+    """Bron met sub-eenheden (parent_id RESTRICT) faalde voorheen op delete.
+
+    Dit is het BZK-scenario in productie: handmatige BZK heeft DG's en
+    directies hangen via parent_id. Zonder parent_id-rewrite gaf delete
+    een ForeignKeyViolation -> 500.
+    """
+    handmatig = reconciliation_setup["handmatig"]
+    tooi = reconciliation_setup["tooi"]
+    rec = reconciliation_setup["rec"]
+
+    child1 = OrganisatieEenheid(
+        id=uuid.uuid4(),
+        naam="Sub DG 1",
+        type="directoraat_generaal",
+        bron="handmatig",
+        parent_id=handmatig.id,
+    )
+    child2 = OrganisatieEenheid(
+        id=uuid.uuid4(),
+        naam="Sub DG 2",
+        type="directoraat_generaal",
+        bron="handmatig",
+        parent_id=handmatig.id,
+    )
+    db_session.add_all([child1, child2])
+    await db_session.flush()
+
+    resp = await client.post(f"/api/admin/reconciliation/{rec.id}/merge")
+    assert resp.status_code == 200, resp.text
+
+    await db_session.refresh(child1)
+    await db_session.refresh(child2)
+    assert child1.parent_id == tooi.id
+    assert child2.parent_id == tooi.id
+
+    nog_handmatig = (
+        (
+            await db_session.execute(
+                select(OrganisatieEenheid).where(OrganisatieEenheid.id == handmatig.id)
+            )
+        )
+        .scalars()
+        .first()
+    )
+    assert nog_handmatig is None
+
+
+async def test_reconciliation_merge_dedup_op_eenheid_module(
+    client, db_session: AsyncSession, reconciliation_setup
+):
+    """Als bron en doel allebei dezelfde module-key hebben dedupliceren."""
+    from bouwmeester.models.eenheid_module import EenheidModule
+
+    handmatig = reconciliation_setup["handmatig"]
+    tooi = reconciliation_setup["tooi"]
+    rec = reconciliation_setup["rec"]
+
+    # Beide rijen hebben dezelfde module_key — zou unique_constraint
+    # schenden bij naïeve UPDATE.
+    db_session.add_all(
+        [
+            EenheidModule(
+                organisatie_eenheid_id=handmatig.id,
+                module="leads",
+                enabled=True,
+            ),
+            EenheidModule(
+                organisatie_eenheid_id=tooi.id,
+                module="leads",
+                enabled=False,
+            ),
+            # En een module die alleen op handmatig zit -> moet wel mee.
+            EenheidModule(
+                organisatie_eenheid_id=handmatig.id,
+                module="opdrachten",
+                enabled=True,
+            ),
+        ]
+    )
+    await db_session.flush()
+
+    resp = await client.post(f"/api/admin/reconciliation/{rec.id}/merge")
+    assert resp.status_code == 200, resp.text
+
+    rows = (
+        (
+            await db_session.execute(
+                select(EenheidModule).where(
+                    EenheidModule.organisatie_eenheid_id == tooi.id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    keys = {r.module for r in rows}
+    assert keys == {"leads", "opdrachten"}

--- a/backend/tests/test_reconciliation.py
+++ b/backend/tests/test_reconciliation.py
@@ -231,6 +231,139 @@ async def test_reconciliation_merge_verplaatst_children(
     assert nog_handmatig is None
 
 
+async def test_reconciliation_merge_behoudt_historische_plaatsingen(
+    client, db_session: AsyncSession, reconciliation_setup, sample_person
+):
+    """Regressie: historische plaatsingen op source moeten BLIJVEN bestaan,
+    niet weggegooid worden door dedup. De partial-unique constraint op
+    person_organisatie_eenheid is WHERE eind_datum IS NULL, dus historische
+    rijen (eind_datum gevuld) botsen nooit en moeten gewoon mee."""
+    from datetime import date
+
+    from bouwmeester.models.person_organisatie import PersonOrganisatieEenheid
+
+    handmatig = reconciliation_setup["handmatig"]
+    tooi = reconciliation_setup["tooi"]
+    rec = reconciliation_setup["rec"]
+
+    # 1) Historische plaatsing op source (eind_datum gevuld)
+    historisch = PersonOrganisatieEenheid(
+        id=uuid.uuid4(),
+        person_id=sample_person.id,
+        organisatie_eenheid_id=handmatig.id,
+        start_datum=date(2020, 1, 1),
+        eind_datum=date(2022, 1, 1),
+    )
+    # 2) Actieve plaatsing op source
+    actief_source = PersonOrganisatieEenheid(
+        id=uuid.uuid4(),
+        person_id=sample_person.id,
+        organisatie_eenheid_id=handmatig.id,
+        start_datum=date(2024, 1, 1),
+    )
+    # 3) Actieve plaatsing op target — partial-unique conflict aanstaande
+    actief_target = PersonOrganisatieEenheid(
+        id=uuid.uuid4(),
+        person_id=sample_person.id,
+        organisatie_eenheid_id=tooi.id,
+        start_datum=date(2023, 1, 1),
+    )
+    db_session.add_all([historisch, actief_source, actief_target])
+    await db_session.flush()
+
+    resp = await client.post(f"/api/admin/reconciliation/{rec.id}/merge")
+    assert resp.status_code == 200, resp.text
+
+    # Verifieer via raw SQL — de session cached oude IDs op de in-memory
+    # objecten omdat de helper raw UPDATEs gebruikt, niet ORM-instances.
+    from sqlalchemy import text
+
+    rows = (
+        await db_session.execute(
+            text(
+                "SELECT id, organisatie_eenheid_id, start_datum, eind_datum "
+                "FROM person_organisatie_eenheid "
+                "WHERE person_id = :p ORDER BY start_datum"
+            ),
+            {"p": sample_person.id},
+        )
+    ).all()
+    assert len(rows) == 3, f"Verwacht 3 plaatsingen, kreeg {len(rows)} — data-verlies!"
+    by_id = {r.id: r for r in rows}
+    assert by_id[historisch.id].organisatie_eenheid_id == tooi.id
+    assert by_id[historisch.id].eind_datum == date(2022, 1, 1)
+    assert by_id[actief_source.id].organisatie_eenheid_id == tooi.id
+    # Source's actieve plaatsing is afgesloten i.p.v. weggegooid
+    assert by_id[actief_source.id].eind_datum is not None
+    assert by_id[actief_target.id].organisatie_eenheid_id == tooi.id
+    assert by_id[actief_target.id].eind_datum is None
+
+
+async def test_reconciliation_merge_behoudt_verschillende_rollen(
+    client, db_session: AsyncSession, reconciliation_setup
+):
+    """Regressie B2: resource_permission unique is (person, OE, type, id, rol).
+    Scenario: target en source zijn beide subjects van permissions op een
+    derde resource X — met verschillende rollen. Alleen identieke rollen
+    mogen dedupen, verschillende rollen moeten blijven."""
+    from sqlalchemy import text
+
+    from bouwmeester.models.corpus_node import CorpusNode
+    from bouwmeester.models.resource_permission import ResourcePermission
+
+    handmatig = reconciliation_setup["handmatig"]
+    tooi = reconciliation_setup["tooi"]
+    rec = reconciliation_setup["rec"]
+
+    # Twee derden — een corpus_node en de eenheden zelf zijn niet relevant.
+    # We zetten permissions met person_id=None (eenheid-scoped) op
+    # resource_type='corpus_node'.
+    node = CorpusNode(
+        id=uuid.uuid4(), title="Test node", node_type="dossier", status="actief"
+    )
+    db_session.add(node)
+    await db_session.flush()
+
+    # Source als subject: 'eigenaar' op de node
+    perm_a = ResourcePermission(
+        id=uuid.uuid4(),
+        person_id=None,
+        organisatie_eenheid_id=handmatig.id,
+        resource_type="corpus_node",
+        resource_id=node.id,
+        rol="eigenaar",
+    )
+    # Target als subject: 'adviseur' op dezelfde node
+    perm_b = ResourcePermission(
+        id=uuid.uuid4(),
+        person_id=None,
+        organisatie_eenheid_id=tooi.id,
+        resource_type="corpus_node",
+        resource_id=node.id,
+        rol="adviseur",
+    )
+    db_session.add_all([perm_a, perm_b])
+    await db_session.flush()
+
+    resp = await client.post(f"/api/admin/reconciliation/{rec.id}/merge")
+    assert resp.status_code == 200, resp.text
+
+    rows = (
+        await db_session.execute(
+            text(
+                "SELECT rol FROM resource_permission "
+                "WHERE organisatie_eenheid_id = :oe "
+                "AND resource_id = :n"
+            ),
+            {"oe": tooi.id, "n": node.id},
+        )
+    ).all()
+    rollen = {r.rol for r in rows}
+    assert rollen == {"eigenaar", "adviseur"}, (
+        f"Verschillende rollen verloren gegaan! rollen={rollen}"
+    )
+
+
 async def test_reconciliation_merge_dedup_op_eenheid_module(
     client, db_session: AsyncSession, reconciliation_setup
 ):

--- a/backend/tests/test_reconciliation.py
+++ b/backend/tests/test_reconciliation.py
@@ -414,3 +414,100 @@ async def test_reconciliation_merge_dedup_op_eenheid_module(
     )
     keys = {r.module for r in rows}
     assert keys == {"leads", "opdrachten"}
+
+
+async def test_reconciliation_merge_geen_self_loop_in_parent(
+    client, db_session: AsyncSession, reconciliation_setup
+):
+    """Regressie C5: source hangt al onder target. Na merge zou een naïeve
+    UPDATE een self-loop (eenheid=target, parent=target) creëren in
+    organisatie_eenheid_parent en organisatie_eenheid.parent_id.
+    """
+    from datetime import date
+
+    from sqlalchemy import text
+
+    handmatig = reconciliation_setup["handmatig"]
+    tooi = reconciliation_setup["tooi"]
+    rec = reconciliation_setup["rec"]
+
+    # Source hangt onder target via direct parent_id
+    handmatig.parent_id = tooi.id
+    # Plus temporele tabel: actieve rij (eenheid=source, parent=target)
+    await db_session.execute(
+        text(
+            "INSERT INTO organisatie_eenheid_parent "
+            "(eenheid_id, parent_id, geldig_van) VALUES (:e, :p, :v)"
+        ),
+        {"e": handmatig.id, "p": tooi.id, "v": date.today()},
+    )
+    await db_session.flush()
+
+    resp = await client.post(f"/api/admin/reconciliation/{rec.id}/merge")
+    assert resp.status_code == 200, resp.text
+
+    # organisatie_eenheid.parent_id mag niet naar zichzelf wijzen
+    row = (
+        await db_session.execute(
+            text("SELECT parent_id FROM organisatie_eenheid WHERE id = :t"),
+            {"t": tooi.id},
+        )
+    ).first()
+    assert row.parent_id != tooi.id, "self-loop in organisatie_eenheid.parent_id!"
+
+    # organisatie_eenheid_parent mag geen self-loop bevatten
+    self_loops = (
+        await db_session.execute(
+            text(
+                "SELECT COUNT(*) AS n FROM organisatie_eenheid_parent "
+                "WHERE eenheid_id = parent_id"
+            ),
+        )
+    ).first()
+    assert self_loops.n == 0, (
+        f"{self_loops.n} self-loops in organisatie_eenheid_parent!"
+    )
+
+
+async def test_reconciliation_merge_dedup_stakeholder_assessment(
+    client, db_session: AsyncSession, reconciliation_setup, sample_person
+):
+    """Regressie C14: stakeholder_assessment heeft unique
+    (person_id, scope_type, scope_id). Als persoon assessment heeft op
+    zowel source als target eenheid, mag UPDATE niet violaten.
+    """
+    from sqlalchemy import text
+
+    handmatig = reconciliation_setup["handmatig"]
+    tooi = reconciliation_setup["tooi"]
+    rec = reconciliation_setup["rec"]
+
+    # Twee assessments voor dezelfde persoon — één op source, één op target
+    for scope_id, belang in [(handmatig.id, 3), (tooi.id, 5)]:
+        await db_session.execute(
+            text(
+                "INSERT INTO stakeholder_assessment "
+                "(person_id, scope_type, scope_id, belang) "
+                "VALUES (:p, 'organisatie_eenheid', :s, :b)"
+            ),
+            {"p": sample_person.id, "s": scope_id, "b": belang},
+        )
+    await db_session.flush()
+
+    resp = await client.post(f"/api/admin/reconciliation/{rec.id}/merge")
+    assert resp.status_code == 200, resp.text
+
+    # Verwacht: één assessment op target (target's eigen overleeft, source's
+    # wordt gededupeerd). Geen unique-violation, geen orphan op source.
+    rows = (
+        await db_session.execute(
+            text(
+                "SELECT scope_id, belang FROM stakeholder_assessment "
+                "WHERE person_id = :p AND scope_type = 'organisatie_eenheid'"
+            ),
+            {"p": sample_person.id},
+        )
+    ).all()
+    assert len(rows) == 1
+    assert rows[0].scope_id == tooi.id
+    assert rows[0].belang == 5  # Target's eigen waarde behouden

--- a/frontend/src/api/reconciliation.ts
+++ b/frontend/src/api/reconciliation.ts
@@ -29,3 +29,14 @@ export async function mergeReconciliation(id: string): Promise<{ status: string;
 export async function ignoreReconciliation(id: string): Promise<{ status: string }> {
   return apiPost(`/api/admin/reconciliation/${id}/ignore`, {});
 }
+
+export interface OrphanScanResult {
+  scanned: number;
+  found_match: number;
+  new_reconciliations: number;
+  already_pending: number;
+}
+
+export async function scanOrphanHandmatig(): Promise<OrphanScanResult> {
+  return apiPost('/api/admin/sync/orphan-handmatig', {});
+}

--- a/frontend/src/components/admin/ReconciliationManager.tsx
+++ b/frontend/src/components/admin/ReconciliationManager.tsx
@@ -5,6 +5,8 @@ import {
   listReconciliations,
   mergeReconciliation,
   ignoreReconciliation,
+  scanOrphanHandmatig,
+  type OrphanScanResult,
 } from '@/api/reconciliation';
 import { Button } from '@/components/common/Button';
 import { Card } from '@/components/common/Card';
@@ -36,6 +38,15 @@ export function ReconciliationManager() {
     },
   });
 
+  const [scanResult, setScanResult] = useState<OrphanScanResult | null>(null);
+  const orphanScanMutation = useMutation({
+    mutationFn: scanOrphanHandmatig,
+    onSuccess: (data) => {
+      setScanResult(data);
+      queryClient.invalidateQueries({ queryKey: ['reconciliation'] });
+    },
+  });
+
   return (
     <div className="space-y-4">
       <div>
@@ -49,6 +60,31 @@ export function ReconciliationManager() {
           beide rijen bestaan.
         </p>
       </div>
+
+      <Card>
+        <div className="p-3 flex items-center justify-between gap-3 text-sm">
+          <div>
+            <strong>Scan op afkorting/naam-match:</strong> zoekt handmatige
+            rijen (vaak FCC-import) die alsnog matchen op een TOOI-rij.
+            Genereert open reconciliations.
+            {scanResult && (
+              <span className="ml-2 text-text-secondary">
+                Laatste run: {scanResult.scanned} gescand,
+                {' '}{scanResult.found_match} matches,
+                {' '}{scanResult.new_reconciliations} nieuw,
+                {' '}{scanResult.already_pending} al open.
+              </span>
+            )}
+          </div>
+          <Button
+            onClick={() => orphanScanMutation.mutate()}
+            disabled={orphanScanMutation.isPending}
+            variant="secondary"
+          >
+            {orphanScanMutation.isPending ? 'Bezig…' : 'Scan starten'}
+          </Button>
+        </div>
+      </Card>
 
       <div className="flex gap-2">
         {(['open', 'merged', 'ignored'] as const).map((s) => (


### PR DESCRIPTION
## Achtergrond

Na merge van #313 in productie zijn er twee problemen:

**1. Reconciliation-merge faalt op BZK + Rijksorganisatie ODI.**
De endpoint migreert alleen drie FK-kolommen voor delete: \`person_organisatie\`, \`lead\`, \`opdracht.opdrachtnemer\`. BZK heeft sub-DG's (parent_id RESTRICT) en interne members/eenheid_modules/resource_permissions. Delete crasht op FK-violation.

**2. CJIB staat 3x in zoek.**
1) TOOI \`Centraal Justitieel Incassobureau\` onder JenV-agentschappen
2) FCC-rij \`CJIB\` (afkorting=CJIB) onder \"Marktpartijen en overige\"
3) Andere TOOI-rij onder ZBO's

De FCC-rij belandde daar omdat \`externe_org_reconciliation.yaml\` (20 entries) CJIB niet kent — de migratie viel in de \`else\`-branch en plaatste 'm zonder afkorting/naam-match-poging tegen TOOI.

## Wat doet deze PR

### Fix A: robuuste merge via FK-introspectie

Nieuwe helper \`merge_organisatie_eenheden.py\` ontdekt via \`pg_catalog\` alle FK's naar \`organisatie_eenheid.id\` en rewrite ze. Toekomstige models worden automatisch gedekt.

Speciale gevallen:
- \`organisatie_eenheid.parent_id\` (RESTRICT, self-FK): children-rewrite vóór delete
- Composite unique constraints (\`eenheid_module\`, \`organisatie_email_domein\`, \`person_organisatie_eenheid\`): dedup per (target, other_cols) vóór UPDATE
- Partial unique \`WHERE geldig_tot IS NULL\` (\`organisatie_eenheid_naam\`, \`organisatie_eenheid_parent\`): bron's actieve rij afsluiten als target er ook één heeft
- Polymorphic \`resource_type+resource_id\` (\`resource_permission\`, \`stakeholder_assessment\`, \`activity\`, \`notification\`): kolom-bestaan-check eerst (asyncpg aborteert transactie op missende kolom)

\`reconciliation.py\` route gebruikt nu deze helper. Response bevat \`rewritten\`-dict voor telemetry.

### Fix B: orphan-handmatig scan

Nieuwe service \`detect_orphan_handmatig.py\` zoekt handmatige rijen zonder \`tooi_uri\` die alsnog matchen op afkorting (CI-exact) of genormaliseerde naam (prefix-stripping voor 'agentschap', 'DG', 'stichting' etc.) met een TOOI-rij. Genereert \`PendingReconciliation\`-rijen die via dezelfde merge-flow opgelost worden.

Trigger via:
- \`POST /api/admin/sync/orphan-handmatig\`
- 'Scan starten'-knop in Beheer > Reconciliatie

## Tests

12 nieuwe tests:
- \`test_reconciliation_merge_verplaatst_children\` (regressie BZK-scenario)
- \`test_reconciliation_merge_dedup_op_eenheid_module\` (composite unique)
- \`test_orphan_match_op_afkorting_genereert_reconciliation\` (CJIB-scenario)
- \`test_orphan_match_op_genormaliseerde_naam\` ('agentschap X' = 'X')
- \`test_orphan_skipt_reeds_open_reconciliation\` (idempotency)
- ...

Alle 19 reconciliation/orphan/tooi-tests groen lokaal. Lint + format clean. tsc clean.

## Test plan

- [ ] CI groen
- [ ] Na deploy: merge BZK-reconciliation in Beheer > Reconciliatie. Verifieer dat sub-DG's, members, opdrachten, leads allemaal verhuizen naar de TOOI-rij.
- [ ] Klik 'Scan starten' in Beheer > Reconciliatie. Verifieer dat CJIB en andere FCC-rijen die op TOOI matchen verschijnen als nieuwe open reconciliations.
- [ ] Merge ze en verifieer dat de zoek-functie nog maar één CJIB-rij toont.