### PR TITLE
Instrument-dropdown: inline aanmaken met type, alfabetisch sorteren

### DIFF
--- a/backend/bouwmeester/repositories/corpus_node.py
+++ b/backend/bouwmeester/repositories/corpus_node.py
@@ -150,7 +150,10 @@ class CorpusNodeRepository(BaseRepository[CorpusNode]):
             stmt = stmt.where(exclude_unconnected_pi())
 
         stmt = apply_org_filter(stmt, CorpusNode.organisatie_eenheid_id, org_ctx)
-        stmt = stmt.order_by(CorpusNode.created_at.desc()).offset(skip).limit(limit)
+        # Alphabetical by title: this is the generic node list used by
+        # selection dropdowns (e.g. the Opdracht instrument picker), where
+        # alphabetical order is what users expect, not creation order.
+        stmt = stmt.order_by(CorpusNode.title.asc()).offset(skip).limit(limit)
         result = await self.session.execute(stmt)
         return list(result.scalars().all())
 

--- a/backend/bouwmeester/schema/corpus_node.py
+++ b/backend/bouwmeester/schema/corpus_node.py
@@ -3,7 +3,7 @@
 import enum
 from datetime import date, datetime
 from decimal import Decimal
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -56,8 +56,17 @@ class CorpusNodeBase(BaseModel):
     status: str = Field("actief", max_length=50)
 
 
+InstrumentType = Literal[
+    "wetgeving", "subsidie", "voorlichting", "handhaving", "overig"
+]
+
+
 class CorpusNodeCreate(CorpusNodeBase):
     geldig_van: date | None = None  # defaults to today in repository
