### PR TITLE
Mattermost lead-suggesties: singleton-lock + atomic idempotency tegen duplicaten

### DIFF
--- a/backend/bouwmeester/core/worker_lock.py
+++ b/backend/bouwmeester/core/worker_lock.py
@@ -1,0 +1,69 @@
+"""Postgres session-advisory-lock die het background worker-process als
+singleton afdwingt.
+
+De backend-container start de worker als losstaand proces naast uvicorn
+(zie ``entrypoint.sh``). Bij een deploy/restart kan de oude pod's worker
+nog even blijven draaien terwijl de nieuwe al is opgestart — beide zouden
+dan hun eigen Mattermost-websocket openen en dezelfde posts verwerken.
+``WorkerLock`` voorkomt dat: een tweede instantie kan de lock niet
+verkrijgen en moet wachten tot de eerste stopt (of crasht — Postgres
+geeft een session-advisory-lock automatisch vrij zodra de onderliggende
+connectie sluit, dus een crash zonder nette shutdown is geen probleem).
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine
+
+# Vast, willekeurig gekozen bigint — enige vereiste is dat het geen key
+# is die elders in de codebase voor een ander doel wordt gebruikt. Eén
+# lock-key is genoeg: er is precies één worker-rol om te bewaken.
+WORKER_SINGLETON_LOCK_KEY = 728194055201733611
+
+
+class WorkerLock:
+    """Session-advisory-lock op een vaste key, gebonden aan één connectie.
+
+    ``acquire()`` opent een toegewijde connectie uit ``engine`` en probeert
+    de lock non-blocking te nemen (``pg_try_advisory_lock``). Die connectie
+    blijft open zolang de lock gehouden wordt — advisory locks in Postgres
+    zijn per-connectie, dus teruggeven aan de pool zou de lock direct weer
+    vrijgeven.
+    """
+
+    def __init__(self, engine: AsyncEngine, *, key: int = WORKER_SINGLETON_LOCK_KEY):
+        self._engine = engine
+        self._key = key
+        self._conn: AsyncConnection | None = None
+
+    async def acquire(self) -> bool:
+        """Probeer de lock te verkrijgen. Non-blocking: retourneert direct
+        ``False`` als een andere houder 'm al vasthoudt, in plaats van te
+        wachten."""
+        conn = await self._engine.connect()
+        result = await conn.execute(
+            text("SELECT pg_try_advisory_lock(:key)"), {"key": self._key}
+        )
+        got_lock = bool(result.scalar())
+        if got_lock:
+            self._conn = conn
+            return True
+        await conn.close()
+        return False
+
+    async def release(self) -> None:
+        """Geef de lock vrij en sluit de bijbehorende connectie.
+
+        Veilig aan te roepen ongeacht of ``acquire()`` ooit succesvol was
+        (bv. in een ``finally``-block) — zonder gehouden lock is dit een
+        no-op."""
+        if self._conn is None:
+            return
+        conn, self._conn = self._conn, None
+        try:
+            await conn.execute(
+                text("SELECT pg_advisory_unlock(:key)"), {"key": self._key}
+            )
+        finally:
+            await conn.close()

--- a/backend/bouwmeester/services/mattermost_ingest_service.py
+++ b/backend/bouwmeester/services/mattermost_ingest_service.py
@@ -189,6 +189,31 @@ class MattermostIngestService:
             if mapping is not None:
                 person_id = mapping.person_id
 
+        # Claim de post NU, vóór de LLM-call en eventuele bot-reply naar
+        # Mattermost. Twee overlappende workers (bv. tijdens een
+        # deploy-overlap) kunnen de pre-check-SELECT hierboven allebei
+        # passeren vóórdat een van beiden commit; zonder deze insert-
+        # first-claim zouden beiden de LLM aanroepen en allebei een
+        # zichtbare suggestie-post naar Mattermost sturen, en pas de
+        # állerlaatste insert zou de unique constraint raken — te laat om
+        # de dubbele Mattermost-post nog te voorkomen.
+        record = MattermostPostLink(
+            post_id=post_id,
+            channel_id=channel_id,
+            root_id=root_id,
+            scope_type=channel_link.scope_type,
+            scope_id=channel_link.scope_id,
+            mm_user_id=mm_user_id,
+            person_id=person_id,
+        )
+        self.session.add(record)
+        try:
+            async with self.session.begin_nested():
+                await self.session.flush()
+        except IntegrityError:
+            # Race-condition op unique post_id — andere worker was sneller.
+            return
+
         message = post.get("message") or ""
         lead_activity_id: UUID | None = None
         suggested_lead_id: UUID | None = None
@@ -230,25 +255,10 @@ class MattermostIngestService:
             # zodat we de post niet opnieuw zien, maar geen note van maken.
             skipped_reason = "no_link"
 
-        record = MattermostPostLink(
-            post_id=post_id,
-            channel_id=channel_id,
-            root_id=root_id,
-            scope_type=channel_link.scope_type,
-            scope_id=channel_link.scope_id,
-            mm_user_id=mm_user_id,
-            person_id=person_id,
-            lead_activity_id=lead_activity_id,
-            suggested_lead_id=suggested_lead_id,
-            skipped_reason=skipped_reason,
-        )
-        self.session.add(record)
-        try:
-            async with self.session.begin_nested():
-                await self.session.flush()
-        except IntegrityError:
-            # Race-condition op unique post_id — andere worker was sneller.
-            return
+        record.lead_activity_id = lead_activity_id
+        record.suggested_lead_id = suggested_lead_id
+        record.skipped_reason = skipped_reason
+        await self.session.flush()
 
         # Eén regel per verwerkte post in production logs zodat we
         # kunnen zien waarom een note wel/niet ontstaat zonder DB-query.

--- a/backend/bouwmeester/services/mattermost_ingest_service.py
+++ b/backend/bouwmeester/services/mattermost_ingest_service.py
@@ -18,7 +18,7 @@ import logging
 from uuid import UUID
 
 from sqlalchemy import func, or_, select
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, PendingRollbackError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from bouwmeester.core.database import async_session
@@ -210,8 +210,16 @@ class MattermostIngestService:
         try:
             async with self.session.begin_nested():
                 await self.session.flush()
-        except IntegrityError:
+        except (IntegrityError, PendingRollbackError):
             # Race-condition op unique post_id — andere worker was sneller.
+            # Bij een conflict tegen een nog-niet-gecommitte rij van de
+            # andere worker (i.p.v. een al-gecommitte rij) blokkeert onze
+            # INSERT eerst op de rij-lock en faalt pas zodra de andere
+            # transactie commit; dat laat de *outer* transactie hier
+            # poisoned achter (niet alleen het savepoint), dus zonder
+            # expliciete rollback zou de volgende `session.commit()` bij
+            # de caller alsnog een PendingRollbackError geven.
+            await self.session.rollback()
             return
 
         message = post.get("message") or ""

--- a/backend/bouwmeester/worker.py
+++ b/backend/bouwmeester/worker.py
@@ -6,7 +6,8 @@ import logging
 import traceback
 
 from bouwmeester.core.config import get_settings
-from bouwmeester.core.database import async_session
+from bouwmeester.core.database import async_session, engine
+from bouwmeester.core.worker_lock import WorkerLock
 from bouwmeester.services.worker_health import tick as health_tick
 
 # Note on stdout buffering: PYTHONUNBUFFERED=1 lives in the Dockerfile and
@@ -297,12 +298,47 @@ async def _overheidsorganisaties_wekelijks_loop(settings) -> None:  # type: igno
         await asyncio.sleep(interval_seconds)
 
 
+_SINGLETON_LOCK_RETRY_SECONDS = 5.0
+
+
+async def _acquire_singleton_lock_or_wait(lock: WorkerLock) -> None:
+    """Blokkeert tot deze instantie de worker-singleton-lock krijgt.
+
+    Bij een overlappende deploy (oude pod's worker nog niet gestopt,
+    nieuwe pod al gestart) mag maar één instantie de achtergrond-loops
+    (met name de Mattermost-websocket) draaien — anders verwerken beide
+    dezelfde posts en ontstaan dubbele Mattermost-suggesties. Deze
+    instantie wacht gewoon tot de lock vrijkomt (oude pod stopt of
+    crasht) in plaats van zelf ook te gaan draaien."""
+    logged_waiting = False
+    while not await lock.acquire():
+        if not logged_waiting:
+            logger.warning(
+                "Worker-singleton-lock is al in gebruik door een andere "
+                "instantie, wacht tot die vrijkomt..."
+            )
+            await health_tick(
+                "worker_singleton",
+                status="waiting",
+                detail="lock in gebruik door andere instantie",
+            )
+            logged_waiting = True
+        await asyncio.sleep(_SINGLETON_LOCK_RETRY_SECONDS)
+
+    if logged_waiting:
+        logger.info("Worker-singleton-lock verkregen, start achtergrond-loops")
+    await health_tick("worker_singleton", status="ok", detail="lock verkregen")
+
+
 async def main() -> None:
     settings = get_settings()
     logger.info(
         f"Worker started. Parlementair poll interval: "
         f"{settings.TK_POLL_INTERVAL_SECONDS}s"
     )
+
+    lock = WorkerLock(engine)
+    await _acquire_singleton_lock_or_wait(lock)
 
     await _cleanup_obsolete_heartbeats()
 

--- a/backend/tests/test_mattermost_ingest.py
+++ b/backend/tests/test_mattermost_ingest.py
@@ -531,6 +531,66 @@ async def test_initiatief_channel_writes_only_post_link(db_session, sample_initi
     assert post_link.scope_type == SCOPE_INITIATIEF
 
 
+async def test_post_link_row_exists_before_suggestion_side_effect(
+    db_session, sample_initiatief
+):
+    """De ``MattermostPostLink``-idempotency-row moet in de database staan
+    vóórdat de LLM-call/suggestie-side-effect (``_create_suggested_lead``,
+    die ook de Mattermost-bot-reply verstuurt) wordt uitgevoerd.
+
+    Twee overlappende workers (bv. tijdens een deploy-overlap) die
+    dezelfde post allebei oppikken mogen niet allebei een SuggestedLead +
+    bot-reply produceren. Zolang de insert pas ná de side-effect gebeurt,
+    kunnen beide workers de pre-check-SELECT passeren vóórdat een van
+    beiden z'n insert commit — met als gevolg een dubbele Mattermost-post
+    die niet meer teruggedraaid kan worden zodra de unique constraint
+    de tweede insert alsnog blokkeert."""
+    from unittest.mock import AsyncMock, patch
+
+    cid = _id()
+    db_session.add(
+        MattermostChannelLink(
+            channel_id=cid,
+            channel_name="alg",
+            channel_display_name="Algemeen",
+            scope_type=SCOPE_INITIATIEF,
+            scope_id=sample_initiatief.id,
+            auto_note_enabled=False,
+            suggest_leads_enabled=True,
+        )
+    )
+    await db_session.flush()
+
+    post_id = _id()
+    post = {
+        "id": post_id,
+        "channel_id": cid,
+        "user_id": _id(),
+        "create_at": 1_700_000_000_000,
+        "message": "Mogelijk een nieuwe lead?",
+    }
+
+    row_existed_during_side_effect = None
+
+    async def fake_create_suggested_lead(**kwargs):
+        nonlocal row_existed_during_side_effect
+        existing = await db_session.execute(
+            select(MattermostPostLink.id).where(MattermostPostLink.post_id == post_id)
+        )
+        row_existed_during_side_effect = existing.scalar_one_or_none() is not None
+        return None, "no_lead"
+
+    ingest = MattermostIngestService(db_session)
+    with patch.object(
+        ingest,
+        "_create_suggested_lead",
+        new=AsyncMock(side_effect=fake_create_suggested_lead),
+    ):
+        await ingest.ingest_post(post)
+
+    assert row_existed_during_side_effect is True
+
+
 # ---------------------------------------------------------------------------
 # Native file-uploads
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_mattermost_ingest.py
+++ b/backend/tests/test_mattermost_ingest.py
@@ -591,6 +591,110 @@ async def test_post_link_row_exists_before_suggestion_side_effect(
     assert row_existed_during_side_effect is True
 
 
+async def test_two_concurrent_sessions_racing_same_post_id_produce_one_suggestion(
+    _test_engine,
+):
+    """Echte race-test met twee onafhankelijke connecties (niet de gedeelde
+    ``db_session``-fixture): twee workers verwerken dezelfde post
+    tegelijk. Precies één moet de LLM/suggestie-flow uitvoeren; de ander
+    moet vroeg stoppen zodra de insert-first-claim tegen de rij-lock van
+    de eerste aanloopt.
+
+    Dit dekt een subtielere fout dan de same-session-test hierboven: onder
+    échte gelijktijdigheid raakt de INSERT van de tweede sessie eerst een
+    rij-lock (niet direct een IntegrityError) en faalt pas zodra de eerste
+    sessie commit. Dat conflict poisoned niet alleen het savepoint maar
+    ook de *outer* transactie van de tweede sessie — zonder een expliciete
+    ``session.rollback()`` op dat pad zou de daaropvolgende
+    ``session.commit()`` van de caller alsnog een ``PendingRollbackError``
+    geven."""
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+
+    from sqlalchemy import delete
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    init_id = uuid.uuid4()
+    cid = _id()
+    post_id = _id()
+
+    async with AsyncSession(_test_engine, expire_on_commit=False) as setup:
+        setup.add(Initiatief(id=init_id, naam="Race check ingest"))
+        await setup.flush()
+        setup.add(
+            MattermostChannelLink(
+                channel_id=cid,
+                channel_name="alg",
+                channel_display_name="Algemeen",
+                scope_type=SCOPE_INITIATIEF,
+                scope_id=init_id,
+                auto_note_enabled=False,
+                suggest_leads_enabled=True,
+            )
+        )
+        await setup.commit()
+
+    post = {
+        "id": post_id,
+        "channel_id": cid,
+        "user_id": _id(),
+        "create_at": 1_700_000_000_000,
+        "message": "Mogelijk een nieuwe lead?",
+    }
+    call_count = 0
+
+    async def slow_create_suggested_lead(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        # Simuleert LLM-latency zodat beide workers overlappen.
+        await asyncio.sleep(0.2)
+        return None, "no_lead"
+
+    async def worker() -> None:
+        async with AsyncSession(_test_engine, expire_on_commit=False) as s:
+            ingest = MattermostIngestService(s)
+            with patch.object(
+                ingest,
+                "_create_suggested_lead",
+                new=AsyncMock(side_effect=slow_create_suggested_lead),
+            ):
+                await ingest.ingest_post(dict(post))
+            # Moet zonder PendingRollbackError kunnen committen, ook voor
+            # de worker die het race-conflict trof.
+            await s.commit()
+
+    try:
+        await asyncio.gather(worker(), worker())
+
+        assert call_count == 1
+
+        async with AsyncSession(_test_engine, expire_on_commit=False) as verify:
+            rows = (
+                (
+                    await verify.execute(
+                        select(MattermostPostLink).where(
+                            MattermostPostLink.post_id == post_id
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+        assert len(rows) == 1
+    finally:
+        async with AsyncSession(_test_engine, expire_on_commit=False) as cleanup:
+            await cleanup.execute(
+                delete(MattermostPostLink).where(MattermostPostLink.post_id == post_id)
+            )
+            await cleanup.execute(
+                delete(MattermostChannelLink).where(
+                    MattermostChannelLink.channel_id == cid
+                )
+            )
+            await cleanup.execute(delete(Initiatief).where(Initiatief.id == init_id))
+            await cleanup.commit()
+
+
 # ---------------------------------------------------------------------------
 # Native file-uploads
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_worker.py
+++ b/backend/tests/test_worker.py
@@ -1,0 +1,44 @@
+"""Tests voor de worker-singleton-lock-wait in bouwmeester.worker.main().
+
+Bij een overlappende deploy mag een tweede worker-instantie niet ook de
+achtergrond-loops starten; hij moet wachten tot de eerste stopt. Zie
+``bouwmeester.core.worker_lock.WorkerLock`` voor de onderliggende
+Postgres-advisory-lock."""
+
+from unittest.mock import AsyncMock, patch
+
+from bouwmeester import worker as worker_module
+
+
+async def test_acquire_singleton_lock_or_wait_returns_immediately_when_free():
+    lock = AsyncMock()
+    lock.acquire = AsyncMock(return_value=True)
+
+    with patch.object(worker_module, "health_tick", new=AsyncMock()) as health_tick:
+        await worker_module._acquire_singleton_lock_or_wait(lock)
+
+    lock.acquire.assert_awaited_once()
+    health_tick.assert_awaited_once_with(
+        "worker_singleton", status="ok", detail="lock verkregen"
+    )
+
+
+async def test_acquire_singleton_lock_or_wait_retries_until_free():
+    """Als de lock al bezet is, moet de functie blijven pollen (zonder
+    zelf door te gaan) tot een latere poging wél lukt."""
+    lock = AsyncMock()
+    lock.acquire = AsyncMock(side_effect=[False, False, True])
+
+    with (
+        patch.object(worker_module, "health_tick", new=AsyncMock()) as health_tick,
+        patch.object(worker_module.asyncio, "sleep", new=AsyncMock()) as sleep,
+    ):
+        await worker_module._acquire_singleton_lock_or_wait(lock)
+
+    assert lock.acquire.await_count == 3
+    assert sleep.await_count == 2
+
+    # Eerste tick meldt "waiting", laatste meldt "ok" — geen tussentijdse
+    # duplicaten (de waiting-tick wordt maar één keer gelogd/geticked).
+    statuses = [call.kwargs["status"] for call in health_tick.await_args_list]
+    assert statuses == ["waiting", "ok"]

--- a/backend/tests/test_worker_lock.py
+++ b/backend/tests/test_worker_lock.py
@@ -1,0 +1,85 @@
+"""Tests voor WorkerLock: Postgres session-advisory-lock als singleton-guard
+voor de background worker.
+
+Zonder deze lock kunnen twee overlappende worker-processen (bv. tijdens een
+deploy waarbij de oude pod nog niet is opgeruimd) allebei een Mattermost-
+websocket openen en dezelfde posts verwerken — zie de race in
+``test_mattermost_ingest.py::test_post_link_row_exists_before_suggestion_side_effect``
+voor het directe gevolg daarvan. De lock voorkomt dat een tweede instantie
+ooit begint te draaien."""
+
+import uuid
+
+from bouwmeester.core.worker_lock import WorkerLock
+
+# Elke test gebruikt een eigen willekeurige lock-key zodat tests niet met
+# elkaar (of met een echt draaiende worker tijdens lokale dev) om dezelfde
+# advisory lock botsen.
+
+
+def _random_key() -> int:
+    return uuid.uuid4().int & 0x7FFFFFFFFFFFFFFF
+
+
+async def test_acquire_succeeds_when_unheld(_test_engine):
+    lock = WorkerLock(_test_engine, key=_random_key())
+    try:
+        assert await lock.acquire() is True
+    finally:
+        await lock.release()
+
+
+async def test_second_acquire_on_same_key_fails_while_first_holds_it(_test_engine):
+    key = _random_key()
+    first = WorkerLock(_test_engine, key=key)
+    second = WorkerLock(_test_engine, key=key)
+    try:
+        assert await first.acquire() is True
+        assert await second.acquire() is False
+    finally:
+        await first.release()
+        await second.release()
+
+
+async def test_second_acquire_succeeds_after_first_releases(_test_engine):
+    key = _random_key()
+    first = WorkerLock(_test_engine, key=key)
+    second = WorkerLock(_test_engine, key=key)
+    try:
+        assert await first.acquire() is True
+        await first.release()
+        assert await second.acquire() is True
+    finally:
+        await first.release()
+        await second.release()
+
+
+async def test_second_acquire_succeeds_after_first_connection_closes(_test_engine):
+    """Als het proces crasht zonder release (bv. OOM-kill), sluit
+    Postgres de connectie en geeft de session-advisory-lock vanzelf vrij
+    — de volgende worker die opstart mag dan gewoon de lock krijgen."""
+    key = _random_key()
+    first = WorkerLock(_test_engine, key=key)
+    second = WorkerLock(_test_engine, key=key)
+    try:
+        assert await first.acquire() is True
+        # Simuleer een crash: de onderliggende connectie sluit zonder
+        # expliciete unlock. `release()` zou daarna zelf opnieuw op de
+        # (dan al gesloten) connectie proberen te unlocken, dus we
+        # laten `first` los zonder `release()` te callen — precies het
+        # scenario dat we simuleren.
+        await first._conn.close()  # noqa: SLF001
+        first._conn = None  # noqa: SLF001
+
+        assert await second.acquire() is True
+    finally:
+        await first.release()
+        await second.release()
+
+
+async def test_release_without_acquire_is_a_noop(_test_engine):
+    """Release mag veilig aangeroepen worden als acquire() nooit
+    (succesvol) is gedaan — bv. in een ``finally``-block na een mislukte
+    acquire-poging."""
+    lock = WorkerLock(_test_engine, key=_random_key())
+    await lock.release()  # mag niet raisen


### PR DESCRIPTION
## Samenvatting

Bouwmeester's Mattermost-bot plaatste soms herhaaldelijk dezelfde "bestaande lead"-suggestie voor één bericht (3-4x per post, structureel over meerdere weken). Root cause: bij een deploy/restart start `entrypoint.sh` de worker als losstaand proces naast uvicorn; als de oude pod's worker nog niet gestopt is wanneer de nieuwe start, draaien er tijdelijk twee workers die allebei op dezelfde Mattermost-websocket meelezen.

In `MattermostIngestService.ingest_post` gebeurde de idempotency-insert (`MattermostPostLink`, unique op `post_id`) pas **na** de LLM-classificatie en de bot-reply naar Mattermost. Twee overlappende workers konden dus allebei de pre-check-SELECT passeren, allebei de LLM aanroepen en allebei een zichtbare suggestie posten — pas de laatste insert raakte de unique constraint, te laat om de dubbele Mattermost-post nog te voorkomen.

## Fixes

- **Atomic idempotency**: `MattermostPostLink` wordt nu geïnsert vóór de LLM-call/suggestie-side-effect, niet erna. Een racing tweede insert faalt nu vóórdat er ooit een dubbele Mattermost-post is verstuurd.
- **Race-conflict laat de sessie bruikbaar**: bij twéé genuine concurrent, nog-niet-gecommitte transacties blokkeert de tweede INSERT eerst op de rij-lock van de eerste in plaats van direct een `IntegrityError` te geven; het conflict komt pas naar boven zodra de eerste committed, en poisoned op dat moment niet alleen het savepoint maar ook de *outer* transactie. Nu vangen we ook `PendingRollbackError` en roepen we expliciet `session.rollback()` aan op dat pad, zodat de caller's `session.commit()` niet alsnog crasht.
- **`WorkerLock`** (`bouwmeester/core/worker_lock.py`): Postgres session-advisory-lock die het background worker-process als singleton afdwingt. `worker.py::main()` wacht nu op deze lock vóór het starten van de achtergrond-loops (incl. de Mattermost-websocket). Een overlappende tweede instantie wacht gewoon tot de eerste stopt of crasht (de lock geeft zichzelf vrij zodra de onderliggende connectie sluit) — zelfheling zonder handmatig ingrijpen. Status zichtbaar via de bestaande worker-heartbeat (`worker_singleton`, Beheer > Systeem).

## Bekende beperking (niet in deze PR)

`WorkerLock` neutraliseert een orphaned worker (hij kan de lock niet winnen en draait dus geen achtergrond-loops), maar ruimt 'm niet op. `entrypoint.sh` start de worker als losstaand proces zonder SIGTERM-trap; bij een restart/deploy kan de oude worker daardoor als leeg spinnend proces blijven hangen tot de container's SIGKILL-grace-period verloopt. Een structurele fix (SIGTERM doorzetten vanuit entrypoint.sh) hoort in een aparte PR — andere laag (container-lifecycle i.p.v. applicatie-logica).

## Test plan

- [x] `test_post_link_row_exists_before_suggestion_side_effect` — bewijst dat de post_link-row bestaat vóórdat de suggestie-side-effect draait
- [x] `test_two_concurrent_sessions_racing_same_post_id_produce_one_suggestion` — echte race met twee onafhankelijke DB-connecties (niet de gedeelde test-fixture), dekt zowel de dubbele-suggestie-race als de PendingRollbackError-regressie
- [x] `test_worker_lock.py` — vijf tests tegen een echte Postgres-advisory-lock (acquire/release/contentie/crash-recovery)
- [x] `test_worker.py` — lock-wait-orchestratie in `main()`
- [x] Volledige backend-testsuite: 1163 passed