### PR TITLE
DGDOO-duplicaat fixen: organogram-scrape op genormaliseerde naam + handmatige merge-UI

### DIFF
--- a/backend/bouwmeester/api/routes/reconciliation.py
+++ b/backend/bouwmeester/api/routes/reconciliation.py
@@ -239,6 +239,14 @@ async def manual_merge(
         raise HTTPException(
             status_code=404, detail="source of target eenheid bestaat niet"
         )
+    # Een synthetische rij is een container ('ZBO's en agentschappen',
+    # 'Marktpartijen en overige'), geen echte eenheid. FK's daarheen
+    # verhuizen is vrijwel altijd fout.
+    if target.bron == "synthetisch":
+        raise HTTPException(
+            status_code=400,
+            detail="target is een synthetische groep, geen echte eenheid",
+        )
 
     _backfill_target_fields(target=target, source=source)
     await db.flush()

--- a/backend/bouwmeester/api/routes/reconciliation.py
+++ b/backend/bouwmeester/api/routes/reconciliation.py
@@ -7,6 +7,7 @@ laten een super_admin (of org:manage) de duplicaten oplossen.
 GET /api/admin/reconciliation - lijst open conflicten
 POST /api/admin/reconciliation/{id}/merge - merge handmatige rij in TOOI-rij
 POST /api/admin/reconciliation/{id}/ignore - markeer als 'no merge'
+POST /api/admin/reconciliation/manual-merge - ad-hoc merge van twee eenheden
 """
 
 from __future__ import annotations
@@ -54,6 +55,33 @@ class ReconciliationResponse(BaseModel):
     created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class ManualMergeRequest(BaseModel):
+    # source verdwijnt, target blijft. De UI stelt standaard de gesyncte
+    # rij als target voor (officiële naam + tooi_uri blijven, alle FK's
+    # van de handmatige rij verhuizen mee), maar de admin mag omkeren.
+    source_id: uuid.UUID
+    target_id: uuid.UUID
+
+
+def _backfill_target_fields(
+    *, target: OrganisatieEenheid, source: OrganisatieEenheid
+) -> None:
+    """Vul lege target-velden met source-data vóór de merge.
+
+    afkorting/website/kvk/beschrijving levert TOOI niet maar een
+    handmatige rij vaak wel; zonder backfill zou die data met de
+    source-rij verdwijnen.
+    """
+    if not target.afkorting and source.afkorting:
+        target.afkorting = source.afkorting
+    if not target.website and source.website:
+        target.website = source.website
+    if not target.kvk_nummer and source.kvk_nummer:
+        target.kvk_nummer = source.kvk_nummer
+    if not target.beschrijving and source.beschrijving:
+        target.beschrijving = source.beschrijving
 
 
 @router.get("", response_model=list[ReconciliationResponse])
@@ -142,17 +170,7 @@ async def merge_reconciliation(
             detail="Een van beide rijen bestaat niet meer; reconciliation is stale",
         )
 
-    # Vul ontbrekende velden op kandidaat met handmatige data vóór de
-    # source-rij wordt verwijderd. afkorting/website/kvk/beschrijving zijn
-    # de velden die TOOI niet levert maar handmatig vaak wel.
-    if not kandidaat.afkorting and handmatig.afkorting:
-        kandidaat.afkorting = handmatig.afkorting
-    if not kandidaat.website and handmatig.website:
-        kandidaat.website = handmatig.website
-    if not kandidaat.kvk_nummer and handmatig.kvk_nummer:
-        kandidaat.kvk_nummer = handmatig.kvk_nummer
-    if not kandidaat.beschrijving and handmatig.beschrijving:
-        kandidaat.beschrijving = handmatig.beschrijving
+    _backfill_target_fields(target=kandidaat, source=handmatig)
     await db.flush()
 
     rewritten = await merge_organisatie_eenheden(db, handmatig.id, kandidaat.id)
@@ -192,3 +210,70 @@ async def ignore_reconciliation(
     rec.resolved_at = datetime.now()
     await db.commit()
     return {"status": "ignored"}
+
+
+@router.post("/manual-merge", summary="Ad-hoc merge van twee organisatie-eenheden")
+async def manual_merge(
+    body: ManualMergeRequest,
+    db: AsyncSession = Depends(get_db),
+    _perm=Depends(require_permission("org:manage")),
+) -> dict:
+    """Merge twee willekeurige eenheden zonder voorafgaande reconciliation.
+
+    Voor duplicaten die de scan niet vangt (bv. een seed-DG naast een
+    organogram-scrape-rij met net andere naam). Alle referenties van
+    source verhuizen naar target via dezelfde merge_organisatie_eenheden-
+    helper; source wordt daarna verwijderd. Eventuele open reconciliations
+    die naar source of target wijzen worden afgesloten zodat de admin geen
+    stale conflict-rij overhoudt.
+    """
+    if body.source_id == body.target_id:
+        raise HTTPException(
+            status_code=400, detail="source en target zijn dezelfde eenheid"
+        )
+
+    source = await db.get(OrganisatieEenheid, body.source_id)
+    target = await db.get(OrganisatieEenheid, body.target_id)
+    if source is None or target is None:
+        raise HTTPException(
+            status_code=404, detail="source of target eenheid bestaat niet"
+        )
+
+    _backfill_target_fields(target=target, source=source)
+    await db.flush()
+
+    rewritten = await merge_organisatie_eenheden(db, source.id, target.id)
+
+    # Sluit open reconciliations die nu zinloos zijn (source is weg).
+    stale = (
+        (
+            await db.execute(
+                select(PendingReconciliation).where(
+                    PendingReconciliation.status == "open",
+                    PendingReconciliation.handmatige_id.in_(
+                        [body.source_id, body.target_id]
+                    ),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for rec in stale:
+        rec.status = "merged"
+        rec.resolved_at = datetime.now()
+
+    await db.commit()
+    log.info(
+        "Manual merge: %s '%s' -> %s '%s'; FK-rewrites: %s",
+        source.id,
+        source.naam,
+        target.id,
+        target.naam,
+        rewritten,
+    )
+    return {
+        "status": "merged",
+        "doelrij_id": str(target.id),
+        "rewritten": rewritten,
+    }

--- a/backend/bouwmeester/api/routes/reconciliation.py
+++ b/backend/bouwmeester/api/routes/reconciliation.py
@@ -19,7 +19,7 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, ConfigDict
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from bouwmeester.core.database import get_db
@@ -216,6 +216,7 @@ async def ignore_reconciliation(
 async def manual_merge(
     body: ManualMergeRequest,
     db: AsyncSession = Depends(get_db),
+    perm_ctx: PermissionContext = Depends(get_permission_context),
     _perm=Depends(require_permission("org:manage")),
 ) -> dict:
     """Merge twee willekeurige eenheden zonder voorafgaande reconciliation.
@@ -244,14 +245,19 @@ async def manual_merge(
 
     rewritten = await merge_organisatie_eenheden(db, source.id, target.id)
 
-    # Sluit open reconciliations die nu zinloos zijn (source is weg).
+    # Sluit open reconciliations die nu zinloos zijn: source is verwijderd
+    # en al zijn FK's (ook PendingReconciliation.handmatige_id/kandidaat_id)
+    # zijn naar target herschreven. Een open conflict tussen target en
+    # zichzelf of een al-opgeloste source heeft geen betekenis meer.
+    ids = [body.source_id, body.target_id]
     stale = (
         (
             await db.execute(
                 select(PendingReconciliation).where(
                     PendingReconciliation.status == "open",
-                    PendingReconciliation.handmatige_id.in_(
-                        [body.source_id, body.target_id]
+                    or_(
+                        PendingReconciliation.handmatige_id.in_(ids),
+                        PendingReconciliation.kandidaat_id.in_(ids),
                     ),
                 )
             )
@@ -261,6 +267,7 @@ async def manual_merge(
     )
     for rec in stale:
         rec.status = "merged"
+        rec.resolved_by = perm_ctx.person_id
         rec.resolved_at = datetime.now()
 
     await db.commit()

--- a/backend/bouwmeester/core/text.py
+++ b/backend/bouwmeester/core/text.py
@@ -15,3 +15,37 @@ def unescape_html(value: str | None) -> str | None:
     if value is None:
         return None
     return html.unescape(value)
+
+
+# Prefixes that different sources add or drop for the same organisational
+# unit. organogram.overheid.nl lists "Digitalisering en Overheidsorganisatie"
+# where the seed has "DG Digitalisering en Overheidsorganisatie"; TOOI uses
+# "Ministerie van ..." where a scrape may not. Stripping these before
+# comparison lets cross-source matching find the same unit.
+_ORG_NAME_PREFIXES = (
+    "ministerie van ",
+    "directoraat-generaal ",
+    "directoraat generaal ",
+    "dg ",
+    "directie ",
+    "afdeling ",
+    "agentschap ",
+    "zbo ",
+    "stichting ",
+)
+
+
+def normalize_org_name(naam: str) -> str:
+    """Normalize an organisational-unit name for cross-source matching.
+
+    Lowercases, collapses whitespace, and strips one leading source-specific
+    prefix (see _ORG_NAME_PREFIXES). Used both by the organogram scrape (to
+    avoid creating a duplicate of an existing manual/seed row) and by the
+    orphan-handmatig reconciliation scan, so the two stay in lockstep.
+    """
+    n = " ".join(naam.lower().split())
+    for prefix in _ORG_NAME_PREFIXES:
+        if n.startswith(prefix):
+            n = n[len(prefix) :]
+            break
+    return n.strip()

--- a/backend/bouwmeester/services/detect_orphan_handmatig.py
+++ b/backend/bouwmeester/services/detect_orphan_handmatig.py
@@ -14,6 +14,12 @@ Match-strategie (in volgorde, eerste hit wint):
   1. afkorting case-insensitive exact (sterkst — 'CJIB' = 'CJIB')
   2. genormaliseerde naam (lower + trim + strip 'ministerie van' / 'agentschap')
 
+Kandidaten komen uit alle gesyncte bronnen (tooi, organogram_scrape,
+kabinet, ...), niet alleen TOOI. De DGDOO-duplicaat ontstond doordat een
+seed-DG ('DG Digitalisering en Overheidsorganisatie') en een
+organogram-scrape-rij ('Digitalisering en Overheidsorganisatie') naast
+elkaar bleven staan; een tooi-only kandidaatfilter zag dat nooit.
+
 Skipt rijen die al een open reconciliation hebben.
 """
 
@@ -26,10 +32,22 @@ from dataclasses import dataclass
 from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from bouwmeester.core.text import normalize_org_name
 from bouwmeester.models.organisatie_eenheid import OrganisatieEenheid
 from bouwmeester.models.pending_reconciliation import PendingReconciliation
 
 log = logging.getLogger(__name__)
+
+# Bronnen waaruit een kandidaat voor een handmatige rij mag komen. Alles
+# wat door een externe sync wordt onderhouden; 'handmatig' zelf valt af
+# (we willen een handmatige rij juist in een gesyncte rij opgaan).
+_KANDIDAAT_BRONNEN = (
+    "tooi",
+    "organogram_scrape",
+    "kabinet",
+    "rio",
+    "ministeries_csv",
+)
 
 
 @dataclass
@@ -38,23 +56,6 @@ class OrphanScanStats:
     found_match: int
     new_reconciliations: int
     already_pending: int
-
-
-def _normalize_name(naam: str) -> str:
-    n = " ".join(naam.lower().split())
-    for prefix in (
-        "ministerie van ",
-        "directoraat-generaal ",
-        "directoraat generaal ",
-        "dg ",
-        "agentschap ",
-        "zbo ",
-        "stichting ",
-    ):
-        if n.startswith(prefix):
-            n = n[len(prefix) :]
-            break
-    return n.strip()
 
 
 async def _existing_open_for_handmatig(
@@ -103,7 +104,7 @@ async def detect_orphan_handmatig_matches(
 
     for handmatig in handmatig_rows:
         afk = (handmatig.afkorting or "").strip()
-        norm = _normalize_name(handmatig.naam)
+        norm = normalize_org_name(handmatig.naam)
         if not afk and not norm:
             continue
 
@@ -127,7 +128,7 @@ async def detect_orphan_handmatig_matches(
                 await session.execute(
                     select(OrganisatieEenheid).where(
                         and_(
-                            OrganisatieEenheid.bron == "tooi",
+                            OrganisatieEenheid.bron.in_(_KANDIDAAT_BRONNEN),
                             OrganisatieEenheid.id != handmatig.id,
                             or_(*conditions),
                         )
@@ -148,7 +149,7 @@ async def detect_orphan_handmatig_matches(
                     break
         if kandidaat is None and norm:
             for kand in kandidaten:
-                if _normalize_name(kand.naam) == norm:
+                if normalize_org_name(kand.naam) == norm:
                     kandidaat = kand
                     match_reden = "naam_normalized"
                     break
@@ -168,17 +169,18 @@ async def detect_orphan_handmatig_matches(
             resource_type="organisatie_eenheid",
             handmatige_id=handmatig.id,
             kandidaat_id=kandidaat.id,
-            kandidaat_bron="tooi",
+            kandidaat_bron=kandidaat.bron or "tooi",
             match_reden=match_reden,
             status="open",
         )
         session.add(rec)
         stats.new_reconciliations += 1
         log.info(
-            "Orphan-match: handmatig %s '%s' (afk=%s) -> TOOI %s '%s' (%s)",
+            "Orphan-match: handmatig %s '%s' (afk=%s) -> %s %s '%s' (%s)",
             handmatig.id,
             handmatig.naam,
             handmatig.afkorting,
+            kandidaat.bron,
             kandidaat.id,
             kandidaat.naam,
             match_reden,

--- a/backend/bouwmeester/services/organogram_scrape.py
+++ b/backend/bouwmeester/services/organogram_scrape.py
@@ -26,7 +26,7 @@ import httpx
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from bouwmeester.core.text import unescape_html
+from bouwmeester.core.text import normalize_org_name, unescape_html
 from bouwmeester.models.organisatie_eenheid import OrganisatieEenheid
 from bouwmeester.models.tooi_sync_log import TooiSyncLog
 
@@ -234,9 +234,13 @@ async def sync_organogram(
             stats.skipped.append(ministerie.naam)
             continue
 
-        # Bestaande children van dit ministerie
+        # Bestaande children van dit ministerie, gekeyed op genormaliseerde
+        # naam. Cross-source-mismatch: de seed heeft "DG Digitalisering en
+        # Overheidsorganisatie", organogram.overheid.nl noemt diezelfde DG
+        # "Digitalisering en Overheidsorganisatie". Exacte string-match liet
+        # dat als duplicaat ontstaan; normaliseren strijkt de "DG "-prefix glad.
         bestaande_children = {
-            r.naam: r
+            normalize_org_name(r.naam): r
             for r in (
                 await session.execute(
                     select(OrganisatieEenheid).where(
@@ -250,8 +254,9 @@ async def sync_organogram(
         }
 
         for dg in dgs:
-            # Skip als handmatig al bestaat met dezelfde naam
-            if dg.naam in bestaande_children:
+            # Skip als er al een rij (handmatig, seed of eerdere scrape) met
+            # dezelfde genormaliseerde naam onder dit ministerie hangt
+            if normalize_org_name(dg.naam) in bestaande_children:
                 continue
             dg_type = _classificeer_dg_type(dg.naam)
             dg_row = OrganisatieEenheid(
@@ -273,23 +278,23 @@ async def sync_organogram(
                 )
             )
 
-            # Directies onder DG
-            for d_naam in directies_per_dg.get(dg.naam, []):
-                # Check niet handmatig
-                bestaand = (
-                    (
-                        await session.execute(
-                            select(OrganisatieEenheid).where(
-                                OrganisatieEenheid.naam == d_naam,
-                                OrganisatieEenheid.parent_id == dg_row.id,
-                                OrganisatieEenheid.geldig_tot.is_(None),
-                            )
+            # Directies onder DG. Genormaliseerde naam-match zodat een
+            # bestaande "Directie X" niet als "X" opnieuw wordt aangemaakt.
+            bestaande_dir_children = {
+                normalize_org_name(r.naam)
+                for r in (
+                    await session.execute(
+                        select(OrganisatieEenheid).where(
+                            OrganisatieEenheid.parent_id == dg_row.id,
+                            OrganisatieEenheid.geldig_tot.is_(None),
                         )
                     )
-                    .scalars()
-                    .first()
                 )
-                if bestaand:
+                .scalars()
+                .all()
+            }
+            for d_naam in directies_per_dg.get(dg.naam, []):
+                if normalize_org_name(d_naam) in bestaande_dir_children:
                     continue
                 dir_row = OrganisatieEenheid(
                     naam=d_naam,

--- a/backend/tests/test_detect_orphan_handmatig.py
+++ b/backend/tests/test_detect_orphan_handmatig.py
@@ -158,6 +158,49 @@ async def test_orphan_skipt_reeds_open_reconciliation(
     assert len(rec2) == 1
 
 
+async def test_orphan_match_op_organogram_bron(
+    db_session: AsyncSession, schone_pending
+):
+    """Kandidaat mag ook uit organogram_scrape komen, niet alleen tooi.
+
+    Dit is de DGDOO-case: seed-DG 'DG X' (handmatig) naast een
+    organogram-scrape-rij 'X' — een tooi-only kandidaatfilter zag dat
+    nooit en liet het duplicaat staan.
+    """
+    seed_dg = OrganisatieEenheid(
+        id=uuid.uuid4(),
+        naam="DG Digitalisering-test-Overheidsorg",
+        type="directoraat_generaal",
+        bron="handmatig",
+    )
+    organogram = OrganisatieEenheid(
+        id=uuid.uuid4(),
+        naam="Digitalisering-test-Overheidsorg",
+        type="directoraat_generaal",
+        bron="organogram_scrape",
+    )
+    db_session.add_all([seed_dg, organogram])
+    await db_session.flush()
+
+    await detect_orphan_handmatig_matches(db_session, commit=False)
+
+    rec = (
+        (
+            await db_session.execute(
+                select(PendingReconciliation).where(
+                    PendingReconciliation.handmatige_id == seed_dg.id
+                )
+            )
+        )
+        .scalars()
+        .first()
+    )
+    assert rec is not None
+    assert rec.kandidaat_id == organogram.id
+    assert rec.kandidaat_bron == "organogram_scrape"
+    assert rec.match_reden == "naam_normalized"
+
+
 async def test_orphan_match_op_genormaliseerde_naam(
     db_session: AsyncSession, schone_pending
 ):

--- a/backend/tests/test_organogram_scrape.py
+++ b/backend/tests/test_organogram_scrape.py
@@ -1,0 +1,91 @@
+"""Tests voor organogram-scrape dedup op genormaliseerde naam.
+
+De DGDOO-duplicaat: seed maakt 'DG Digitalisering en Overheidsorganisatie',
+organogram.overheid.nl noemt diezelfde DG 'Digitalisering en
+Overheidsorganisatie'. Exacte string-match liet dat als tweede rij
+ontstaan; na de fix matcht de scrape op genormaliseerde naam.
+"""
+
+import uuid
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bouwmeester.core.text import normalize_org_name
+from bouwmeester.models.organisatie_eenheid import OrganisatieEenheid
+from bouwmeester.services.organogram_scrape import DgInfo, sync_organogram
+
+
+def test_normalize_org_name_stript_dg_prefix():
+    assert normalize_org_name("DG Digitalisering en Overheidsorganisatie") == (
+        normalize_org_name("Digitalisering en Overheidsorganisatie")
+    )
+    assert normalize_org_name("Ministerie van Financiën") == "financiën"
+    assert normalize_org_name("  Agentschap   Telecom ") == "telecom"
+    # Slechts één prefix wordt gestript (geen herhaalde pass)
+    assert normalize_org_name("DG DG Test") == "dg test"
+
+
+async def test_organogram_scrape_geen_duplicaat_op_dg_prefix(
+    db_session: AsyncSession,
+):
+    """Bestaande seed-DG 'DG X' + organogram levert 'X' -> geen tweede rij."""
+    bzk = OrganisatieEenheid(
+        id=uuid.uuid4(),
+        naam="ministerie van Binnenlandse Zaken en Koninkrijksrelaties",
+        type="ministerie",
+        bron="handmatig",
+    )
+    seed_dg = OrganisatieEenheid(
+        id=uuid.uuid4(),
+        naam="DG Digitalisering en Overheidsorganisatie",
+        type="directoraat_generaal",
+        bron="handmatig",
+        parent_id=bzk.id,
+    )
+    db_session.add_all([bzk, seed_dg])
+    await db_session.flush()
+
+    async def fake_fetch(slug: str):
+        # organogram noemt de DG zonder "DG "-prefix
+        return (
+            [DgInfo(naam="Digitalisering en Overheidsorganisatie", detail_url="x")],
+            {},
+        )
+
+    stats = await sync_organogram(db_session, fetcher=fake_fetch)
+
+    # De bestaande DG werd herkend -> geen nieuwe DG aangemaakt
+    assert stats.dgs_added == 0
+
+    count = (
+        await db_session.execute(
+            select(func.count())
+            .select_from(OrganisatieEenheid)
+            .where(
+                OrganisatieEenheid.parent_id == bzk.id,
+                OrganisatieEenheid.geldig_tot.is_(None),
+            )
+        )
+    ).scalar_one()
+    assert count == 1, f"Verwacht 1 DG onder BZK, kreeg {count} (duplicaat!)"
+
+
+async def test_organogram_scrape_maakt_wel_nieuwe_dg_aan(
+    db_session: AsyncSession,
+):
+    """Sanity: een echt nieuwe DG wordt nog steeds aangemaakt."""
+    bzk = OrganisatieEenheid(
+        id=uuid.uuid4(),
+        naam="ministerie van Binnenlandse Zaken en Koninkrijksrelaties",
+        type="ministerie",
+        bron="handmatig",
+    )
+    db_session.add(bzk)
+    await db_session.flush()
+
+    async def fake_fetch(slug: str):
+        return ([DgInfo(naam="DG Volkshuisvesting en Bouwen", detail_url="y")], {})
+
+    stats = await sync_organogram(db_session, fetcher=fake_fetch)
+    assert stats.dgs_added == 1

--- a/backend/tests/test_reconciliation.py
+++ b/backend/tests/test_reconciliation.py
@@ -469,6 +469,100 @@ async def test_reconciliation_merge_geen_self_loop_in_parent(
     )
 
 
+async def test_manual_merge_verplaatst_children_en_verwijdert_source(
+    client, db_session: AsyncSession
+):
+    """Ad-hoc merge zonder reconciliation-rij: DGDOO-scenario.
+
+    Seed-DG 'DG X' (source) heeft sub-eenheden; organogram-rij 'X'
+    (target) blijft. Sub-eenheden verhuizen, source verdwijnt.
+    """
+    seed_dg = OrganisatieEenheid(
+        id=uuid.uuid4(),
+        naam="DG Digitalisering en Overheidsorganisatie",
+        type="directoraat_generaal",
+        bron="handmatig",
+        afkorting="DGDOO",
+    )
+    organogram_dg = OrganisatieEenheid(
+        id=uuid.uuid4(),
+        naam="Digitalisering en Overheidsorganisatie",
+        type="directoraat_generaal",
+        bron="organogram_scrape",
+    )
+    child = OrganisatieEenheid(
+        id=uuid.uuid4(),
+        naam="Directie Digitale Overheid",
+        type="directie",
+        bron="handmatig",
+        parent_id=seed_dg.id,
+    )
+    db_session.add_all([seed_dg, organogram_dg, child])
+    await db_session.flush()
+
+    resp = await client.post(
+        "/api/admin/reconciliation/manual-merge",
+        json={"source_id": str(seed_dg.id), "target_id": str(organogram_dg.id)},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["doelrij_id"] == str(organogram_dg.id)
+
+    await db_session.refresh(child)
+    assert child.parent_id == organogram_dg.id
+
+    # afkorting van seed-DG is naar de organogram-rij gebackfilld
+    await db_session.refresh(organogram_dg)
+    assert organogram_dg.afkorting == "DGDOO"
+
+    weg = (
+        (
+            await db_session.execute(
+                select(OrganisatieEenheid).where(OrganisatieEenheid.id == seed_dg.id)
+            )
+        )
+        .scalars()
+        .first()
+    )
+    assert weg is None
+
+
+async def test_manual_merge_400_op_zelfde_eenheid(client, db_session: AsyncSession):
+    e = OrganisatieEenheid(id=uuid.uuid4(), naam="Solo", type="zbo", bron="handmatig")
+    db_session.add(e)
+    await db_session.flush()
+    resp = await client.post(
+        "/api/admin/reconciliation/manual-merge",
+        json={"source_id": str(e.id), "target_id": str(e.id)},
+    )
+    assert resp.status_code == 400
+
+
+async def test_manual_merge_404_op_onbekende_eenheid(client):
+    resp = await client.post(
+        "/api/admin/reconciliation/manual-merge",
+        json={"source_id": str(uuid.uuid4()), "target_id": str(uuid.uuid4())},
+    )
+    assert resp.status_code == 404
+
+
+async def test_manual_merge_sluit_open_reconciliation(
+    client, db_session: AsyncSession, reconciliation_setup
+):
+    """Open reconciliation die naar de gemergede rijen wijst wordt afgesloten."""
+    handmatig = reconciliation_setup["handmatig"]
+    tooi = reconciliation_setup["tooi"]
+    rec = reconciliation_setup["rec"]
+
+    resp = await client.post(
+        "/api/admin/reconciliation/manual-merge",
+        json={"source_id": str(handmatig.id), "target_id": str(tooi.id)},
+    )
+    assert resp.status_code == 200, resp.text
+
+    await db_session.refresh(rec)
+    assert rec.status == "merged"
+
+
 async def test_reconciliation_merge_dedup_stakeholder_assessment(
     client, db_session: AsyncSession, reconciliation_setup, sample_person
 ):

--- a/backend/tests/test_reconciliation.py
+++ b/backend/tests/test_reconciliation.py
@@ -563,6 +563,56 @@ async def test_manual_merge_sluit_open_reconciliation(
     assert rec.status == "merged"
 
 
+async def test_manual_merge_sluit_reconciliation_via_kandidaat_id(
+    client, db_session: AsyncSession
+):
+    """Open reconciliation waarvan de SOURCE de kandidaat is wordt ook
+    afgesloten — niet alleen die via handmatige_id. Anders blijft er een
+    conflict-rij staan die naar een verwijderde kandidaat wijst."""
+    andere_handmatig = OrganisatieEenheid(
+        id=uuid.uuid4(),
+        naam="Andere handmatige rij",
+        type="zbo",
+        bron="handmatig",
+    )
+    source = OrganisatieEenheid(
+        id=uuid.uuid4(),
+        naam="Bron die kandidaat is",
+        type="zbo",
+        bron="organogram_scrape",
+    )
+    target = OrganisatieEenheid(
+        id=uuid.uuid4(),
+        naam="Doelrij",
+        type="zbo",
+        bron="tooi",
+        tooi_uri="https://identifier.overheid.nl/tooi/id/test/doel",
+    )
+    db_session.add_all([andere_handmatig, source, target])
+    await db_session.flush()
+
+    rec = PendingReconciliation(
+        id=uuid.uuid4(),
+        resource_type="organisatie_eenheid",
+        handmatige_id=andere_handmatig.id,
+        kandidaat_id=source.id,
+        kandidaat_bron="organogram_scrape",
+        match_reden="naam_normalized",
+        status="open",
+    )
+    db_session.add(rec)
+    await db_session.flush()
+
+    resp = await client.post(
+        "/api/admin/reconciliation/manual-merge",
+        json={"source_id": str(source.id), "target_id": str(target.id)},
+    )
+    assert resp.status_code == 200, resp.text
+
+    await db_session.refresh(rec)
+    assert rec.status == "merged"
+
+
 async def test_reconciliation_merge_dedup_stakeholder_assessment(
     client, db_session: AsyncSession, reconciliation_setup, sample_person
 ):

--- a/backend/tests/test_reconciliation.py
+++ b/backend/tests/test_reconciliation.py
@@ -545,6 +545,39 @@ async def test_manual_merge_404_op_onbekende_eenheid(client):
     assert resp.status_code == 404
 
 
+async def test_manual_merge_400_op_synthetisch_doel(client, db_session: AsyncSession):
+    """Een synthetische groep als doel wordt geweigerd."""
+    source = OrganisatieEenheid(
+        id=uuid.uuid4(), naam="Echte eenheid", type="zbo", bron="handmatig"
+    )
+    synthetisch = OrganisatieEenheid(
+        id=uuid.uuid4(),
+        naam="Marktpartijen en overige",
+        type="overig",
+        bron="synthetisch",
+    )
+    db_session.add_all([source, synthetisch])
+    await db_session.flush()
+
+    resp = await client.post(
+        "/api/admin/reconciliation/manual-merge",
+        json={"source_id": str(source.id), "target_id": str(synthetisch.id)},
+    )
+    assert resp.status_code == 400
+
+    # source bestaat nog (merge niet uitgevoerd)
+    nog = (
+        (
+            await db_session.execute(
+                select(OrganisatieEenheid).where(OrganisatieEenheid.id == source.id)
+            )
+        )
+        .scalars()
+        .first()
+    )
+    assert nog is not None
+
+
 async def test_manual_merge_sluit_open_reconciliation(
     client, db_session: AsyncSession, reconciliation_setup
 ):

--- a/frontend/src/api/organisatie.ts
+++ b/frontend/src/api/organisatie.ts
@@ -17,11 +17,18 @@ export async function getOrganisatieTree(
   });
 }
 
-export async function getOrganisatieFlat(
-  includeHistorisch = false,
-): Promise<OrganisatieEenheid[]> {
+export async function getOrganisatieFlat(): Promise<OrganisatieEenheid[]> {
+  return apiGet<OrganisatieEenheid[]>('/api/organisatie');
+}
+
+// Aparte functie i.p.v. een optionele param op getOrganisatieFlat: die
+// wordt vaak direct als React Query queryFn doorgegeven, en een leading
+// boolean-param botst dan met de QueryFunctionContext die RQ injecteert.
+export async function getOrganisatieFlatMetHistorisch(): Promise<
+  OrganisatieEenheid[]
+> {
   return apiGet<OrganisatieEenheid[]>('/api/organisatie', {
-    ...(includeHistorisch ? { include_historisch: 'true' } : {}),
+    include_historisch: 'true',
   });
 }
 

--- a/frontend/src/api/organisatie.ts
+++ b/frontend/src/api/organisatie.ts
@@ -17,8 +17,12 @@ export async function getOrganisatieTree(
   });
 }
 
-export async function getOrganisatieFlat(): Promise<OrganisatieEenheid[]> {
-  return apiGet<OrganisatieEenheid[]>('/api/organisatie');
+export async function getOrganisatieFlat(
+  includeHistorisch = false,
+): Promise<OrganisatieEenheid[]> {
+  return apiGet<OrganisatieEenheid[]>('/api/organisatie', {
+    ...(includeHistorisch ? { include_historisch: 'true' } : {}),
+  });
 }
 
 export async function getOrganisatieEenheid(id: string): Promise<OrganisatieEenheid> {

--- a/frontend/src/api/reconciliation.ts
+++ b/frontend/src/api/reconciliation.ts
@@ -40,3 +40,19 @@ export interface OrphanScanResult {
 export async function scanOrphanHandmatig(): Promise<OrphanScanResult> {
   return apiPost('/api/admin/sync/orphan-handmatig', {});
 }
+
+export interface ManualMergeResult {
+  status: string;
+  doelrij_id: string;
+  rewritten: Record<string, number>;
+}
+
+export async function manualMerge(
+  sourceId: string,
+  targetId: string,
+): Promise<ManualMergeResult> {
+  return apiPost('/api/admin/reconciliation/manual-merge', {
+    source_id: sourceId,
+    target_id: targetId,
+  });
+}

--- a/frontend/src/components/admin/ReconciliationManager.tsx
+++ b/frontend/src/components/admin/ReconciliationManager.tsx
@@ -19,9 +19,11 @@ type Status = 'open' | 'merged' | 'ignored';
 
 function ManualMergePanel() {
   const queryClient = useQueryClient();
+  // include_historisch: een duplicaat kan soft-deleted zijn (geldig_tot
+  // gevuld); zonder dit kun je zo'n rij niet als bron kiezen.
   const { data: eenheden = [] } = useQuery({
-    queryKey: ['organisatie', 'flat'],
-    queryFn: getOrganisatieFlat,
+    queryKey: ['organisatie', 'flat', 'historisch'],
+    queryFn: () => getOrganisatieFlat(true),
   });
 
   // source verdwijnt, target blijft. Default-voorstel zodra beide gekozen
@@ -48,6 +50,7 @@ function ManualMergePanel() {
             e.type,
             e.afkorting,
             e.bron && e.bron !== 'handmatig' ? e.bron : null,
+            e.geldig_tot ? 'historisch' : null,
           ]
             .filter(Boolean)
             .join(' · '),
@@ -82,7 +85,11 @@ function ManualMergePanel() {
   };
 
   const sameRow = sourceId !== '' && sourceId === targetId;
-  const canMerge = source && target && !sameRow;
+  // Een synthetische rij ('ZBO's en agentschappen', 'Marktpartijen en
+  // overige', ...) is een container, geen echte eenheid. FK's daarheen
+  // verhuizen is vrijwel altijd fout — blokkeer het als doel.
+  const targetIsSynthetic = target?.bron === 'synthetisch';
+  const canMerge = source && target && !sameRow && !targetIsSynthetic;
 
   return (
     <Card>
@@ -136,6 +143,13 @@ function ManualMergePanel() {
         {sameRow && (
           <p className="text-sm text-red-600">
             Bron en doel zijn dezelfde eenheid.
+          </p>
+        )}
+
+        {targetIsSynthetic && (
+          <p className="text-sm text-red-600">
+            Het doel is een synthetische groep, geen echte eenheid. Kies
+            een echte organisatie-eenheid als doel.
           </p>
         )}
 

--- a/frontend/src/components/admin/ReconciliationManager.tsx
+++ b/frontend/src/components/admin/ReconciliationManager.tsx
@@ -1,18 +1,213 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { ArrowRight, Check, X } from 'lucide-react';
+import { ArrowRight, ArrowLeftRight, Check, X } from 'lucide-react';
 import {
   listReconciliations,
   mergeReconciliation,
   ignoreReconciliation,
   scanOrphanHandmatig,
+  manualMerge,
   type OrphanScanResult,
 } from '@/api/reconciliation';
+import { getOrganisatieFlat } from '@/api/organisatie';
 import { Button } from '@/components/common/Button';
 import { Card } from '@/components/common/Card';
+import { CreatableSelect } from '@/components/common/CreatableSelect';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
 
 type Status = 'open' | 'merged' | 'ignored';
+
+function ManualMergePanel() {
+  const queryClient = useQueryClient();
+  const { data: eenheden = [] } = useQuery({
+    queryKey: ['organisatie', 'flat'],
+    queryFn: getOrganisatieFlat,
+  });
+
+  // source verdwijnt, target blijft. Default-voorstel zodra beide gekozen
+  // zijn: de gesyncte rij wordt target (officiële naam + tooi_uri blijven),
+  // de handmatige rij wordt source. De admin kan met de swap-knop omkeren.
+  const [sourceId, setSourceId] = useState('');
+  const [targetId, setTargetId] = useState('');
+  const [confirming, setConfirming] = useState(false);
+
+  const byId = useMemo(
+    () => new Map(eenheden.map((e) => [e.id, e])),
+    [eenheden],
+  );
+  const source = sourceId ? byId.get(sourceId) : undefined;
+  const target = targetId ? byId.get(targetId) : undefined;
+
+  const options = useMemo(
+    () =>
+      eenheden
+        .map((e) => ({
+          value: e.id,
+          label: e.naam,
+          description: [
+            e.type,
+            e.afkorting,
+            e.bron && e.bron !== 'handmatig' ? e.bron : null,
+          ]
+            .filter(Boolean)
+            .join(' · '),
+        }))
+        .sort((a, b) => a.label.localeCompare(b.label, 'nl')),
+    [eenheden],
+  );
+
+  const mergeMutation = useMutation({
+    mutationFn: () => manualMerge(sourceId, targetId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['reconciliation'] });
+      queryClient.invalidateQueries({ queryKey: ['organisatie'] });
+      setSourceId('');
+      setTargetId('');
+      setConfirming(false);
+    },
+  });
+
+  // Slim default: zodra source een handmatige rij is en target een
+  // gesyncte, klopt de richting al. Is het andersom gekozen, bied de
+  // swap prominent aan via een hint (geen auto-swap — admin houdt regie).
+  const sourceIsSynced = source?.bron && source.bron !== 'handmatig';
+  const targetIsManual = !target?.bron || target.bron === 'handmatig';
+  const suggestSwap = Boolean(
+    source && target && sourceIsSynced && targetIsManual,
+  );
+
+  const swap = () => {
+    setSourceId(targetId);
+    setTargetId(sourceId);
+  };
+
+  const sameRow = sourceId !== '' && sourceId === targetId;
+  const canMerge = source && target && !sameRow;
+
+  return (
+    <Card>
+      <div className="p-4 space-y-3">
+        <div>
+          <h3 className="font-semibold text-sm mb-1">Handmatig mergen</h3>
+          <p className="text-sm text-text-secondary">
+            Twee eenheden samenvoegen die de scan niet vangt (bv. een
+            seed-DG naast een organogram-rij met net andere naam). Alle
+            plaatsingen, leads, opdrachten en sub-eenheden van de{' '}
+            <strong>bron</strong> verhuizen naar het <strong>doel</strong>;
+            de bron wordt verwijderd. Hou als doel de gesyncte rij aan
+            (officiële naam en TOOI-koppeling blijven dan staan).
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-[1fr_auto_1fr] gap-3 items-end">
+          <CreatableSelect
+            label="Bron (verdwijnt)"
+            value={sourceId}
+            onChange={(v) => {
+              setSourceId(v);
+              setConfirming(false);
+            }}
+            options={options}
+            placeholder="Zoek eenheid…"
+            emptyMessage="Geen eenheid gevonden"
+          />
+          <button
+            type="button"
+            onClick={swap}
+            disabled={!sourceId && !targetId}
+            title="Bron en doel omwisselen"
+            className="mb-1 p-2 rounded text-text-secondary hover:bg-gray-100 disabled:opacity-40"
+          >
+            <ArrowLeftRight className="h-5 w-5" />
+          </button>
+          <CreatableSelect
+            label="Doel (blijft)"
+            value={targetId}
+            onChange={(v) => {
+              setTargetId(v);
+              setConfirming(false);
+            }}
+            options={options}
+            placeholder="Zoek eenheid…"
+            emptyMessage="Geen eenheid gevonden"
+          />
+        </div>
+
+        {sameRow && (
+          <p className="text-sm text-red-600">
+            Bron en doel zijn dezelfde eenheid.
+          </p>
+        )}
+
+        {suggestSwap && (
+          <p className="text-sm text-amber-700">
+            De bron is een gesyncte rij ({source?.bron}) en het doel
+            handmatig. Meestal wil je het andersom zodat de gesyncte rij
+            blijft bestaan.{' '}
+            <button
+              type="button"
+              onClick={swap}
+              className="underline font-medium"
+            >
+              Omwisselen
+            </button>
+          </p>
+        )}
+
+        {canMerge && !confirming && (
+          <div className="flex justify-end">
+            <Button variant="primary" onClick={() => setConfirming(true)}>
+              Mergen…
+            </Button>
+          </div>
+        )}
+
+        {canMerge && confirming && (
+          <div className="border border-red-200 bg-red-50 rounded p-3 space-y-3">
+            <p className="text-sm">
+              <strong>{source?.naam}</strong> wordt verwijderd. Alle
+              referenties verhuizen naar <strong>{target?.naam}</strong>
+              {target?.bron && target.bron !== 'handmatig'
+                ? ` (${target.bron})`
+                : ''}
+              . Dit is niet terug te draaien.
+            </p>
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="secondary"
+                onClick={() => setConfirming(false)}
+                disabled={mergeMutation.isPending}
+              >
+                Annuleren
+              </Button>
+              <Button
+                variant="primary"
+                onClick={() => mergeMutation.mutate()}
+                disabled={mergeMutation.isPending}
+              >
+                {mergeMutation.isPending
+                  ? 'Bezig…'
+                  : 'Definitief mergen'}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {mergeMutation.isError && (
+          <p className="text-sm text-red-600">
+            Merge mislukt:{' '}
+            {mergeMutation.error instanceof Error
+              ? mergeMutation.error.message
+              : 'onbekende fout'}
+          </p>
+        )}
+        {mergeMutation.isSuccess && (
+          <p className="text-sm text-green-700">Merge voltooid.</p>
+        )}
+      </div>
+    </Card>
+  );
+}
 
 export function ReconciliationManager() {
   const [status, setStatus] = useState<Status>('open');
@@ -85,6 +280,8 @@ export function ReconciliationManager() {
           </Button>
         </div>
       </Card>
+
+      <ManualMergePanel />
 
       <div className="flex gap-2">
         {(['open', 'merged', 'ignored'] as const).map((s) => (

--- a/frontend/src/components/admin/ReconciliationManager.tsx
+++ b/frontend/src/components/admin/ReconciliationManager.tsx
@@ -9,7 +9,7 @@ import {
   manualMerge,
   type OrphanScanResult,
 } from '@/api/reconciliation';
-import { getOrganisatieFlat } from '@/api/organisatie';
+import { getOrganisatieFlatMetHistorisch } from '@/api/organisatie';
 import { Button } from '@/components/common/Button';
 import { Card } from '@/components/common/Card';
 import { CreatableSelect } from '@/components/common/CreatableSelect';
@@ -23,7 +23,7 @@ function ManualMergePanel() {
   // gevuld); zonder dit kun je zo'n rij niet als bron kiezen.
   const { data: eenheden = [] } = useQuery({
     queryKey: ['organisatie', 'flat', 'historisch'],
-    queryFn: () => getOrganisatieFlat(true),
+    queryFn: getOrganisatieFlatMetHistorisch,
   });
 
   // source verdwijnt, target blijft. Default-voorstel zodra beide gekozen


### PR DESCRIPTION
## Wat

Daniël signaleerde dat DGDOO ("DG Digitalisering en Overheidsorganisatie") twee keer in de organisatieboom stond. Diagnose: geen seed-fout maar een bug in de organogram-scrape uit #313.

- Seed: `DG Digitalisering en Overheidsorganisatie` (bron `handmatig`)
- organogram_scrape: `Digitalisering en Overheidsorganisatie` zonder "DG"-prefix (bron `organogram_scrape`), met Eva Heijblom als DG

De scrape vergeleek bestaande children op **exacte naam** (`organogram_scrape.py:253`), dus de "DG "-prefix maakte er een tweede rij van. De orphan-scan uit #314 ving het niet omdat die alleen `handmatig`→`tooi` scant.

## Wijzigingen

- **`core/text.py`**: `normalize_org_name` als gedeelde helper (lower, trim, strip één bron-specifieke prefix). Scrape én orphan-scan gebruiken nu dezelfde normalisatie. Prefix-lijst aangevuld met `directie`/`afdeling`.
- **`organogram_scrape.py`**: DG- en directie-match op genormaliseerde naam i.p.v. exacte string. Voorkomt het duplicaat aan de bron.
- **`detect_orphan_handmatig.py`**: kandidaten uit alle gesyncte bronnen (`tooi`, `organogram_scrape`, `kabinet`, `rio`, `ministeries_csv`), niet alleen `tooi`. `kandidaat_bron` reflecteert nu de echte bron. Vangnet voor cross-source mismatches.
- **Handmatige merge**: `POST /api/admin/reconciliation/manual-merge` + UI-paneel in Beheer > Reconciliatie. Twee eenheden vrij kiezen en mergen zonder voorafgaande scan-hit, via de bestaande `merge_organisatie_eenheden`-helper. Default stelt de gesyncte rij als doel voor (officiële naam + `tooi_uri` blijven), admin kan omkeren. Bevestigingsstap toont wat verdwijnt vs. blijft. Lost de bestaande productie-DGDOO direct op.

## Tests

- 3 nieuw in `test_organogram_scrape.py` (normalizer + dedup + sanity nieuwe DG)
- 1 nieuw in `test_detect_orphan_handmatig.py` (organogram-bron kandidaat)
- 4 nieuw in `test_reconciliation.py` (manual-merge happy path, 400 self, 404 onbekend, sluit open reconciliation)
- Volledige backend-suite groen (1130). Frontend `tsc` + eslint clean.

## Reviewpunten

- Default merge-richting "gesyncte rij wint" is bewust: anders ontstaat het duplicaat bij de volgende scrape opnieuw. Handmatige substructuur gaat niet verloren (FK-rewrite verhuist het mee).
- `directie`/`afdeling` toegevoegd aan de gedeelde prefix-lijst raakt ook de al-gedeployede orphan-scan. Match is parent-scoped (scrape) of admin-reviewed vóór merge (scan), dus acceptabel.