### PR TITLE
Ontescape HTML-entities bij organisatie-import

### DIFF
--- a/backend/bouwmeester/core/text.py
+++ b/backend/bouwmeester/core/text.py
@@ -1,4 +1,4 @@
-"""Tekst-helpers voor externe-bron-import."""
+"""Text helpers for external-source import."""
 
 from __future__ import annotations
 
@@ -6,10 +6,11 @@ import html
 
 
 def unescape_html(value: str | None) -> str | None:
-    """Decode HTML-entities (&amp; -> &) uit externe-bron-tekst.
+    """Decode HTML entities (&amp; -> &) from external-source text.
 
-    Idempotent voor normale tekst: html.unescape() laat strings zonder
-    entities ongemoeid. Veilig om bij elke import-extractie aan te roepen.
+    Idempotent for clean text: html.unescape() leaves entity-free strings
+    untouched. Safe to call at every import extraction point. Note it only
+    strips one layer, which is exactly what we want for single-encoded input.
     """
     if value is None:
         return None

--- a/backend/bouwmeester/core/text.py
+++ b/backend/bouwmeester/core/text.py
@@ -1,0 +1,16 @@
+"""Tekst-helpers voor externe-bron-import."""
+
+from __future__ import annotations
+
+import html
+
+
+def unescape_html(value: str | None) -> str | None:
+    """Decode HTML-entities (&amp; -> &) uit externe-bron-tekst.
+
+    Idempotent voor normale tekst: html.unescape() laat strings zonder
+    entities ongemoeid. Veilig om bij elke import-extractie aan te roepen.
+    """
+    if value is None:
+        return None
+    return html.unescape(value)

--- a/backend/bouwmeester/migrations/versions/74c4d614b7f5_unescape_html_entities_in_organisatie_.py
+++ b/backend/bouwmeester/migrations/versions/74c4d614b7f5_unescape_html_entities_in_organisatie_.py
@@ -1,0 +1,54 @@
+"""unescape html entities in organisatie names
+
+Bestaande rijen zijn geimporteerd voordat de import-extractie HTML-entities
+ontescapete. Namen als "Directie Ambtenaar &amp; Organisatie (A&amp;O)" staan
+letterlijk in de DB. Deze data-only migratie draait html.unescape() over
+organisatie_eenheid.naam en .afkorting voor elke rij die nog een entity bevat.
+
+Geen schema-wijziging. downgrade() is een no-op: re-escapen is niet
+betrouwbaar omkeerbaar (we weten niet welke '&' origineel '&amp;' was).
+
+Revision ID: 74c4d614b7f5
+Revises: 9d4e5f6a7b02
+Create Date: 2026-05-16 00:00:00.000000
+
+"""
+
+import html
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "74c4d614b7f5"
+down_revision: str | None = "9d4e5f6a7b02"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    rows = conn.execute(
+        sa.text(
+            "SELECT id, naam, afkorting FROM organisatie_eenheid "
+            "WHERE naam LIKE '%&%;%' OR afkorting LIKE '%&%;%'"
+        )
+    ).fetchall()
+    for row_id, naam, afkorting in rows:
+        new_naam = html.unescape(naam) if naam is not None else None
+        new_afkorting = html.unescape(afkorting) if afkorting is not None else None
+        if new_naam == naam and new_afkorting == afkorting:
+            continue
+        conn.execute(
+            sa.text(
+                "UPDATE organisatie_eenheid SET naam = :naam, afkorting = :afkorting "
+                "WHERE id = :id"
+            ),
+            {"naam": new_naam, "afkorting": new_afkorting, "id": row_id},
+        )
+
+
+def downgrade() -> None:
+    # No-op: re-escaping is not reliably reversible.
+    pass

--- a/backend/bouwmeester/services/fcc_import_service.py
+++ b/backend/bouwmeester/services/fcc_import_service.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import selectinload
 
 from bouwmeester.core.config import get_settings
 from bouwmeester.core.encryption import decrypt_value
+from bouwmeester.core.text import unescape_html
 from bouwmeester.models.app_config import AppConfig
 from bouwmeester.models.opdracht import Opdracht
 from bouwmeester.schema.fcc import SyncDirection, SyncStatus
@@ -203,9 +204,9 @@ class FccImportService:
         from decimal import Decimal
 
         if naam := data.get("Naam"):
-            opdracht.titel = naam
+            opdracht.titel = unescape_html(naam)
         if desc := data.get("Omschrijving"):
-            opdracht.beschrijving = desc
+            opdracht.beschrijving = unescape_html(desc)
         if (budget := data.get("Budget_huidig_jaar_")) is not None:
             try:
                 opdracht.budget = Decimal(str(budget))
@@ -250,7 +251,7 @@ class FccImportService:
 
         from bouwmeester.models.organisatie_eenheid import OrganisatieEenheid
 
-        uitvoering = (data.get("Uitvoeringsorganisatie") or "").strip()
+        uitvoering = unescape_html((data.get("Uitvoeringsorganisatie") or "").strip())
         if not uitvoering:
             opdracht.opdrachtnemer_eenheid_id = None
             return

--- a/backend/bouwmeester/services/kabinet_scrape.py
+++ b/backend/bouwmeester/services/kabinet_scrape.py
@@ -25,6 +25,7 @@ import yaml
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from bouwmeester.core.text import unescape_html
 from bouwmeester.models.organisatie_eenheid import OrganisatieEenheid
 
 log = logging.getLogger(__name__)
@@ -128,7 +129,8 @@ async def scrape_bewindspersonen() -> list[tuple[str, str]]:
         resp = await client.get(URL)
         resp.raise_for_status()
     return [
-        (naam.strip(), funct.strip()) for naam, funct in ENTRY_RE.findall(resp.text)
+        (unescape_html(naam.strip()), unescape_html(funct.strip()))
+        for naam, funct in ENTRY_RE.findall(resp.text)
     ]
 
 

--- a/backend/bouwmeester/services/organogram_scrape.py
+++ b/backend/bouwmeester/services/organogram_scrape.py
@@ -26,6 +26,7 @@ import httpx
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from bouwmeester.core.text import unescape_html
 from bouwmeester.models.organisatie_eenheid import OrganisatieEenheid
 from bouwmeester.models.tooi_sync_log import TooiSyncLog
 
@@ -95,7 +96,7 @@ class OrganogramScrapeStats:
 def _parse_organogram_index(html: str) -> list[DgInfo]:
     """Pak alle DG's uit de organogram-indexpagina."""
     return [
-        DgInfo(naam=naam.strip(), detail_url=ORGANOGRAM_BASE + url)
+        DgInfo(naam=unescape_html(naam.strip()), detail_url=ORGANOGRAM_BASE + url)
         for url, naam in WAYFINDER_RE.findall(html)
     ]
 