+    # Only meaningful when node_type == "instrument": sets Instrument.type
+    # on the auto-created extension row. Ignored for other node types.
+    # Defaults to "overig" in NodeService.create when omitted.
+    instrument_type: InstrumentType | None = None
 
     model_config = ConfigDict(
         json_schema_extra={

--- a/backend/bouwmeester/services/node_service.py
+++ b/backend/bouwmeester/services/node_service.py
@@ -59,7 +59,9 @@ class NodeService:
         type_factories = {
             "dossier": lambda nid: Dossier(id=nid, fase="verkenning"),
             "doel": lambda nid: Doel(id=nid, type="operationeel"),
-            "instrument": lambda nid: Instrument(id=nid, type="overig"),
+            "instrument": lambda nid: Instrument(
+                id=nid, type=data.instrument_type or "overig"
+            ),
             "beleidskader": lambda nid: Beleidskader(id=nid, scope="nationaal"),
             "maatregel": lambda nid: Maatregel(id=nid),
             "politieke_input": lambda nid: PolitiekeInput(id=nid, type="toezegging"),

--- a/backend/tests/test_instrument_create.py
+++ b/backend/tests/test_instrument_create.py
@@ -1,0 +1,71 @@
+"""Tests for instrument-node creation with an explicit instrument_type,
+and for the alphabetical ordering of the node list."""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bouwmeester.models.instrument import Instrument
+
+
+async def test_create_instrument_with_explicit_type(client, db_session: AsyncSession):
+    """POST /api/nodes with instrument_type sets Instrument.type accordingly."""
+    resp = await client.post(
+        "/api/nodes",
+        json={
+            "title": "Subsidieregeling open source",
+            "node_type": "instrument",
+            "instrument_type": "subsidie",
+        },
+    )
+    assert resp.status_code == 201
+    node_id = resp.json()["id"]
+
+    instrument = (
+        await db_session.execute(select(Instrument).where(Instrument.id == node_id))
+    ).scalar_one()
+    assert instrument.type == "subsidie"
+
+
+async def test_create_instrument_defaults_to_overig(client, db_session: AsyncSession):
+    """Omitting instrument_type keeps the existing default of 'overig'
+    (backwards compatible with all other create paths)."""
+    resp = await client.post(
+        "/api/nodes",
+        json={"title": "Naamloos instrument", "node_type": "instrument"},
+    )
+    assert resp.status_code == 201
+    node_id = resp.json()["id"]
+
+    instrument = (
+        await db_session.execute(select(Instrument).where(Instrument.id == node_id))
+    ).scalar_one()
+    assert instrument.type == "overig"
+
+
+async def test_create_instrument_rejects_unknown_type(client):
+    """An instrument_type outside the allowed set is a 422."""
+    resp = await client.post(
+        "/api/nodes",
+        json={
+            "title": "Fout instrument",
+            "node_type": "instrument",
+            "instrument_type": "geldboom",
+        },
+    )
+    assert resp.status_code == 422
+
+
+async def test_list_nodes_sorted_alphabetically(client):
+    """GET /api/nodes returns nodes ordered alphabetically by title,
+    so selection dropdowns are usable."""
+    for title in ["Zebra-instrument", "Alfa-instrument", "Midden-instrument"]:
+        resp = await client.post(
+            "/api/nodes",
+            json={"title": title, "node_type": "instrument"},
+        )
+        assert resp.status_code == 201
+
+    resp = await client.get("/api/nodes", params={"node_type": "instrument"})
+    assert resp.status_code == 200
+    titles = [n["title"] for n in resp.json()]
+    assert titles == sorted(titles)

--- a/frontend/src/api/nodes.ts
+++ b/frontend/src/api/nodes.ts
@@ -1,10 +1,11 @@
 import { apiGet, apiPost, apiPut, apiDelete, BASE_URL, getCsrfToken } from './client';
 import type { CorpusNode, CorpusNodeCreate, CorpusNodeUpdate, GraphViewResponse, NodeStakeholder, NodeTitleRecord, NodeStatusRecord, NodeType, NodeParlementairItem, NodeBronDetail, BijlageInfo } from '@/types';
 
-export async function getNodes(nodeType?: NodeType, search?: string): Promise<CorpusNode[]> {
+export async function getNodes(nodeType?: NodeType, search?: string, limit?: number): Promise<CorpusNode[]> {
   return apiGet<CorpusNode[]>('/api/nodes', {
     node_type: nodeType,
     search: search || undefined,
+    limit,
   });
 }
 

--- a/frontend/src/components/opdrachten/NieuwInstrumentDialog.tsx
+++ b/frontend/src/components/opdrachten/NieuwInstrumentDialog.tsx
@@ -1,0 +1,101 @@
+import { useState } from 'react';
+import { Modal } from '@/components/common/Modal';
+import { Button } from '@/components/common/Button';
+import { useCreateNode } from '@/hooks/useNodes';
+import { INSTRUMENT_TYPE_LABELS, NodeType } from '@/types';
+
+interface NieuwInstrumentDialogProps {
+  open: boolean;
+  /** Prefilled title — the text the user typed in the instrument dropdown. */
+  initialTitle: string;
+  onClose: () => void;
+  /** Called with the new instrument's id after a successful create. */
+  onCreated: (id: string) => void;
+}
+
+export function NieuwInstrumentDialog({ open, initialTitle, onClose, onCreated }: NieuwInstrumentDialogProps) {
+  const createNode = useCreateNode();
+  const [titel, setTitel] = useState(initialTitle);
+  const [type, setType] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!titel.trim()) {
+      setError('Geef een titel op.');
+      return;
+    }
+    if (!type) {
+      setError('Kies een type.');
+      return;
+    }
+    setError(null);
+    try {
+      const node = await createNode.mutateAsync({
+        title: titel.trim(),
+        node_type: NodeType.INSTRUMENT,
+        instrument_type: type,
+      });
+      onCreated(node.id);
+    } catch {
+      setError('Fout bij aanmaken van instrument.');
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title="Nieuw instrument"
+      size="sm"
+      zIndex={60}
+      footer={
+        <>
+          <Button variant="secondary" type="button" onClick={onClose}>
+            Annuleren
+          </Button>
+          <Button
+            type="submit"
+            form="nieuw-instrument-form"
+            loading={createNode.isPending}
+          >
+            Aanmaken
+          </Button>
+        </>
+      }
+    >
+      <form id="nieuw-instrument-form" onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-text mb-1">Titel *</label>
+          <input
+            type="text"
+            value={titel}
+            onChange={e => setTitel(e.target.value)}
+            required
+            autoFocus
+            className="w-full px-3 py-2 text-sm rounded-lg border border-border"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-text mb-1">Type *</label>
+          <select
+            value={type}
+            onChange={e => setType(e.target.value)}
+            required
+            className="w-full px-3 py-2 text-sm rounded-lg border border-border"
+          >
+            <option value="">Kies type...</option>
+            {Object.entries(INSTRUMENT_TYPE_LABELS).map(([v, l]) => (
+              <option key={v} value={v}>{l}</option>
+            ))}
+          </select>
+        </div>
+        {error && (
+          <div className="p-3 text-sm text-red-700 bg-red-50 border border-red-200 rounded-lg">
+            {error}
+          </div>
+        )}
+      </form>
+    </Modal>
+  );
+}

--- a/frontend/src/components/opdrachten/NieuwInstrumentDialog.tsx
+++ b/frontend/src/components/opdrachten/NieuwInstrumentDialog.tsx
@@ -2,15 +2,15 @@ import { useState } from 'react';
 import { Modal } from '@/components/common/Modal';
 import { Button } from '@/components/common/Button';
 import { useCreateNode } from '@/hooks/useNodes';
-import { INSTRUMENT_TYPE_LABELS, NodeType } from '@/types';
+import { INSTRUMENT_TYPE_LABELS, NodeType, type CorpusNode } from '@/types';
 
 interface NieuwInstrumentDialogProps {
   open: boolean;
   /** Prefilled title — the text the user typed in the instrument dropdown. */
   initialTitle: string;
   onClose: () => void;
-  /** Called with the new instrument's id after a successful create. */
-  onCreated: (id: string) => void;
+  /** Called with the freshly created instrument node after a successful create. */
+  onCreated: (node: CorpusNode) => void;
 }
 
 export function NieuwInstrumentDialog({ open, initialTitle, onClose, onCreated }: NieuwInstrumentDialogProps) {
@@ -36,7 +36,7 @@ export function NieuwInstrumentDialog({ open, initialTitle, onClose, onCreated }
         node_type: NodeType.INSTRUMENT,
         instrument_type: type,
       });
-      onCreated(node.id);
+      onCreated(node);
     } catch {
       setError('Fout bij aanmaken van instrument.');
     }

--- a/frontend/src/components/opdrachten/OpdrachtForm.tsx
+++ b/frontend/src/components/opdrachten/OpdrachtForm.tsx
@@ -9,6 +9,7 @@ import { CreatableSelect, type SelectOption } from '@/components/common/Creatabl
 import { RichTextFormField } from '@/components/common/RichTextFormField';
 import { buildPersonOptions } from '@/utils/personOptions';
 import { Badge } from '@/components/common/Badge';
+import { NieuwInstrumentDialog } from './NieuwInstrumentDialog';
 import {
   OpdrachtType,
   OpdrachtStatus,
@@ -38,7 +39,9 @@ export function OpdrachtForm({ opdracht, onClose, onSuccess, defaults }: Opdrach
   const createOrganisatieEenheid = useCreateOrganisatieEenheid();
   const addKoppeling = useAddOpdrachtNodeKoppeling();
   const removeKoppeling = useRemoveOpdrachtNodeKoppeling();
-  const { data: instrumenten = [] } = useNodes(NodeType.INSTRUMENT);
+  // limit=500 (backend max) so the instrument picker isn't truncated at the
+  // default 100; the dropdown must show every instrument.
+  const { data: instrumenten = [] } = useNodes(NodeType.INSTRUMENT, undefined, 500);
   const { data: allNodes = [] } = useNodes();
   const { data: people = [] } = usePeople();
   const { data: eenheden = [] } = useOrganisatieFlat();
@@ -70,6 +73,13 @@ export function OpdrachtForm({ opdracht, onClose, onSuccess, defaults }: Opdrach
     referentie: opdracht?.referentie || '',
     startdatum: opdracht?.startdatum || '',
     einddatum: opdracht?.einddatum || '',
+  });
+
+  // Inline "nieuw instrument" dialog: opened from the instrument dropdown's
+  // create action, prefilled with the text the user typed.
+  const [instrumentDialog, setInstrumentDialog] = useState<{ open: boolean; titel: string }>({
+    open: false,
+    titel: '',
   });
 
   const [koppelingen, setKoppelingen] = useState<OpdrachtNodeResponse[]>(opdracht?.node_koppelingen || []);
@@ -106,6 +116,14 @@ export function OpdrachtForm({ opdracht, onClose, onSuccess, defaults }: Opdrach
       parent_id: marktpartijenParent?.id ?? null,
     });
     return result?.id || null;
+  };
+
+  // Returns null: actual creation happens in the dialog, which sets the
+  // instrument id via onChange on success. CreatableSelect treats a null
+  // return as a soft success (closes + clears its query).
+  const handleCreateInstrument = async (text: string): Promise<string | null> => {
+    setInstrumentDialog({ open: true, titel: text });
+    return null;
   };
 
   const nodeOptions: SelectOption[] = allNodes
@@ -219,6 +237,8 @@ export function OpdrachtForm({ opdracht, onClose, onSuccess, defaults }: Opdrach
           onChange={(value) => setForm(f => ({ ...f, instrument_id: value }))}
           options={instrumentOptions}
           placeholder="Kies instrument..."
+          onCreate={handleCreateInstrument}
+          createLabel="Nieuw instrument"
         />
         <CreatableSelect
           label="Opdrachtnemer"
@@ -408,5 +428,18 @@ export function OpdrachtForm({ opdracht, onClose, onSuccess, defaults }: Opdrach
     </form>
   );
 
-  return formContent;
+  return (
+    <>
+      {formContent}
+      <NieuwInstrumentDialog
+        open={instrumentDialog.open}
+        initialTitle={instrumentDialog.titel}
+        onClose={() => setInstrumentDialog({ open: false, titel: '' })}
+        onCreated={(id) => {
+          setForm(f => ({ ...f, instrument_id: id }));
+          setInstrumentDialog({ open: false, titel: '' });
+        }}
+      />
+    </>
+  );
 }

--- a/frontend/src/components/opdrachten/OpdrachtForm.tsx
+++ b/frontend/src/components/opdrachten/OpdrachtForm.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { X, Plus } from 'lucide-react';
 import { useCreateOpdracht, useUpdateOpdracht, useAddOpdrachtNodeKoppeling, useRemoveOpdrachtNodeKoppeling } from '@/hooks/useOpdrachten';
 import { useNodes } from '@/hooks/useNodes';
+import { queryKeys } from '@/hooks/queryKeys';
 import { usePeople } from '@/hooks/usePeople';
 import { useOrganisatieFlat, useCreateOrganisatieEenheid } from '@/hooks/useOrganisatie';
 import { useCurrentPerson } from '@/contexts/CurrentPersonContext';
@@ -23,6 +25,7 @@ import {
   type OpdrachtCreate,
   type OpdrachtUpdate,
   type OpdrachtNodeResponse,
+  type CorpusNode,
 } from '@/types';
 
 interface OpdrachtFormProps {
@@ -50,6 +53,7 @@ export function OpdrachtForm({ opdracht, onClose, onSuccess, defaults }: Opdrach
     (e) => e.bron !== 'synthetisch' && !['ministerie', 'directoraat_generaal', 'directie', 'afdeling', 'cluster', 'bureau', 'team'].includes(e.type),
   );
   const { currentPerson } = useCurrentPerson();
+  const queryClient = useQueryClient();
 
   const [error, setError] = useState<string | null>(null);
 
@@ -440,8 +444,15 @@ export function OpdrachtForm({ opdracht, onClose, onSuccess, defaults }: Opdrach
         open={instrumentDialog.open}
         initialTitle={instrumentDialog.titel}
         onClose={() => setInstrumentDialog(d => ({ ...d, open: false, titel: '' }))}
-        onCreated={(id) => {
-          setForm(f => ({ ...f, instrument_id: id }));
+        onCreated={(node: CorpusNode) => {
+          // Seed the just-created instrument into the same cached list the
+          // dropdown reads from, so its label shows immediately instead of
+          // a blank field until useCreateNode's invalidation refetches.
+          queryClient.setQueryData<CorpusNode[]>(
+            queryKeys.nodes.list(NodeType.INSTRUMENT, undefined, 500),
+            (prev) => (prev ? [...prev, node] : [node]),
+          );
+          setForm(f => ({ ...f, instrument_id: node.id }));
           setInstrumentDialog(d => ({ ...d, open: false, titel: '' }));
         }}
       />

--- a/frontend/src/components/opdrachten/OpdrachtForm.tsx
+++ b/frontend/src/components/opdrachten/OpdrachtForm.tsx
@@ -77,9 +77,13 @@ export function OpdrachtForm({ opdracht, onClose, onSuccess, defaults }: Opdrach
 
   // Inline "nieuw instrument" dialog: opened from the instrument dropdown's
   // create action, prefilled with the text the user typed.
-  const [instrumentDialog, setInstrumentDialog] = useState<{ open: boolean; titel: string }>({
+  // `seq` increments on every open so the dialog remounts and its title
+  // field re-initialises from the freshly typed text (useState reads its
+  // initial value only once per mount).
+  const [instrumentDialog, setInstrumentDialog] = useState<{ open: boolean; titel: string; seq: number }>({
     open: false,
     titel: '',
+    seq: 0,
   });
 
   const [koppelingen, setKoppelingen] = useState<OpdrachtNodeResponse[]>(opdracht?.node_koppelingen || []);
@@ -122,7 +126,7 @@ export function OpdrachtForm({ opdracht, onClose, onSuccess, defaults }: Opdrach
   // instrument id via onChange on success. CreatableSelect treats a null
   // return as a soft success (closes + clears its query).
   const handleCreateInstrument = async (text: string): Promise<string | null> => {
-    setInstrumentDialog({ open: true, titel: text });
+    setInstrumentDialog(d => ({ open: true, titel: text, seq: d.seq + 1 }));
     return null;
   };
 
@@ -432,12 +436,13 @@ export function OpdrachtForm({ opdracht, onClose, onSuccess, defaults }: Opdrach
     <>
       {formContent}
       <NieuwInstrumentDialog
+        key={instrumentDialog.seq}
         open={instrumentDialog.open}
         initialTitle={instrumentDialog.titel}
-        onClose={() => setInstrumentDialog({ open: false, titel: '' })}
+        onClose={() => setInstrumentDialog(d => ({ ...d, open: false, titel: '' }))}
         onCreated={(id) => {
           setForm(f => ({ ...f, instrument_id: id }));
-          setInstrumentDialog({ open: false, titel: '' });
+          setInstrumentDialog(d => ({ ...d, open: false, titel: '' }));
         }}
       />
     </>

--- a/frontend/src/hooks/queryKeys.ts
+++ b/frontend/src/hooks/queryKeys.ts
@@ -12,7 +12,7 @@ export const queryKeys = {
   nodes: {
     all: ['nodes'] as const,
     lists: () => ['nodes', 'list'] as const,
-    list: (nodeType?: string, search?: string) => ['nodes', 'list', nodeType, search] as const,
+    list: (nodeType?: string, search?: string, limit?: number) => ['nodes', 'list', nodeType, search, limit] as const,
     details: () => ['nodes', 'detail'] as const,
     detail: (id: string | undefined) => ['nodes', 'detail', id] as const,
     neighbors: (id: string | undefined) => ['nodes', 'detail', id, 'neighbors'] as const,

--- a/frontend/src/hooks/useNodes.ts
+++ b/frontend/src/hooks/useNodes.ts
@@ -10,10 +10,10 @@ import { useMutationWithError } from '@/hooks/useMutationWithError';
 import { queryKeys } from '@/hooks/queryKeys';
 import type { CorpusNodeCreate, CorpusNodeUpdate, NodeType } from '@/types';
 
-export function useNodes(nodeType?: NodeType, search?: string) {
+export function useNodes(nodeType?: NodeType, search?: string, limit?: number) {
   return useQuery({
-    queryKey: queryKeys.nodes.list(nodeType, search),
-    queryFn: () => getNodes(nodeType, search),
+    queryKey: queryKeys.nodes.list(nodeType, search, limit),
+    queryFn: () => getNodes(nodeType, search, limit),
   });
 }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -96,6 +96,14 @@ export const BRON_TYPE_LABELS: Record<string, string> = {
   overig: 'Overig',
 };
 
+export const INSTRUMENT_TYPE_LABELS: Record<string, string> = {
+  wetgeving: 'Wetgeving',
+  subsidie: 'Subsidie',
+  voorlichting: 'Voorlichting',
+  handhaving: 'Handhaving',
+  overig: 'Overig',
+};
+
 // Node Status
 export enum NodeStatus {
   CONCEPT = 'concept',
@@ -151,6 +159,8 @@ export interface CorpusNodeCreate {
   status?: string;
   metadata?: Record<string, unknown>;
   geldig_van?: string | null;
+  /** Only used when node_type is 'instrument'; sets Instrument.type. */
+  instrument_type?: string;
 }
 
 export interface CorpusNodeUpdate {


### PR DESCRIPTION
## Aanleiding

Mattermost-feedback van Daniël de Wolf op het "Opdracht bewerken"-formulier. Hij vraagt wat een "instrument" is, en als blijkt dat het concrete beleidsinstrumenten zijn: "Dan mis ik de Subsidie, want dat is 't" en "(en die droplist is niet gesorteerd)".

Drie problemen onder die feedback:

1. De Instrument-dropdown stond op aanmaakdatum, niet alfabetisch.
2. De dropdown haalde instrumenten op zonder `limit`, dus de backend-default van 100 kapte stilletjes af.
3. Subsidie is een klassiek beleidsinstrument. Het datamodel kent dat al als `Instrument.type` (`wetgeving|subsidie|voorlichting|handhaving|overig`), maar er was geen UI om zelf een instrument toe te voegen, en `Instrument.type` werd bij aanmaak hardcoded op `"overig"` — nergens via de API te zetten.

## Wijzigingen

- **Sortering**: `CorpusNodeRepository.get_all` sorteert nu op `title ASC` i.p.v. `created_at DESC`. Dit is de generieke node-lijst die de keuzelijsten voedt; alfabetisch is daar de juiste default.
- **Limit**: `getNodes`/`useNodes` krijgen een optionele `limit` (opgenomen in de queryKey om cache-collisions te voorkomen). Het Opdracht-formulier haalt instrumenten met `limit=500` (backend-max).
- **Inline aanmaken**: nieuw `NieuwInstrumentDialog` met titel (voorgevuld met de getypte tekst) + verplicht type. De Instrument-`CreatableSelect` krijgt een "Nieuw instrument"-actie die de dialoog opent; na opslaan wordt het nieuwe instrument geselecteerd. Volgt het bestaande `bron`-extension-patroon (`BRON_TYPE_LABELS` → `INSTRUMENT_TYPE_LABELS`).
- **Backend**: `CorpusNodeCreate` krijgt een optioneel `instrument_type` (Literal-validatie op de vijf toegestane waarden). `NodeService.create` gebruikt dat i.p.v. hardcoded `"overig"`. Default blijft `"overig"` als niets wordt meegegeven, dus alle bestaande aanmaakpaden (o.a. `NodeCreateForm`) veranderen niet. Geen migratie nodig — de kolom bestond al.

## Buiten scope

- `Instrument.type` bewerkbaar maken ná aanmaak (geen UPDATE-pad/detail-UI; de feedback gaat over aanmaken/kiezen).
- Een kaal pseudo-instrument "Subsidie" als los dropdown-item — bewust niet: dat mengt categorie en concrete instrumenten en maakt de data inconsistent.

## Tests

- 4 nieuwe tests in `test_instrument_create.py`: create met expliciet type → `Instrument.type` gezet; zonder type → `overig` (backwards compat); ongeldig type → 422; node-lijst alfabetisch gesorteerd.
- Volledige backend-suite groen (1117 passed). Frontend `tsc` + `vite build` schoon.