### PR TITLE
Fix overheidsorganisaties_daily: kabinet.yaml naar writable /data

### DIFF
--- a/backend/bouwmeester/api/routes/admin_sync.py
+++ b/backend/bouwmeester/api/routes/admin_sync.py
@@ -26,10 +26,7 @@ from bouwmeester.services.tooi_sync import sync_tooi
 
 router = APIRouter(prefix="/admin/sync", tags=["admin-sync"])
 
-# Pad naar kabinet.yaml — relatief vanaf backend-root
-from pathlib import Path  # noqa: E402
-
-KABINET_YAML = Path(__file__).resolve().parent.parent.parent / "data" / "kabinet.yaml"
+from bouwmeester.core.storage import kabinet_yaml_path  # noqa: E402
 
 
 @router.get(
@@ -329,8 +326,9 @@ async def trigger_kabinet(
     db: AsyncSession = Depends(get_db),
     _perm=Depends(require_permission("org:manage")),
 ) -> dict:
-    aantal = await write_kabinet_yaml(db, str(KABINET_YAML))
-    stats = await sync_kabinet(db, KABINET_YAML)
+    kab_yaml = kabinet_yaml_path()
+    aantal = await write_kabinet_yaml(db, str(kab_yaml))
+    stats = await sync_kabinet(db, kab_yaml)
     return {
         "scrape_aantal": aantal,
         "sync_run_id": str(stats.sync_run_id),
@@ -367,8 +365,9 @@ async def trigger_all(
         "nieuwe_personen": s5.nieuwe_personen,
         "new_placements": s5.new_placements,
     }
-    aantal = await write_kabinet_yaml(db, str(KABINET_YAML))
-    s6 = await sync_kabinet(db, KABINET_YAML)
+    kab_yaml = kabinet_yaml_path()
+    aantal = await write_kabinet_yaml(db, str(kab_yaml))
+    s6 = await sync_kabinet(db, kab_yaml)
     results["kabinet"] = {
         "scrape_aantal": aantal,
         "new_placements": s6.new_placements,

--- a/backend/bouwmeester/core/storage.py
+++ b/backend/bouwmeester/core/storage.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import shutil
 import uuid as _uuid
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -14,6 +15,50 @@ if TYPE_CHECKING:
     from fastapi import UploadFile
 
 logger = logging.getLogger(__name__)
+
+
+def data_root() -> Path:
+    """Return the writable runtime data directory.
+
+    Resolution order:
+    1. ``DATA_PATH`` env var (explicit override)
+    2. ``/data`` (container default — made group-writable for arbitrary
+       UIDs in the Dockerfile, unlike the read-only ``/app`` code tree)
+
+    Used for generated runtime state that must survive process restarts
+    but cannot be written into the immutable image layer.
+    """
+    data_path = os.environ.get("DATA_PATH")
+    if data_path:
+        return Path(data_path)
+    return Path("/data")
+
+
+def kabinet_yaml_path() -> Path:
+    """Return the writable path for the scraped ``kabinet.yaml``.
+
+    The worker scrapes rijksoverheid.nl and overwrites this file daily, so
+    it cannot live in the read-only ``/app`` code tree (the deployed
+    container runs as an arbitrary, non-owning UID and gets ``EACCES`` on
+    write — see ``backend/bouwmeester/data/kabinet.yaml`` shipped only as a
+    seed). On first run we copy the in-image seed into the writable data
+    dir so ``write_kabinet_yaml``'s "0 entries → keep existing YAML"
+    data-loss guard still has a baseline to fall back to.
+    """
+    target = data_root() / "kabinet.yaml"
+    if not target.exists():
+        seed = Path(__file__).resolve().parent.parent / "data" / "kabinet.yaml"
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if seed.exists():
+                shutil.copyfile(seed, target)
+        except OSError:
+            logger.warning(
+                "Kon kabinet.yaml-seed niet naar %s kopiëren; scrape begint "
+                "zonder baseline",
+                target,
+            )
+    return target
 
 
 def bijlagen_root() -> Path:

--- a/backend/bouwmeester/worker.py
+++ b/backend/bouwmeester/worker.py
@@ -211,15 +211,14 @@ async def _overheidsorganisaties_dagelijks_loop(settings) -> None:  # type: igno
     while True:
         try:
             async with async_session() as session:
+                from bouwmeester.core.storage import kabinet_yaml_path
                 from bouwmeester.services.kabinet_scrape import write_kabinet_yaml
                 from bouwmeester.services.kabinet_sync import sync_kabinet
                 from bouwmeester.services.tk_persoon_sync import sync_tk_personen
 
                 tk_stats = await sync_tk_personen(session)
 
-                from pathlib import Path
-
-                kab_yaml = Path(__file__).resolve().parent / "data" / "kabinet.yaml"
+                kab_yaml = kabinet_yaml_path()
             async with async_session() as session2:
                 await write_kabinet_yaml(session2, str(kab_yaml))
                 kab_stats = await sync_kabinet(session2, kab_yaml)

--- a/backend/tests/test_kabinet_yaml_path.py
+++ b/backend/tests/test_kabinet_yaml_path.py
@@ -1,0 +1,48 @@
+"""Tests for the writable kabinet.yaml path resolution.
+
+Regression for the deployed worker crashing with EACCES when it tried to
+overwrite kabinet.yaml inside the read-only /app code tree.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from bouwmeester.core import storage
+
+
+def test_data_root_uses_data_path_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("DATA_PATH", str(tmp_path))
+    assert storage.data_root() == tmp_path
+
+
+def test_data_root_defaults_to_data_dir(monkeypatch):
+    monkeypatch.delenv("DATA_PATH", raising=False)
+    assert storage.data_root() == Path("/data")
+
+
+def test_kabinet_yaml_path_under_data_root(monkeypatch, tmp_path):
+    monkeypatch.setenv("DATA_PATH", str(tmp_path))
+    target = storage.kabinet_yaml_path()
+    assert target == tmp_path / "kabinet.yaml"
+
+
+def test_kabinet_yaml_path_seeds_from_in_image_baseline(monkeypatch, tmp_path):
+    monkeypatch.setenv("DATA_PATH", str(tmp_path))
+
+    seed = Path(storage.__file__).resolve().parent.parent / "data" / "kabinet.yaml"
+    target = storage.kabinet_yaml_path()
+
+    assert target.exists()
+    if seed.exists():
+        assert target.read_bytes() == seed.read_bytes()
+
+
+def test_kabinet_yaml_path_does_not_clobber_existing(monkeypatch, tmp_path):
+    monkeypatch.setenv("DATA_PATH", str(tmp_path))
+    existing = tmp_path / "kabinet.yaml"
+    existing.write_text("bewindspersonen: []\n")
+
+    target = storage.kabinet_yaml_path()
+
+    assert target.read_text() == "bewindspersonen: []\n"


### PR DESCRIPTION
## Probleem

De cron-job `overheidsorganisaties_daily` hangt op **Vertraagd** met:

```
PermissionError: [Errno 13] Permission denied: '/app/bouwmeester/data/kabinet.yaml'
```

`write_kabinet_yaml` overschrijft dagelijks de gescrapete `kabinet.yaml`. Het pad wees naar `Path(__file__).parent / "data" / "kabinet.yaml"`, dus binnen de read-only image-laag (`/app`). De gedeployde container draait onder een arbitraire, niet-eigenaar UID (Zad/OpenShift-patroon); de `--chown=appuser` uit de Dockerfile helpt die UID niet, dus de write faalt met `EACCES`.

`/data` is in de Dockerfile al expliciet schrijfbaar gemaakt voor arbitraire UIDs (`chgrp -R 0 /data && chmod -R g=u /data`) — alleen de `data/`-map in de code-tree kreeg die behandeling nooit.

## Oplossing

- Nieuwe helper `kabinet_yaml_path()` in `core/storage.py`, zelfde resolutie-conventie als het bestaande `bijlagen_root()` (`DATA_PATH` env, default `/data`).
- Bij eerste run kopieert de helper de meegeleverde seed (`backend/bouwmeester/data/kabinet.yaml`) naar de writable map, zodat de bestaande "scrape gaf 0 entries → bestaande YAML behouden" data-loss-guard een baseline houdt.
- Worker en de twee admin-sync endpoints (`/admin/sync/kabinet`, `/admin/sync/all`) gebruiken nu deze helper.
- `run_kabinet_scrape_and_sync.py` (lokaal dev-script) blijft bewust naar de in-repo seed schrijven, zodat een ververste seed gecommit kan worden.

## Test

`backend/tests/test_kabinet_yaml_path.py`: pad-resolutie via `DATA_PATH`, default `/data`, seed-copy op eerste run, en geen clobber van een bestaand bestand. 5 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)