@@ -104,7 +105,7 @@ def _parse_directies(html: str) -> list[str]:
     """Pak directies (h2-koppen) uit DG-detailpagina, exclusief metadata-koppen."""
     out: list[str] = []
     for h in H2_RE.findall(html):
-        clean = h.strip()
+        clean = unescape_html(h.strip())
         if not clean:
             continue
         if clean.lower() in H2_BLACKLIST:

--- a/backend/bouwmeester/services/tooi_sync.py
+++ b/backend/bouwmeester/services/tooi_sync.py
@@ -27,6 +27,7 @@ import httpx
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from bouwmeester.core.text import unescape_html
 from bouwmeester.models.organisatie_eenheid import OrganisatieEenheid
 from bouwmeester.models.pending_reconciliation import PendingReconciliation
 from bouwmeester.models.tooi_sync_log import TooiSyncLog
@@ -139,7 +140,9 @@ def _value(node: dict[str, Any], predicate: str) -> str | None:
     if not items:
         return None
     first = items[0]
-    return first.get("@value") if isinstance(first, dict) else None
+    if not isinstance(first, dict):
+        return None
+    return unescape_html(first.get("@value"))
 
 
 def _id(node: dict[str, Any], predicate: str) -> str | None:

--- a/backend/tests/test_text.py
+++ b/backend/tests/test_text.py
@@ -1,0 +1,34 @@
+"""Tests voor de unescape_html-helper."""
+
+from __future__ import annotations
+
+import pytest
+
+from bouwmeester.core.text import unescape_html
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (
+            "Directie Ambtenaar &amp; Organisatie (A&amp;O)",
+            "Directie Ambtenaar & Organisatie (A&O)",
+        ),
+        ("&quot;quoted&quot;", '"quoted"'),
+        ("d&#39;Hondt", "d'Hondt"),
+        ("Caf&eacute;", "Café"),
+        # Idempotent: al-schone tekst blijft ongemoeid.
+        (
+            "Directie Ambtenaar & Organisatie (A&O)",
+            "Directie Ambtenaar & Organisatie (A&O)",
+        ),
+        ("gewone naam zonder entities", "gewone naam zonder entities"),
+        ("", ""),
+    ],
+)
+def test_unescape_html(raw: str, expected: str) -> None:
+    assert unescape_html(raw) == expected
+
+
+def test_unescape_html_none_passthrough() -> None:
+    assert unescape_html(None) is None

--- a/backend/tests/test_tooi_sync.py
+++ b/backend/tests/test_tooi_sync.py
@@ -20,7 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from bouwmeester.models.organisatie_eenheid import OrganisatieEenheid
 from bouwmeester.models.pending_reconciliation import PendingReconciliation
-from bouwmeester.services.tooi_sync import TooiOrganisatie, sync_tooi
+from bouwmeester.services.tooi_sync import TooiOrganisatie, _parse_rwc, sync_tooi
 
 
 @pytest.fixture
@@ -267,3 +267,21 @@ async def test_sync_soft_delete_en_reactivate(db_session: AsyncSession, synth_gr
     await sync_tooi(db_session, fetcher=hersteld, commit=False)
     await db_session.refresh(weg)
     assert weg.geldig_tot is None
+
+
+def test_parse_rwc_unescapes_html_entities() -> None:
+    """JSON-LD-bron levert &amp;; _parse_rwc moet naam/afkorting ontescapen."""
+    node = {
+        "@id": "https://identifier.overheid.nl/tooi/id/test/ao",
+        "@type": ["https://identifier.overheid.nl/tooi/def/ont/Ministerie"],
+        "https://identifier.overheid.nl/tooi/def/ont/voorkeursnaamInclSoort": [
+            {"@value": "Directie Ambtenaar &amp; Organisatie (A&amp;O)"}
+        ],
+        "https://identifier.overheid.nl/tooi/def/ont/afkorting": [
+            {"@value": "A&amp;O"}
+        ],
+    }
+    orgs = _parse_rwc("rwc_ministeries_compleet", "ministerie", None, [node])
+    assert len(orgs) == 1
+    assert orgs[0].naam == "Directie Ambtenaar & Organisatie (A&O)"
+    assert orgs[0].afkorting == "A&O"


### PR DESCRIPTION
## Probleem

Organisatie-namen tonen `&amp;` letterlijk in de UI, bijv. `Directie Ambtenaar &amp; Organisatie (A&amp;O)` i.p.v. `Directie Ambtenaar & Organisatie (A&O)`. De HTML-bronnen (TOOI-JSON-LD met entity-geëncodeerde `@value`, rijksoverheid.nl-HTML via rauwe regex) leveren namen met HTML-entities die nooit ontescaped werden voordat ze in `organisatie_eenheid.naam` belandden. React rendert die strings als platte tekst, dus de entity verschijnt letterlijk op het scherm. De DB bevat al vervuilde rijen én de import bleef nieuwe produceren.

## Aanpak

- Nieuwe gedeelde helper `core/text.unescape_html()` (dunne wrapper om `html.unescape`, idempotent voor schone tekst, `None`-passthrough, strip één laag).
- Toegepast op elk extractiepunt:
  - `tooi_sync._value()` — dekt naam, afkorting, organisatiecode in één keer (autoritatieve bron, ~1100 organisaties); bewezen bron van de bug
  - `organogram_scrape` — DG-naam + directie-koppen (rauwe regex op HTML, idem)
  - `kabinet_scrape` — naam + functie (rauwe regex op HTML, idem)
  - `fcc_import_service` — titel, beschrijving, uitvoeringsorganisatie. **Defensief**: FCC OData is JSON, niet HTML, dus hier zijn entities niet bewezen aanwezig. Meegenomen voor consistentie zodat één gedeelde import-helper alle externe-bron-tekst dekt; no-op als de OData al plain UTF-8 is.
- Data-only migratie `74c4d614b7f5` ontescapet bestaande vervuilde rijen. `html.unescape()` per rij i.p.v. naïeve `&amp;`-replace, zodat `&quot;`/`&#39;`/`&eacute;` ook meekomen. Alleen rijen die echt wijzigen worden geüpdatet. `downgrade()` is een no-op (re-escapen niet betrouwbaar omkeerbaar).

## Tests

- `test_text.py` — helper-unittests (entity-decode, idempotent, `None`, `&quot;`/`&#39;`/`&eacute;`)
- `test_tooi_sync.py` — `_parse_rwc()` met entity-payload, assert `naam`/`afkorting` ontescaped
- De drie scrape/FCC call-sites zijn one-liners die dezelfde helper aanroepen; die paden waren al integratie-only (geen unit-tests in de codebase)
- Migratie handmatig geverifieerd: vervuilde rij `Directie Ambtenaar &amp; Organisatie (A&amp;O)` → `Directie Ambtenaar & Organisatie (A&O)`, `A&amp;O` → `A&O` na downgrade+upgrade re-run
- Volledige suites groen: `test_text` (7), `test_tooi_sync` (8), `test_onderwijs_kabinet_sync` (5); CI groen (backend-lint, backend-test, frontend-checks)